### PR TITLE
feat: Implement Database Table Browser with Extensible Data Sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+### Added
+* Database table browser with two-level navigation (table list page and row grid view).
+* Multi-direction scrolling (horizontal and vertical) in row grid view.
+* Local column sorting with NULLs always sorted to the end in both directions.
+* Dialog value preview and copy for individual grid cell values.
+* Pagination for row grid (200 rows limit with 'Load More' button).
+* Public `DatabaseBrowserSource`, `DatabaseTableInfo`, and `DatabaseTablePage` classes.
+* `FlutterInspector.registerDatabaseSource` and constructor parameter `databaseSources` to dynamically registry third-party databases (e.g. SQLite, ObjectBox).
+
+### Changed
+* Redesigned Database tab from chronological operation list to database table list view.
+
 ## 0.1.0
 
 Initial release on pub.dev (package renamed from `flutter_inspector` to `flutter_inspector_kit`).

--- a/README.md
+++ b/README.md
@@ -211,6 +211,171 @@ inspector.database(
 
 Available operations: `insert`, `update`, `delete`, `query`.
 
+### Browse database tables
+
+You can browse tables and rows directly from the Database tab. By default, operations logged via `inspector.database(...)` are grouped into virtual tables.
+
+To browse real databases (e.g. SQLite, ObjectBox), implement `DatabaseBrowserSource` and register it.
+
+#### SQLite Adapter Example
+Here is a complete, copy-pasteable implementation of `DatabaseBrowserSource` for `sqflite`:
+
+```dart
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+import 'package:sqflite/sqflite.dart';
+
+class SqfliteBrowserSource implements DatabaseBrowserSource {
+  SqfliteBrowserSource(this._db, {this.name = 'SQLite database'});
+
+  final Database _db;
+
+  @override
+  final String name;
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async {
+    final List<Map<String, Object?>> tables = await _db.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    );
+
+    final List<DatabaseTableInfo> result = [];
+    for (final table in tables) {
+      final name = table['name'] as String;
+      final countResult = await _db.rawQuery('SELECT COUNT(*) as count FROM "$name"');
+      final rowCount = Sqflite.firstIntValue(countResult);
+      result.add(DatabaseTableInfo(name: name, rowCount: rowCount));
+    }
+    return result;
+  }
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    final countResult = await _db.rawQuery('SELECT COUNT(*) as count FROM "$tableName"');
+    final totalRows = Sqflite.firstIntValue(countResult) ?? 0;
+
+    final List<Map<String, Object?>> queryResult = await _db.rawQuery(
+      'SELECT * FROM "$tableName" LIMIT ? OFFSET ?',
+      [limit, offset],
+    );
+
+    if (queryResult.isEmpty) {
+      final tableInfo = await _db.rawQuery('PRAGMA table_info("$tableName")');
+      final columns = tableInfo.map((info) => info['name'] as String).toList();
+      return DatabaseTablePage(
+        columns: columns,
+        rows: const [],
+        totalRows: totalRows,
+      );
+    }
+
+    final columns = queryResult.first.keys.toList();
+    final rows = queryResult.map((map) {
+      return columns.map((col) => map[col]).toList();
+    }).toList();
+
+    return DatabaseTablePage(
+      columns: columns,
+      rows: rows,
+      totalRows: totalRows,
+    );
+  }
+}
+```
+
+#### ObjectBox Adapter Example
+For ObjectBox, since Box/Entity represents a table and reflection is not available at runtime to convert entities to map, you can register entities manually:
+
+```dart
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+import 'package:objectbox/objectbox.dart';
+
+class ObjectBoxEntityInfo<T> {
+  ObjectBoxEntityInfo({
+    required this.name,
+    required this.box,
+    required this.toMap,
+  });
+
+  final String name;
+  final Box<T> box;
+  final Map<String, dynamic> Function(T) toMap;
+}
+
+class ObjectBoxBrowserSource implements DatabaseBrowserSource {
+  ObjectBoxBrowserSource({
+    required this.entities,
+    this.name = 'ObjectBox database',
+  });
+
+  final List<ObjectBoxEntityInfo> entities;
+
+  @override
+  final String name;
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async {
+    return entities.map((e) {
+      return DatabaseTableInfo(
+        name: e.name,
+        rowCount: e.box.count(),
+      );
+    }).toList();
+  }
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    final entityInfo = entities.firstWhere((e) => e.name == tableName);
+    final totalRows = entityInfo.box.count();
+
+    // Query with offset and limit
+    final query = entityInfo.box.query().build();
+    query.limit = limit;
+    query.offset = offset;
+    final items = query.find();
+    query.close();
+
+    if (items.isEmpty) {
+      return DatabaseTablePage(
+        columns: [],
+        rows: const [],
+        totalRows: totalRows,
+      );
+    }
+
+    final maps = items.map((item) => entityInfo.toMap(item)).toList();
+    final columns = maps.first.keys.toList();
+    final rows = maps.map((map) => columns.map((col) => map[col]).toList()).toList();
+
+    return DatabaseTablePage(
+      columns: columns,
+      rows: rows,
+      totalRows: totalRows,
+    );
+  }
+}
+```
+
+#### Registration
+You can register these sources when initializing `FlutterInspector` or dynamically at runtime:
+
+```dart
+// At initialization
+final inspector = FlutterInspector(
+  databaseSources: [SqfliteBrowserSource(db)],
+);
+
+// Or dynamically
+inspector.registerDatabaseSource(SqfliteBrowserSource(db));
+```
+
 ## 🕹️ Example
 
 A complete, runnable integration lives in the [`example/`](example/) directory:

--- a/docs/features/2026-06-11-database-table-browser.md
+++ b/docs/features/2026-06-11-database-table-browser.md
@@ -1,0 +1,209 @@
+# 功能規格：Database Table Browser（SQL administrator 式表格瀏覽）
+
+- **日期**：2026-06-11
+- **專案**：flutter_inspector_kit（v0.1.0）
+- **狀態**：STAGE 0a — 待確認
+
+---
+
+## 1. 背景與目標（Why）
+
+目前 Dashboard 的 Database tab（`lib/src/ui/dashboard/tabs/database_tab.dart`，僅 56 行）是一份「操作流水帳」：每筆 `DatabaseEntry` 以 `ListTile` 顯示 `INSERT on users / Rows affected: 1`。問題：
+
+- 看不到資料本身的樣貌——只知道「發生過什麼操作」，不知道「table 裡現在有什麼」。
+- 無分組、無結構：同一 table 的操作散落在時間軸上，無法以 table 為單位檢視。
+- 與 Network tab 的成熟度落差大（Network 已有搜尋、篩選、詳情頁、分享）。
+
+**目標**：把 Database tab 改造成 SQL administrator（如 DB Browser for SQLite / phpMyAdmin）式的兩層瀏覽——Table 清單 → Row grid——並建立可插拔的資料來源架構，讓使用者既能零設定看到操作紀錄重組的虛擬表格，也能接上真實的 SQLite / ObjectBox 資料庫。
+
+## 2. 使用者故事
+
+### US-1：Table 清單（零設定）
+
+> 身為開發者，打開 Database tab 時，我要看到「有哪些 table、各有幾筆資料」，而不是一條條操作紀錄。
+
+### US-2：Row grid 瀏覽
+
+> 身為開發者，點進某個 table 後，我要看到像資料庫管理工具一樣的表格：欄名做標頭、一列一筆資料、欄太多時可以橫向捲動、點欄名可以排序。
+
+### US-3：接上真實資料庫
+
+> 身為使用 sqflite 或 ObjectBox 的開發者，我要能用少量程式碼把真實 DB 接進 inspector，直接瀏覽 DB 裡的實際資料，而不只是操作紀錄的重組。
+
+### US-4：不被拖累的使用者
+
+> 身為只用 inspector 看 network/log 的開發者，我不希望因為這個功能被迫安裝 sqflite 或 objectbox。
+
+## 3. UI 規格
+
+### 3.1 第一層：Table 清單頁（Database tab 預設畫面）
+
+```
+┌─────────────────────────────────────────────┐
+│ Source: [Operation log        ▼]   ⟳  🗑    │  ← 來源切換 + refresh + clear
+├─────────────────────────────────────────────┤
+│ ▦ users                          12 rows  › │
+│ ▦ orders                         48 rows  › │
+│ ▦ cart_items                      3 rows  › │
+│ ▦ settings                       (n/a)    › │  ← rowCount 不可得時顯示 n/a
+├─────────────────────────────────────────────┤
+│              (empty state:                   │
+│        "No database activity" /              │
+│        "No tables in this source")           │
+└─────────────────────────────────────────────┘
+```
+
+- **Source 下拉**：列出所有已註冊的資料來源；只有一個來源（預設情況）時隱藏下拉、只顯示來源名稱文字。
+- **清單項目**：table 名稱 + row 數 + chevron（沿用 `network_tab` 的 `ListTile` + `Icons.chevron_right` 慣例）。
+- **🗑（Clear）**：僅對預設來源（operation log）有效——清空 `DatabaseInspector` buffer；真實 DB 來源為唯讀，clear 按鈕隱藏或停用。
+- **排序**：table 依名稱字母排序。
+
+### 3.2 第二層：Row grid 頁（push 全頁，沿用 `network_detail_view` 的 `MaterialPageRoute` 先例）
+
+```
+┌─────────────────────────────────────────────┐
+│ ←  users (12 rows)                       ⟳  │  ← AppBar：返回 + table 名 + refresh
+├─────────────────────────────────────────────┤
+│ │ id ▲│ name      │ email          │ age │ ◄──── 橫向捲動 ────►
+│ ├─────┼───────────┼────────────────┼─────┤
+│ │ 1   │ Alice     │ a@example.com  │ 30  │
+│ │ 2   │ Bob       │ b@example.com  │ 25  │
+│ │ 3   │ Carol     │ NULL           │ 41  │  ← null 以灰色斜體 NULL 呈現
+│ │ ... │           │                │     │  ↕ 縱向捲動
+├─────────────────────────────────────────────┤
+│ Showing 12 of 12                             │  ← 底部列數狀態列
+└─────────────────────────────────────────────┘
+```
+
+- **表格元件**：Flutter `DataTable`（內建 `sortColumnIndex` / `sortAscending` 支援），外層包橫向 + 縱向 `SingleChildScrollView`。
+- **欄位排序**：點欄名切換 升冪 ▲ / 降冪 ▼；排序在已載入的資料上以記憶體內比較完成（數字按數值、其餘按字串、null 排最後）。
+- **儲存格**：值以 `toString()` 呈現，過長截斷（單格上限約 100 字元 + ellipsis）；點儲存格以 dialog/bottom sheet 顯示完整值並可複製（複製給 SnackBar 回饋，沿用 US-4 sharing 慣例）。
+- **載入上限**：單次最多載入 **200 列**（避免大表卡死 UI）；超過時底部顯示 `Showing 200 of 1,500` 並提供「Load more」。
+- **錯誤處理**：來源查詢失敗（DB 已關閉等）顯示錯誤訊息卡片，不崩潰。
+
+## 4. 資料來源架構
+
+### 4.1 核心抽象（放在 package core，零新依賴）
+
+```dart
+/// 一個可被 Database tab 瀏覽的資料來源。
+abstract class DatabaseBrowserSource {
+  /// 顯示在來源下拉中的名稱，如 "Operation log"、"app.db"。
+  String get name;
+
+  /// 列出所有 table（名稱 + 可選的 row 數；取不到時為 null）。
+  Future<List<DatabaseTableInfo>> listTables();
+
+  /// 讀取某 table 的一頁資料。
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  });
+}
+
+class DatabaseTableInfo {
+  final String name;
+  final int? rowCount;
+}
+
+class DatabaseTablePage {
+  final List<String> columns;       // 欄名（標頭）
+  final List<List<Object?>> rows;   // 一列一筆，與 columns 對齊
+  final int? totalRows;             // 取不到時為 null
+}
+```
+
+- 介面為 `Future`-based：真實 DB 查詢本來就是非同步；預設來源同步資料包成 Future 即可，消除兩種分支。
+- 排序不下放到介面（不加 `orderBy` 參數）：在已載入頁面上記憶體內排序，介面保持最小。未來真有需求再擴充。
+
+### 4.2 預設來源：`OperationLogSource`（零設定，永遠存在）
+
+把現有 `DatabaseInspector` 的 `DatabaseEntry` 紀錄重組為虛擬表格：
+
+- **分組**：依 `tableName` 分組 → 每組一個虛擬 table，rowCount = 該組 entry 數。
+- **欄位**：固定中繼欄 `#time`、`#op`、`#rows`（timestamp / operation / affectedRows），加上該組所有 entry 的 `data` map key 的聯集（依首次出現順序）。
+- **列**：一筆 entry 一列；entry 沒有的 key 填 null。
+- 中繼欄以 `#` 前綴與資料欄區隔，避免和使用者的 `data` key 撞名。
+
+### 4.3 真實資料庫接法：介面在 core、adapter 由使用者實作
+
+**調查結論（Dart/Flutter 生態慣例）**：pub 沒有「optional dependency」機制，社群兩種主流作法——
+
+| 作法 | 範例 | 優點 | 缺點 |
+|---|---|---|---|
+| **(A) 介面放 core + 使用者實作 adapter** | `talker` 的 logger 介面、`alice` 0.x 的 storage 介面 | core 零新依賴；使用者 20–40 行即可接上；維護成本最低 | 使用者要自己寫一小段膠水碼 |
+| **(B) Companion packages** | `alice` 1.x（`alice_objectbox`、`alice_dio`…）、`drift_db_viewer` | 使用者只要 `pub add` 即用 | 要維護多個 package 的發版、版本對齊；v0.1.0 階段成本過高 |
+
+**本規格建議：先做 (A)，介面設計上不阻礙未來演進到 (B)**。core 只新增上述抽象；example app（可自由依賴 sqflite/objectbox）內附兩個參考 adapter 實作，README 提供複製貼上等級的範例：
+
+- **SQLite adapter（參考實作，放 example）**：
+  - `listTables()` → `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`，rowCount 用 `SELECT COUNT(*)`。
+  - `fetchRows()` → `SELECT * FROM "<table>" LIMIT ? OFFSET ?`，columns 取自查詢結果的 keys。
+- **ObjectBox adapter（參考實作，放 example）**：
+  - ObjectBox 沒有 SQL table，對應關係為 **Entity/Box → table**。Dart 端無泛用 runtime 反射可把任意 entity 轉成 map，因此 adapter 需由使用者**逐 entity 註冊**：`box` + 該 entity 的 `toMap()` 轉換函式。`listTables()` 列出已註冊的 entity，rowCount 用 `box.count()`；`fetchRows()` 用 `box.query().build().find()` 搭配 offset/limit 後逐筆 `toMap()`。
+
+### 4.4 註冊 API
+
+```dart
+final inspector = FlutterInspector(
+  databaseSources: [MySqfliteSource(db)],   // 建構時注入（可選）
+);
+inspector.registerDatabaseSource(source);    // 或執行期動態註冊（DB 開啟較晚的情境）
+```
+
+- 預設來源 `OperationLogSource` 永遠在清單第一位，不需註冊。
+- 新公開 API export：`DatabaseBrowserSource`、`DatabaseTableInfo`、`DatabaseTablePage`（注意：現有 `DatabaseEntry` 未 export，本次不變動其可見性）。
+
+## 5. 驗收條件
+
+### Table 清單頁
+- [ ] 有 database 操作紀錄時，Database tab 顯示依 tableName 分組的 table 清單，每項含 row 數。
+- [ ] 無任何來源資料時顯示空狀態文字，不顯示空白畫面。
+- [ ] 註冊多個來源時出現來源下拉，切換後清單即時更新；單一來源時不顯示下拉。
+- [ ] Clear 只作用於 operation log 來源；真實 DB 來源下 clear 不可用。
+
+### Row grid 頁
+- [ ] 點 table 進入 row grid：欄名標頭、一列一筆、可橫向與縱向捲動。
+- [ ] 點欄名可排序，再點切換升/降冪，標頭有方向指示；數字欄按數值排序、null 排最後。
+- [ ] null 值以可辨識方式呈現（灰色 NULL），不顯示為空字串。
+- [ ] 單次載入上限 200 列；超過時顯示 `Showing X of Y` 與 Load more。
+- [ ] 點儲存格可看完整值並複製，複製有 SnackBar 回饋。
+- [ ] 來源查詢拋例外時顯示錯誤訊息，UI 不崩潰。
+
+### 預設來源（OperationLogSource）
+- [ ] data map 的 key 聯集成為欄位，缺值補 null；中繼欄 `#time`/`#op`/`#rows` 永遠存在。
+- [ ] 與現有 `inspector.database(...)` 記錄 API 完全相容，呼叫端零改動（Never break userspace）。
+
+### 架構與品質
+- [ ] `pubspec.yaml` 不新增任何依賴（sqflite/objectbox 僅出現在 example）。
+- [ ] `DatabaseBrowserSource` 等新型別正確 export 於 `lib/flutter_inspector_kit.dart`。
+- [ ] example app 含可運作的 SQLite adapter 示範（ObjectBox adapter 至少提供文件級範例，見待決策 D4）。
+- [ ] `flutter analyze` 零 issue；新增邏輯（分組、欄位聯集、排序比較器、分頁）有單元測試；UI 有 widget test（沿用 `test/ui/tabs/` 慣例）。
+- [ ] 既有 `database_inspector_test.dart` 等測試不退化。
+
+## 6. 範圍邊界（Non-goals）
+
+- **不做資料編輯/寫入**：純唯讀瀏覽，不提供 insert/update/delete UI。
+- **不做 SQL query console**：不提供自由輸入 SQL 的介面（見待決策 D5）。
+- **不做 schema 檢視**（索引、外鍵、欄位型別宣告）。
+- **不發布 companion packages**：本次不建 `flutter_inspector_kit_sqflite` 等獨立 package（介面設計保留未來空間）。
+- **不支援 sqflite/objectbox 以外的 DB**（drift、hive、isar 等）——但任何人可透過 `DatabaseBrowserSource` 自行接上。
+- **不做跨欄位搜尋/篩選**：第一版不在 row grid 提供關鍵字搜尋（可列為後續迭代）。
+- **不做資料持久化**：operation log 來源維持 RingBuffer 記憶體內行為。
+
+## 7. 待使用者決策事項
+
+| # | 事項 | 選項 | 建議 |
+|---|---|---|---|
+| D1 | **舊版操作流水帳視圖去留**：新設計以 table 分組取代時間軸流水帳，原始的「按時間看所有操作」視圖是否保留？ | (a) 完全移除 (b) 在 tab 內加 view 切換（Tables / Log） | **(b)**——流水帳對 debug「操作順序」仍有價值，且避免破壞既有使用習慣 |
+| D2 | **Adapter 策略**：介面 + example 參考實作（本規格建議），或現在就發 companion packages？ | (A) core 介面 + example 示範 (B) companion packages | **(A)**——v0.1.0 階段維護成本考量，介面不阻礙未來轉 (B) |
+| D3 | **載入上限數值**：單頁 200 列是否合適？ | 100 / 200 / 500 / 可設定 | **200 + Load more**，第一版不開放設定 |
+| D4 | **ObjectBox 示範深度**：example app 是否實際引入 objectbox 依賴跑出可執行示範（需 build_runner codegen，example 變重），或僅 README 文件級範例？ | (a) example 內可執行 (b) 文件級範例 | **(b)**——SQLite 已有可執行示範驗證介面，ObjectBox 留文件範例即可 |
+| D5 | **SQL query console**：是否納入本次範圍？ | 納入 / 不納入 | **不納入**——唯讀 console 只對 SQLite 來源有意義（ObjectBox/operation log 無 SQL），且注入風險與範圍膨脹不成比例；列為未來迭代 |
+
+---
+
+## 確認
+
+請確認以上規格（特別是第 7 節五項決策）。確認後進入 STAGE 0b 產出實作計畫。

--- a/docs/plans/2026-06-11-database-table-browser.md
+++ b/docs/plans/2026-06-11-database-table-browser.md
@@ -1,0 +1,244 @@
+# 實作計畫：Database Table Browser（SQL administrator 式表格瀏覽）
+
+- **日期**：2026-06-11
+- **功能規格**：`docs/features/2026-06-11-database-table-browser.md`
+- **狀態**：STAGE 0b — 待確認
+- **已確認決策**：D1 直接取代（舊流水帳移除、舊測試改寫保覆蓋率）｜D2 core 介面 + example SQLite adapter｜D3 200 列 + Load more｜D4 ObjectBox 僅文件級範例｜D5 不做 SQL console
+
+---
+
+## 1. 設計總覽
+
+核心策略：**資料結構先行——介面 + 純函式（分組、欄位聯集、排序比較器）全部 TDD 做扎實，UI 疊在上面**。`DatabaseBrowserSource` 是唯一抽象，operation log 與真實 DB 走同一條路徑，UI 不出現「預設來源 vs 真實來源」的資料分支（唯一例外：clear 按鈕可見性）。
+
+### 資料結構決策
+
+- **介面 `Future`-based**：真實 DB 本來就非同步，operation log 同步資料包成 Future——消除兩種分支，UI 一律 `FutureBuilder`。
+- **排序不進介面**：在已載入頁面上記憶體內排序（純函式，100% 可單測），介面保持最小。
+- **OperationLogSource 欄位聯集以「時間順序首次出現」決定欄序**：新 entry 進來不會打亂既有欄位順序（buffer 是 newest-first，聯集計算須反轉為 oldest-first 再掃描）。
+- **中繼欄 `#time` / `#op` / `#rows` 永遠在前三欄**，`#` 前綴與使用者 data key 區隔。
+- **`DatabaseEntry` 零改動、`inspector.database(...)` API 零改動**（Never break userspace）。
+
+### 新增依賴
+
+- **core `pubspec.yaml`：零新增**（驗收條件）。
+- **example `pubspec.yaml`：新增 `sqflite: ^2.4.0`**（僅 example，唯一 owner = T8a）。
+
+### 既有程式碼影響面
+
+- `DatabaseTab(inspector:)` 建構子簽名不變 → `dashboard_modal.dart` **零改動**。
+- 舊 `test/ui/tabs/database_tab_test.dart` 覆蓋的行為（顯示 entry、clear 清空）改寫為：顯示 table 清單、clear 清空 operation log 來源——**覆蓋率不退化，是改寫不是刪除**。
+- `test/inspectors/database_inspector_test.dart` 不動（行為未變，最終驗證鏈確認不退化）。
+
+## 2. 檔案異動清單
+
+| 檔案 | 動作 | 任務 | 共享檔 owner |
+|------|------|------|------|
+| `lib/src/models/database_browser_source.dart` | **新增**：`DatabaseBrowserSource` / `DatabaseTableInfo` / `DatabaseTablePage` | T1 | — |
+| `lib/flutter_inspector_kit.dart` | 改：export 上述三型別 | T1 | **唯一 owner = T1** |
+| `test/models/database_browser_source_test.dart` | **新增** | T1 | — |
+| `lib/src/utils/table_sort.dart` | **新增**：`compareCells` / `sortRows` / `cellPreview` 純函式 | T3 | — |
+| `test/utils/table_sort_test.dart` | **新增** | T3 | — |
+| `lib/src/sources/operation_log_source.dart` | **新增**：`OperationLogSource`（包 `DatabaseInspector`） | T2 | — |
+| `test/sources/operation_log_source_test.dart` | **新增** | T2 | — |
+| `lib/src/core/flutter_inspector_impl.dart` | 改：`databaseSources` 建構參數 + `registerDatabaseSource()` + getter | T4 | — |
+| `test/core/flutter_inspector_impl_test.dart` | 改：追加註冊 API 測試 group | T4 | — |
+| `lib/src/ui/dashboard/tabs/database/table_rows_view.dart` | **新增**：Row grid 全頁 | T5a, T5b | T5a→T5b 序列 |
+| `test/ui/tabs/table_rows_view_test.dart` | **新增** | T5a, T5b | T5a→T5b 序列 |
+| `lib/src/ui/dashboard/tabs/database_tab.dart` | **重寫**：流水帳 → table 清單頁（D1 直接取代） | T6 | — |
+| `test/ui/tabs/database_tab_test.dart` | **改寫**（非刪除）：對應新 UI、保留 clear 覆蓋 | T6 | — |
+| `example/pubspec.yaml` | 改：加 `sqflite` | T8a | **唯一 owner = T8a** |
+| `example/lib/sqflite_browser_source.dart` | **新增**：SQLite adapter 參考實作 | T8a | — |
+| `example/lib/main.dart` | 改：seed 按鈕 + 註冊 source 示範 | T8b | **唯一 owner = T8b** |
+| `README.md` | 改：Database 段落改寫 + SQLite/ObjectBox adapter 範例（D4） | T9 | **唯一 owner = T9** |
+| `CHANGELOG.md` | 改：頂部新增 `## Unreleased` 段落（0.1.0 剛發布） | T10 | **唯一 owner = T10** |
+
+## 3. 任務拆分
+
+> 複雜度分級對齊 implementer model 策略：🟢 機械性=快/便宜｜🟡 整合=標準｜🔴 設計判斷/跨層=最強。
+> 每任務 2–5 分鐘。**TDD：先寫測試（紅）→ 實作（綠）**。
+
+### T1 — 介面與 models（TDD）🟢 機械性
+- **目標**：建立 `DatabaseBrowserSource` 抽象與兩個 model，並 export 為公開 API。
+- **寫入**：`lib/src/models/database_browser_source.dart`、`test/models/database_browser_source_test.dart`、`lib/flutter_inspector_kit.dart`（T1 為此共享檔唯一 owner）
+- **內容**（直接採用規格 §4.1 的程式碼形狀）：
+  - `abstract class DatabaseBrowserSource { String get name; Future<List<DatabaseTableInfo>> listTables(); Future<DatabaseTablePage> fetchRows(String tableName, {int limit = 200, int offset = 0}); }`
+  - `DatabaseTableInfo`（`name` + `rowCount?`，`@immutable`、`==`/`hashCode`/`toString` 比照 `DatabaseEntry` 慣例）
+  - `DatabaseTablePage`（`columns` / `rows` / `totalRows?`）
+  - export 檔加一行 `export 'src/models/database_browser_source.dart';`（依字母序插入）
+- **測試先行**：model 建構/相等性；以匿名 fake 實作介面驗證 `limit`/`offset` 預設值（`limit == 200`、`offset == 0`）；測試從 `package:flutter_inspector_kit/flutter_inspector_kit.dart` import 以同時驗證 export。
+- **驗證**：`flutter test test/models/database_browser_source_test.dart`
+
+### T2 — `OperationLogSource`（TDD）🟡 整合
+- **目標**：把 `DatabaseInspector` 的 entries 重組為虛擬表格的預設來源。
+- **寫入**：`lib/src/sources/operation_log_source.dart`、`test/sources/operation_log_source_test.dart`
+- **內容**：
+  - `class OperationLogSource implements DatabaseBrowserSource`，建構子收 `DatabaseInspector`；`name => 'Operation log'`。
+  - `listTables()`：依 `tableName` 分組，table 依名稱字母排序，`rowCount` = 該組 entry 數。
+  - `fetchRows()`：columns = `['#time', '#op', '#rows']` + 該組 data key 聯集（**以 oldest-first 掃描的首次出現順序**，buffer 為 newest-first 須反轉計算）；rows 一筆 entry 一列（newest-first，與 buffer 一致），缺 key 補 null；`#time` = `timestamp.toIso8601String()`、`#op` = `operation.name`、`#rows` = `affectedRows`；以 `limit`/`offset` 切頁，`totalRows` = 組內 entry 總數。
+  - 不存在的 tableName → 回傳空 page（columns 僅三中繼欄、rows 空、totalRows 0），不丟例外。
+- **測試先行**（規格驗收逐條轉測試）：分組正確、字母排序、rowCount、中繼欄永遠存在、key 聯集順序穩定、缺值補 null、分頁（limit/offset/totalRows）、空 buffer 回空清單。
+- **驗證**：`flutter test test/sources/operation_log_source_test.dart`
+
+### T3 — 排序比較器與 cell 純函式（TDD）🟢 機械性
+- **目標**：row grid 的記憶體內排序與儲存格顯示邏輯，純函式、零 Flutter 依賴。
+- **寫入**：`lib/src/utils/table_sort.dart`、`test/utils/table_sort_test.dart`
+- **內容**：
+  - `int compareCells(Object? a, Object? b)`：null 永遠排最後（不論升降冪由呼叫端處理——比較器中 null 視為最大）；兩者皆 `num` 按數值；其餘 `toString()` 字串比較。
+  - `List<List<Object?>> sortRows(List<List<Object?>> rows, int columnIndex, bool ascending)`：回傳新 list 不改原資料；降冪時 null 仍排最後（即先比 null、再反轉非 null 部分的比較結果）。
+  - `String cellPreview(Object? value, {int maxLength = 100})`：null → `'NULL'`；超長截斷 + `…`。
+- **測試先行**：數字欄按數值（`9 < 10`）、字串欄、混合型別、null 排最後（升冪與降冪皆然）、不可變性、截斷邊界（99/100/101 字元）。
+- **驗證**：`flutter test test/utils/table_sort_test.dart`
+- **依賴**：無（函式收純 `List<Object?>`，不 import T1 型別）→ 可與 T1 並行。
+
+### T4 — `FlutterInspector` 註冊 API（TDD）🟡 整合
+- **目標**：來源註冊機制，`OperationLogSource` 永遠第一位。
+- **寫入**：`lib/src/core/flutter_inspector_impl.dart`、`test/core/flutter_inspector_impl_test.dart`（追加 group，不動既有測試）
+- **內容**：
+  - 建構子新增可選參數 `List<DatabaseBrowserSource>? databaseSources`。
+  - 內部建立 `OperationLogSource(_registry.database)` 作為預設來源。
+  - `void registerDatabaseSource(DatabaseBrowserSource source)`：執行期動態註冊。
+  - `List<DatabaseBrowserSource> get databaseSources`：回傳 unmodifiable list，`[operationLog, ...建構時注入, ...動態註冊]`。
+  - 既有參數、getter、行為全部不動。
+- **測試先行**：預設只有一個來源且 `name == 'Operation log'`；建構注入排第二；`registerDatabaseSource` 追加；回傳 list 不可變；`inspector.database(...)` 記錄後預設來源 `listTables()` 看得到（端到端黏合）。
+- **驗證**：`flutter test test/core/flutter_inspector_impl_test.dart`
+- **依賴**：T1、T2。
+
+### T5a — Row grid 頁骨架（TDD）🔴 設計判斷
+- **目標**：`TableRowsView` 全頁——載入、表格呈現、雙向捲動、NULL 呈現、狀態列、錯誤卡片。
+- **寫入**：`lib/src/ui/dashboard/tabs/database/table_rows_view.dart`、`test/ui/tabs/table_rows_view_test.dart`
+- **內容**：
+  - `TableRowsView({required DatabaseBrowserSource source, required String tableName})`，StatefulWidget；`initState` 觸發 `fetchRows(limit: 200, offset: 0)`。
+  - AppBar：返回 + `users (12 rows)`（rowCount 不可得時只顯示名稱）+ refresh（重置 offset 重新載入）。
+  - `DataTable` 外包橫向 + 縱向 `SingleChildScrollView`（沿用 `network_detail_view` 的 `MaterialPageRoute` push 慣例由呼叫端負責）。
+  - 儲存格：`cellPreview()`（T3）；null 值以灰色斜體 `NULL` Text 呈現（非一般文字）。
+  - **守衛**：`columns` 為空或 rows 為空 → 顯示置中 `'No rows'` 文字，**不建 DataTable**（`DataTable` 空 columns 會 assert 崩潰）。
+  - 底部狀態列：`Showing X of Y`（`totalRows` null 時顯示 `Showing X`）。
+  - 錯誤處理：`fetchRows` 拋例外 → 錯誤訊息卡片（`Card` + error icon + `e.toString()`）+ Retry 按鈕，UI 不崩潰。
+  - 排序、cell 詳情、Load more 留給 T5b（同檔序列）。
+- **測試先行**：欄名標頭呈現、一列一筆、NULL 灰色斜體（`find.byWidgetPredicate` 驗 style）、空 table 顯示 `'No rows'`、狀態列文字、來源丟例外顯示錯誤卡片不崩潰、refresh 重新呼叫來源。測試用 in-memory fake `DatabaseBrowserSource`（可注入延遲/例外）。**FutureBuilder/async 載入記得 `await tester.pumpAndSettle()`**。
+- **驗證**：`flutter test test/ui/tabs/table_rows_view_test.dart`
+- **依賴**：T1、T3。
+
+### T5b — Row grid 互動：排序 + cell 詳情 + Load more（TDD）🟡 整合
+- **目標**：補齊 row grid 三個互動。
+- **寫入**：`lib/src/ui/dashboard/tabs/database/table_rows_view.dart`、`test/ui/tabs/table_rows_view_test.dart`（接 T5a，同檔**序列**）
+- **內容**：
+  - 排序：`DataColumn.onSort` + `DataTable.sortColumnIndex`/`sortAscending`（內建方向箭頭），呼叫 T3 `sortRows`；再點同欄切換升/降冪；Load more 後重套當前排序。
+  - cell 詳情：`onTap` 開 `showModalBottomSheet`，顯示完整值（`SelectableText`）+ Copy 按鈕 → `Clipboard.setData` + SnackBar `'Copied'` 回饋（沿用 network sharing 慣例）。
+  - Load more：`totalRows != null && rows.length < totalRows`，或 `totalRows == null` 且上一頁回滿 200 筆時，狀態列旁顯示 `Load more` 按鈕；點擊 `fetchRows(offset: 已載入數)` 追加。
+- **測試先行**：點欄名後列序改變、再點反向、數字欄數值排序且 null 最後；點 cell 出現完整值與 Copy、複製後 SnackBar；fake source 餵 450 筆 → 首頁 200 筆 + `Showing 200 of 450` + Load more 後 400 筆。
+- **驗證**：`flutter test test/ui/tabs/table_rows_view_test.dart`
+- **依賴**：T5a（同檔）。
+
+### T6 — Database tab 重寫為 table 清單頁 + 舊測試改寫（TDD）🔴 設計判斷
+- **目標**：D1 直接取代——流水帳移除，Database tab 變為 source 切換 + table 清單；舊測試**改寫**保覆蓋。
+- **寫入**：`lib/src/ui/dashboard/tabs/database_tab.dart`（重寫）、`test/ui/tabs/database_tab_test.dart`（改寫）
+- **內容**：
+  - 建構子維持 `DatabaseTab({required this.inspector})` → `dashboard_modal.dart` 零改動。
+  - 頂列：來源選擇（`inspector.databaseSources.length > 1` 才顯示 `DropdownButton`，否則只顯示來源名稱 Text）+ refresh + clear。
+  - clear 僅當選中來源 `is OperationLogSource` 時顯示（內部 import，`OperationLogSource` 不公開 export）；動作 = `inspector.clearDatabase()` + 重載。
+  - 清單：`FutureBuilder` on `listTables()`；`ListTile`（table 名 + `12 rows` / `n/a` + `Icons.chevron_right`，沿用 network_tab 慣例）；點擊 `Navigator.push(MaterialPageRoute(builder: (_) => TableRowsView(source: ..., tableName: ...)))`。
+  - 空狀態：operation log 來源顯示 `'No database activity'`，其他來源顯示 `'No tables in this source'`。
+  - `listTables()` 拋例外 → 同 T5a 風格錯誤卡片。
+- **測試改寫**（覆蓋率不退化是硬要求）：
+  - 舊「displays database entries」→ 新「`inspector.database(...)` 記錄後顯示分組 table 清單與 row 數」。
+  - 舊「supports clearing」→ 新「點 clear 後清單清空、顯示空狀態」（保留 `Icons.delete` tap 路徑覆蓋）。
+  - 新增：空狀態文字、多來源顯示下拉且切換後清單更新、單來源不顯示下拉、非 op-log 來源 clear 不可見、rowCount null 顯示 `n/a`、點 table 推入 `TableRowsView`。
+- **驗證**：`flutter test test/ui/tabs/database_tab_test.dart` 與 `flutter test test/ui/dashboard_modal_test.dart`（確認 modal 不受影響）
+- **依賴**：T4（`databaseSources`）、T5a（push 目標）。
+
+### T8a — Example SQLite adapter 參考實作 🟡 整合
+- **目標**：可複製貼上等級的 `DatabaseBrowserSource` SQLite 實作。
+- **寫入**：`example/pubspec.yaml`（唯一 owner，加 `sqflite: ^2.4.0`）、`example/lib/sqflite_browser_source.dart`
+- **內容**（規格 §4.3）：
+  - `class SqfliteBrowserSource implements DatabaseBrowserSource`，建構子收 `Database` + `name`。
+  - `listTables()`：`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`，每表 `SELECT COUNT(*)` 取 rowCount。
+  - `fetchRows()`：`SELECT * FROM "<table>" LIMIT ? OFFSET ?`（table 名以雙引號包裹），columns 取自第一筆 result 的 keys（空結果 → 空 columns，T5a 已有守衛）；`totalRows` 用 COUNT(*)。
+  - 檔頭註解標明「參考實作，可直接複製到你的 app」。
+- **驗證**：`(cd example && flutter pub get && flutter analyze)`（adapter 無法在 host 單測 sqflite plugin，靠 analyze + T8b 手動煙測）
+- **依賴**：T4（API 定型）。寫入路徑全在 `example/`，可與 T6 並行。
+
+### T8b — Example app 接線示範 🟢 機械性
+- **目標**：main.dart 示範開 DB、seed、註冊 source。
+- **寫入**：`example/lib/main.dart`
+- **內容**：
+  - 新增 `'Seed SQLite demo'` 按鈕：開啟/建立 demo db（`users` 表 + 數筆含 null 的種子資料，重複點擊冪等）、`inspector.registerDatabaseSource(SqfliteBrowserSource(db, name: 'demo.db'))`（以 bool 守衛避免重複註冊）、SnackBar 回饋。
+  - **DB 操作只在按鈕 tap 後發生**——啟動路徑零 plugin 呼叫，`example/test/widget_test.dart` 維持綠燈。
+- **驗證**：`(cd example && flutter analyze && flutter test)`
+- **依賴**：T8a。
+
+### T9 — README 更新（含 ObjectBox 文件級範例，D4）🟢 機械性
+- **目標**：文件對齊新功能。
+- **寫入**：`README.md`（唯一 owner）
+- **內容**：
+  - 「Track database operations」段落後新增「Browse database tables」段：兩層瀏覽說明、`databaseSources:` 建構注入與 `registerDatabaseSource()` 範例。
+  - SQLite adapter：貼 `SqfliteBrowserSource` 完整程式碼（與 T8a 同步）。
+  - ObjectBox adapter：**文件級範例**——逐 entity 註冊（`box` + `toMap()`），`listTables()` 列已註冊 entity、`box.count()`、`fetchRows` 用 `query().build().find(offset:, limit:)` 逐筆 `toMap()`；明確標注「ObjectBox 無 SQL table，Entity/Box 即 table」。
+- **驗證**：人工檢視 + 範例程式碼與 T1/T4 簽名一致。
+- **依賴**：T4、T8a（API 與 adapter 形狀定案）。
+
+### T10 — CHANGELOG 更新 🟢 機械性
+- **目標**：記錄變更（0.1.0 剛發布 → 新增 `## Unreleased` 段落於頂部，**不動 0.1.0 段落**）。
+- **寫入**：`CHANGELOG.md`（唯一 owner）
+- **內容**：
+  - Added：Database table browser（兩層瀏覽、排序、cell 詳情、200 列 + Load more）；公開 `DatabaseBrowserSource` / `DatabaseTableInfo` / `DatabaseTablePage`；`FlutterInspector` 的 `databaseSources` 參數與 `registerDatabaseSource()`。
+  - Changed：Database tab 由操作流水帳改為 table browser（流水帳視圖移除；`inspector.database(...)` 記錄 API 不變）。
+- **驗證**：人工檢視。
+- **依賴**：T4（API 名稱定案）。
+
+### T11 — 最終驗證鏈 🟢 機械性
+- **目標**：全套品質關卡。
+- **寫入**：無（只跑指令；若有 format/analyze 修正則就地修）
+- **指令**（依序）：
+  1. `dart format .`（含 example）
+  2. `flutter analyze`（須零 issue，含 example）
+  3. `flutter test $(find test -name '*_test.dart' ! -name 'magical_tap_test.dart')`
+     — **鐵則：永遠排除 `test/ui/magical_tap_test.dart`**（該檔有 10 分鐘既有 timeout，不在本次變更面）。
+  4. `(cd example && flutter analyze && flutter test)`
+- **驗證**：全綠，既有測試（`database_inspector_test.dart` 等）零退化。
+- **依賴**：全部任務。
+
+## 4. 執行順序與並行批次
+
+> 並行規則：寫入路徑不重疊才可並行；共享檔已指定唯一 owner（`lib/flutter_inspector_kit.dart` → T1、`example/pubspec.yaml` → T8a、`example/lib/main.dart` → T8b、`README.md` → T9、`CHANGELOG.md` → T10）。
+
+```
+批次 1（並行）: T1（models+export）        ‖ T3（排序純函式）
+                      ↓
+批次 2（並行）: T2（OperationLogSource）   ‖ T5a（row grid 骨架，依賴 T1+T3）
+                      ↓
+批次 3（並行）: T4（註冊 API，依賴 T1+T2） ‖ T5b（grid 互動，接 T5a 同檔）
+                      ↓
+批次 4（並行）: T6（database_tab 重寫）    ‖ T8a（example adapter）
+                      ↓
+批次 5（並行）: T8b（example 接線）        ‖ T9（README） ‖ T10（CHANGELOG）
+                      ↓
+批次 6（序列）: T11（最終驗證鏈）
+```
+
+- 同檔序列鏈：T5a → T5b（`table_rows_view.dart` + 其測試）。
+- T4 與 T5b 寫入完全不重疊（core/impl vs ui/database）→ 可並行。
+- T6 與 T8a 寫入完全不重疊（lib/test vs example）→ 可並行。
+
+## 5. 範圍邊界（重申，照規格 §6 + 已確認決策）
+
+- **不做**資料編輯/寫入（純唯讀）。
+- **不做** SQL query console（D5）。
+- **不做** schema 檢視（索引、外鍵、型別宣告）。
+- **不發布** companion packages（介面設計保留未來空間）。
+- **不支援** sqflite/objectbox 以外 DB 的官方 adapter。
+- **不做**跨欄位搜尋/篩選（後續迭代）。
+- **不做**資料持久化（operation log 維持 RingBuffer 記憶體內）。
+- **ObjectBox 不進 example**（D4：僅 README 文件級範例）。
+- **舊流水帳視圖直接移除**（D1），但其測試覆蓋的行為（記錄顯示、clear）必須在新 UI 測試中等價重建。
+- core `pubspec.yaml` 零新依賴；`DatabaseEntry` 可見性不變（不 export）。
+
+## 6. 執行方式選項
+
+| 方式 | 說明 | 適用 |
+|------|------|------|
+| **(A) Subagent-driven**（建議） | 同一 session 內按批次派發 implementer subagent，批次內並行、批次間序列；複雜度分級對應 model 強度（🟢 快/便宜、🟡 標準、🔴 最強） | 預設選擇——依賴鏈清楚、共享檔 owner 已定，調度成本最低 |
+| (B) Parallel session | 批次 1–3（核心邏輯鏈）與 T8a/T9（example/docs）拆兩個 session 並行 | 想壓縮 wall-clock 時間時；注意 T9 依賴 T4 API 定案，需等核心 session 過批次 3 |
+
+請確認計畫與執行方式後進入實作階段。

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -97,6 +97,7 @@ class _MyHomePageState extends State<MyHomePage> {
   bool _sqliteRegistered = false;
 
   Future<void> _seedSqlite() async {
+    if (_sqliteRegistered) return;
     try {
       final databasesPath = await getDatabasesPath();
       final path = '$databasesPath/demo.db';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+import 'package:sqflite/sqflite.dart';
+import 'sqflite_browser_source.dart';
 
 // Enable the live system notification summarising network calls (opt-in).
 // On Android this requires a notification icon + (Android 13+) the
@@ -92,6 +94,71 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
+  bool _sqliteRegistered = false;
+
+  Future<void> _seedSqlite() async {
+    try {
+      final databasesPath = await getDatabasesPath();
+      final path = '$databasesPath/demo.db';
+
+      final db = await openDatabase(
+        path,
+        version: 1,
+        onCreate: (db, version) async {
+          await db.execute(
+            'CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT, age INTEGER)',
+          );
+        },
+      );
+
+      final countResult = await db.rawQuery(
+        'SELECT COUNT(*) as count FROM users',
+      );
+      final count = Sqflite.firstIntValue(countResult) ?? 0;
+      if (count == 0) {
+        await db.insert('users', {
+          'id': 1,
+          'name': 'Alice',
+          'email': 'alice@example.com',
+          'age': 30,
+        });
+        await db.insert('users', {
+          'id': 2,
+          'name': 'Bob',
+          'email': null,
+          'age': 25,
+        });
+        await db.insert('users', {
+          'id': 3,
+          'name': 'Carol',
+          'email': 'carol@example.com',
+          'age': null,
+        });
+      }
+
+      if (!_sqliteRegistered) {
+        inspector.registerDatabaseSource(
+          SqfliteBrowserSource(db, name: 'demo.db'),
+        );
+        _sqliteRegistered = true;
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('SQLite demo.db initialized and registered!'),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('SQLite seeding failed: $e')));
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -112,6 +179,11 @@ class _MyHomePageState extends State<MyHomePage> {
             ElevatedButton(
               onPressed: _makeNetworkRequest,
               child: const Text('Make Network Request'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _seedSqlite,
+              child: const Text('Seed SQLite Demo'),
             ),
             const SizedBox(height: 20),
             ElevatedButton(

--- a/example/lib/sqflite_browser_source.dart
+++ b/example/lib/sqflite_browser_source.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// A reference implementation of [DatabaseBrowserSource] for SQLite databases.
+///
+/// You can copy this code directly into your app to browse SQLite tables.
+class SqfliteBrowserSource implements DatabaseBrowserSource {
+  SqfliteBrowserSource(this._db, {this.name = 'SQLite database'});
+
+  final Database _db;
+
+  @override
+  final String name;
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async {
+    // Select all user tables from sqlite_master
+    final List<Map<String, Object?>> tables = await _db.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    );
+
+    final List<DatabaseTableInfo> result = [];
+    for (final table in tables) {
+      final name = table['name'] as String;
+      // Fetch the row count for each table
+      final countResult = await _db.rawQuery(
+        'SELECT COUNT(*) as count FROM "$name"',
+      );
+      final rowCount = Sqflite.firstIntValue(countResult);
+      result.add(DatabaseTableInfo(name: name, rowCount: rowCount));
+    }
+    return result;
+  }
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    // Fetch total rows count
+    final countResult = await _db.rawQuery(
+      'SELECT COUNT(*) as count FROM "$tableName"',
+    );
+    final totalRows = Sqflite.firstIntValue(countResult) ?? 0;
+
+    // Fetch the page of rows
+    final List<Map<String, Object?>> queryResult = await _db.rawQuery(
+      'SELECT * FROM "$tableName" LIMIT ? OFFSET ?',
+      [limit, offset],
+    );
+
+    if (queryResult.isEmpty) {
+      // If the result is empty, retrieve columns using table_info PRAGMA
+      // to still display the schema columns in the UI.
+      final tableInfo = await _db.rawQuery('PRAGMA table_info("$tableName")');
+      final columns = tableInfo.map((info) => info['name'] as String).toList();
+      return DatabaseTablePage(
+        columns: columns,
+        rows: const [],
+        totalRows: totalRows,
+      );
+    }
+
+    final columns = queryResult.first.keys.toList();
+    final rows = queryResult.map((map) {
+      return columns.map((col) => map[col]).toList();
+    }).toList();
+
+    return DatabaseTablePage(
+      columns: columns,
+      rows: rows,
+      totalRows: totalRows,
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.8
   dio: ^5.0.0
+  sqflite: ^2.4.0
 
   flutter_inspector_kit:
     path: ../

--- a/lib/flutter_inspector_kit.dart
+++ b/lib/flutter_inspector_kit.dart
@@ -1,5 +1,6 @@
 export 'src/core/flutter_inspector_impl.dart';
 export 'src/integrations/dio_interceptor.dart';
+export 'src/models/database_browser_source.dart';
 export 'src/models/database_operation.dart';
 export 'src/models/log_level.dart';
 export 'src/models/network_entry.dart';

--- a/lib/src/core/flutter_inspector_impl.dart
+++ b/lib/src/core/flutter_inspector_impl.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/widgets.dart';
 
+import '../models/database_browser_source.dart';
 import '../models/database_entry.dart';
 import '../models/database_operation.dart';
 import '../models/log_entry.dart';
+import '../sources/operation_log_source.dart';
 import '../models/log_level.dart';
 import '../models/navigator_entry.dart';
 import '../models/network_entry.dart';
@@ -29,8 +31,13 @@ class FlutterInspector {
     this.navigatorKey,
     int bufferSize = 500,
     NetworkNotifier? notifier,
+    List<DatabaseBrowserSource>? databaseSources,
   }) : _registry = InspectorRegistry(bufferSize: bufferSize) {
     _navigatorObserver = FlutterInspectorNavigatorObserver(_registry.navigator);
+    _operationLogSource = OperationLogSource(_registry.database);
+    if (databaseSources != null) {
+      _customDatabaseSources.addAll(databaseSources);
+    }
     if (showNetworkNotification) {
       _notifier =
           notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
@@ -65,6 +72,8 @@ class FlutterInspector {
 
   final InspectorRegistry _registry;
   late final FlutterInspectorNavigatorObserver _navigatorObserver;
+  late final OperationLogSource _operationLogSource;
+  final List<DatabaseBrowserSource> _customDatabaseSources = [];
 
   /// The observer to be added to MaterialApp's navigatorObservers.
   FlutterInspectorNavigatorObserver get navigatorObserver => _navigatorObserver;
@@ -96,6 +105,15 @@ class FlutterInspector {
 
   /// Clears all database logs.
   void clearDatabase() => _registry.database.clear();
+
+  /// Retrieves the registered database browser sources.
+  List<DatabaseBrowserSource> get databaseSources =>
+      List.unmodifiable([_operationLogSource, ..._customDatabaseSources]);
+
+  /// Registers a database browser source.
+  void registerDatabaseSource(DatabaseBrowserSource source) {
+    _customDatabaseSources.add(source);
+  }
 
   OverlayEntry? _overlayEntry;
 

--- a/lib/src/models/database_browser_source.dart
+++ b/lib/src/models/database_browser_source.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/foundation.dart';
+
+/// An abstract interface representing a browseable database source.
+abstract class DatabaseBrowserSource {
+  /// The user-facing name of the source, e.g., 'Operation log', 'app.db'.
+  String get name;
+
+  /// Lists all tables in this database source.
+  Future<List<DatabaseTableInfo>> listTables();
+
+  /// Fetches a page of rows from the specified [tableName].
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  });
+}
+
+/// Metadata about a database table.
+@immutable
+class DatabaseTableInfo {
+  const DatabaseTableInfo({required this.name, this.rowCount});
+
+  /// The table name.
+  final String name;
+
+  /// The total row count in the table, or null if unavailable.
+  final int? rowCount;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DatabaseTableInfo &&
+        other.name == name &&
+        other.rowCount == rowCount;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, rowCount);
+
+  @override
+  String toString() => 'DatabaseTableInfo($name, rows: $rowCount)';
+}
+
+/// A page of rows returned from a database table query.
+@immutable
+class DatabaseTablePage {
+  const DatabaseTablePage({
+    required this.columns,
+    required this.rows,
+    this.totalRows,
+  });
+
+  /// The column headers.
+  final List<String> columns;
+
+  /// The row data, where each row is a list of cell values matching [columns].
+  final List<List<Object?>> rows;
+
+  /// The total rows in the table, or null if unavailable.
+  final int? totalRows;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! DatabaseTablePage) return false;
+    if (other.totalRows != totalRows) return false;
+    if (!listEquals(other.columns, columns)) return false;
+    if (other.rows.length != rows.length) return false;
+    for (var i = 0; i < rows.length; i++) {
+      if (!listEquals(other.rows[i], rows[i])) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    Object.hashAll(columns),
+    Object.hashAll(rows.map((row) => Object.hashAll(row))),
+    totalRows,
+  );
+
+  @override
+  String toString() =>
+      'DatabaseTablePage(columns: $columns, rows: ${rows.length}, total: $totalRows)';
+}

--- a/lib/src/sources/operation_log_source.dart
+++ b/lib/src/sources/operation_log_source.dart
@@ -1,0 +1,82 @@
+import '../inspectors/database_inspector.dart';
+import '../models/database_browser_source.dart';
+
+/// A [DatabaseBrowserSource] that wraps a [DatabaseInspector]
+/// to present its operation log history as virtual database tables.
+class OperationLogSource implements DatabaseBrowserSource {
+  OperationLogSource(this._inspector);
+
+  final DatabaseInspector _inspector;
+
+  @override
+  String get name => 'Operation log';
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async {
+    final entries = _inspector.entries;
+    final tableCounts = <String, int>{};
+
+    for (final entry in entries) {
+      tableCounts[entry.tableName] = (tableCounts[entry.tableName] ?? 0) + 1;
+    }
+
+    final sortedNames = tableCounts.keys.toList()..sort();
+    return sortedNames
+        .map(
+          (name) => DatabaseTableInfo(name: name, rowCount: tableCounts[name]),
+        )
+        .toList();
+  }
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    final entries = _inspector.getEntriesByTable(tableName);
+    if (entries.isEmpty) {
+      return const DatabaseTablePage(
+        columns: ['#time', '#op', '#rows'],
+        rows: [],
+        totalRows: 0,
+      );
+    }
+
+    // Determine the columns by scanning oldest-first to keep order stable
+    final oldestFirst = entries.reversed.toList();
+    final dataKeys = <String>{};
+    for (final entry in oldestFirst) {
+      if (entry.data != null) {
+        dataKeys.addAll(entry.data!.keys);
+      }
+    }
+
+    final columns = ['#time', '#op', '#rows', ...dataKeys];
+
+    // Paginate entries (which are newest-first)
+    final totalRows = entries.length;
+    final start = offset.clamp(0, totalRows);
+    final end = (offset + limit).clamp(0, totalRows);
+    final paginatedEntries = entries.sublist(start, end);
+
+    final List<List<Object?>> rows = [];
+    for (final entry in paginatedEntries) {
+      final row = <Object?>[
+        entry.timestamp.toIso8601String(),
+        entry.operation.name,
+        entry.affectedRows,
+      ];
+      for (final key in dataKeys) {
+        row.add(entry.data?[key]);
+      }
+      rows.add(row);
+    }
+
+    return DatabaseTablePage(
+      columns: columns,
+      rows: rows,
+      totalRows: totalRows,
+    );
+  }
+}

--- a/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
+++ b/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
@@ -241,36 +241,39 @@ class _TableRowsViewState extends State<TableRowsView> {
                       child: SingleChildScrollView(
                         controller: _horizontalController,
                         scrollDirection: Axis.horizontal,
-                        child: DataTable(
-                          sortColumnIndex: _sortColumnIndex,
-                          sortAscending: _sortAscending,
-                          columns: _columns.map((col) {
-                            return DataColumn(
-                              label: Text(col),
-                              onSort: (colIdx, ascending) =>
-                                  _handleSort(colIdx, ascending),
-                            );
-                          }).toList(),
-                          rows: _rows.map((row) {
-                            return DataRow(
-                              cells: row.map((cell) {
-                                final preview = cellPreview(cell);
-                                final isNull = cell == null;
-                                return DataCell(
-                                  Text(
-                                    preview,
-                                    style: isNull
-                                        ? const TextStyle(
-                                            fontStyle: FontStyle.italic,
-                                            color: Colors.grey,
-                                          )
-                                        : null,
-                                  ),
-                                  onTap: () => _showCellDetails(cell),
-                                );
-                              }).toList(),
-                            );
-                          }).toList(),
+                        child: Padding(
+                          padding: const EdgeInsets.only(bottom: 16.0),
+                          child: DataTable(
+                            sortColumnIndex: _sortColumnIndex,
+                            sortAscending: _sortAscending,
+                            columns: _columns.map((col) {
+                              return DataColumn(
+                                label: Text(col),
+                                onSort: (colIdx, ascending) =>
+                                    _handleSort(colIdx, ascending),
+                              );
+                            }).toList(),
+                            rows: _rows.map((row) {
+                              return DataRow(
+                                cells: row.map((cell) {
+                                  final preview = cellPreview(cell);
+                                  final isNull = cell == null;
+                                  return DataCell(
+                                    Text(
+                                      preview,
+                                      style: isNull
+                                          ? const TextStyle(
+                                              fontStyle: FontStyle.italic,
+                                              color: Colors.grey,
+                                            )
+                                          : null,
+                                    ),
+                                    onTap: () => _showCellDetails(cell),
+                                  );
+                                }).toList(),
+                              );
+                            }).toList(),
+                          ),
                         ),
                       ),
                     ),

--- a/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
+++ b/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
@@ -134,7 +134,7 @@ class _TableRowsViewState extends State<TableRowsView> {
                   ],
                 ),
                 const Divider(),
-                Expanded(
+                Flexible(
                   child: SingleChildScrollView(
                     child: SelectableText(
                       fullValue,

--- a/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
+++ b/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
@@ -20,6 +20,7 @@ class TableRowsView extends StatefulWidget {
 
 class _TableRowsViewState extends State<TableRowsView> {
   bool _loading = true;
+  bool _isFetching = false;
   String? _errorMessage;
 
   List<String> _columns = [];
@@ -50,6 +51,9 @@ class _TableRowsViewState extends State<TableRowsView> {
   }
 
   Future<void> _loadData({required bool clearCurrent}) async {
+    if (_isFetching) return;
+    _isFetching = true;
+
     setState(() {
       _loading = true;
       _errorMessage = null;
@@ -88,6 +92,8 @@ class _TableRowsViewState extends State<TableRowsView> {
           _loading = false;
         });
       }
+    } finally {
+      _isFetching = false;
     }
   }
 

--- a/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
+++ b/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../../../models/database_browser_source.dart';
+import '../../../../utils/table_sort.dart';
+
+/// A detailed full-page grid browser for a single database table.
+class TableRowsView extends StatefulWidget {
+  const TableRowsView({
+    super.key,
+    required this.source,
+    required this.tableName,
+  });
+
+  final DatabaseBrowserSource source;
+  final String tableName;
+
+  @override
+  State<TableRowsView> createState() => _TableRowsViewState();
+}
+
+class _TableRowsViewState extends State<TableRowsView> {
+  bool _loading = true;
+  String? _errorMessage;
+
+  List<String> _columns = [];
+  List<List<Object?>> _rows = [];
+  int? _totalRows;
+  int _lastPageSize = 0;
+
+  int? _sortColumnIndex;
+  bool _sortAscending = true;
+
+  int _offset = 0;
+  static const int _limit = 200;
+
+  final ScrollController _verticalController = ScrollController();
+  final ScrollController _horizontalController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData(clearCurrent: true);
+  }
+
+  @override
+  void dispose() {
+    _verticalController.dispose();
+    _horizontalController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadData({required bool clearCurrent}) async {
+    setState(() {
+      _loading = true;
+      _errorMessage = null;
+      if (clearCurrent) {
+        _offset = 0;
+        _rows.clear();
+        _sortColumnIndex = null;
+        _lastPageSize = 0;
+      }
+    });
+
+    try {
+      final page = await widget.source.fetchRows(
+        widget.tableName,
+        limit: _limit,
+        offset: _offset,
+      );
+
+      if (mounted) {
+        setState(() {
+          _columns = page.columns;
+          _rows.addAll(page.rows);
+          _lastPageSize = page.rows.length;
+          _totalRows = page.totalRows;
+
+          if (_sortColumnIndex != null) {
+            _rows = sortRows(_rows, _sortColumnIndex!, _sortAscending);
+          }
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = e.toString();
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  bool _hasMore() {
+    if (_totalRows != null) {
+      return _rows.length < _totalRows!;
+    }
+    return _lastPageSize == _limit;
+  }
+
+  void _handleSort(int columnIndex, bool ascending) {
+    setState(() {
+      _sortColumnIndex = columnIndex;
+      _sortAscending = ascending;
+      _rows = sortRows(_rows, columnIndex, ascending);
+    });
+  }
+
+  void _showCellDetails(Object? cell) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        final fullValue = cell?.toString() ?? 'NULL';
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Cell Details',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: () => Navigator.pop(context),
+                    ),
+                  ],
+                ),
+                const Divider(),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: SelectableText(
+                      fullValue,
+                      style: cell == null
+                          ? const TextStyle(
+                              fontStyle: FontStyle.italic,
+                              color: Colors.grey,
+                            )
+                          : null,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                ElevatedButton.icon(
+                  icon: const Icon(Icons.copy),
+                  label: const Text('Copy Value'),
+                  onPressed: () async {
+                    await Clipboard.setData(ClipboardData(text: fullValue));
+                    if (context.mounted) {
+                      Navigator.pop(context);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Value copied to clipboard'),
+                        ),
+                      );
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final titleSuffix = _totalRows != null ? ' ($_totalRows rows)' : '';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${widget.tableName}$titleSuffix'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _loadData(clearCurrent: true),
+          ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading && _rows.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_errorMessage != null && _rows.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.error, color: Colors.red, size: 48),
+                  const SizedBox(height: 16),
+                  Text(
+                    _errorMessage!,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => _loadData(clearCurrent: true),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        Expanded(
+          child: _columns.isEmpty || _rows.isEmpty
+              ? const Center(child: Text('No rows'))
+              : Scrollbar(
+                  controller: _verticalController,
+                  thumbVisibility: true,
+                  child: SingleChildScrollView(
+                    controller: _verticalController,
+                    scrollDirection: Axis.vertical,
+                    child: Scrollbar(
+                      controller: _horizontalController,
+                      thumbVisibility: true,
+                      child: SingleChildScrollView(
+                        controller: _horizontalController,
+                        scrollDirection: Axis.horizontal,
+                        child: DataTable(
+                          sortColumnIndex: _sortColumnIndex,
+                          sortAscending: _sortAscending,
+                          columns: _columns.map((col) {
+                            return DataColumn(
+                              label: Text(col),
+                              onSort: (colIdx, ascending) =>
+                                  _handleSort(colIdx, ascending),
+                            );
+                          }).toList(),
+                          rows: _rows.map((row) {
+                            return DataRow(
+                              cells: row.map((cell) {
+                                final preview = cellPreview(cell);
+                                final isNull = cell == null;
+                                return DataCell(
+                                  Text(
+                                    preview,
+                                    style: isNull
+                                        ? const TextStyle(
+                                            fontStyle: FontStyle.italic,
+                                            color: Colors.grey,
+                                          )
+                                        : null,
+                                  ),
+                                  onTap: () => _showCellDetails(cell),
+                                );
+                              }).toList(),
+                            );
+                          }).toList(),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+        ),
+        _buildStatusBar(),
+      ],
+    );
+  }
+
+  Widget _buildStatusBar() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardColor,
+        border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            _totalRows != null
+                ? 'Showing ${_rows.length} of $_totalRows'
+                : 'Showing ${_rows.length}',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          if (_hasMore())
+            if (_loading)
+              const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            else
+              TextButton(
+                onPressed: () {
+                  _offset += _limit;
+                  _loadData(clearCurrent: false);
+                },
+                child: const Text('Load More'),
+              ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/ui/dashboard/tabs/database_tab.dart
+++ b/lib/src/ui/dashboard/tabs/database_tab.dart
@@ -19,6 +19,7 @@ class _DatabaseTabState extends State<DatabaseTab> {
   late DatabaseBrowserSource _selectedSource;
   List<DatabaseTableInfo> _tables = [];
   bool _loading = true;
+  bool _isFetching = false;
   String? _errorMessage;
 
   @override
@@ -29,7 +30,8 @@ class _DatabaseTabState extends State<DatabaseTab> {
   }
 
   Future<void> _loadTables() async {
-    if (!mounted) return;
+    if (!mounted || _isFetching) return;
+    _isFetching = true;
     setState(() {
       _loading = true;
       _errorMessage = null;
@@ -50,6 +52,8 @@ class _DatabaseTabState extends State<DatabaseTab> {
           _loading = false;
         });
       }
+    } finally {
+      _isFetching = false;
     }
   }
 

--- a/lib/src/ui/dashboard/tabs/database_tab.dart
+++ b/lib/src/ui/dashboard/tabs/database_tab.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 
 import '../../../core/flutter_inspector_impl.dart';
+import '../../../models/database_browser_source.dart';
+import '../../../sources/operation_log_source.dart';
+import 'database/table_rows_view.dart';
 
-/// Tab for displaying database operations.
+/// Tab for displaying database tables and operations.
 class DatabaseTab extends StatefulWidget {
   const DatabaseTab({required this.inspector, super.key});
 
@@ -13,44 +16,180 @@ class DatabaseTab extends StatefulWidget {
 }
 
 class _DatabaseTabState extends State<DatabaseTab> {
-  void _refresh() => setState(() {});
+  late DatabaseBrowserSource _selectedSource;
+  List<DatabaseTableInfo> _tables = [];
+  bool _loading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedSource = widget.inspector.databaseSources.first;
+    _loadTables();
+  }
+
+  Future<void> _loadTables() async {
+    if (!mounted) return;
+    setState(() {
+      _loading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final tables = await _selectedSource.listTables();
+      if (mounted) {
+        setState(() {
+          _tables = tables;
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = e.toString();
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  void _clearDatabase() {
+    widget.inspector.clearDatabase();
+    _loadTables();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final entries = widget.inspector.databaseEntries;
+    final sources = widget.inspector.databaseSources;
+    final isOpLog = _selectedSource is OperationLogSource;
 
     return Column(
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            IconButton(icon: const Icon(Icons.refresh), onPressed: _refresh),
-            IconButton(
-              icon: const Icon(Icons.delete),
-              onPressed: () {
-                widget.inspector.clearDatabase();
-                _refresh();
-              },
-            ),
-          ],
-        ),
-        Expanded(
-          child: ListView.builder(
-            itemCount: entries.length,
-            itemBuilder: (context, index) {
-              final entry = entries[index];
-              return ListTile(
-                title: Text(
-                  '${entry.operation.name.toUpperCase()} on ${entry.tableName}',
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+          child: Row(
+            children: [
+              if (sources.length > 1)
+                DropdownButton<DatabaseBrowserSource>(
+                  value: _selectedSource,
+                  onChanged: (source) {
+                    if (source != null) {
+                      setState(() {
+                        _selectedSource = source;
+                      });
+                      _loadTables();
+                    }
+                  },
+                  items: sources.map((source) {
+                    return DropdownMenuItem<DatabaseBrowserSource>(
+                      value: source,
+                      child: Text(source.name),
+                    );
+                  }).toList(),
+                )
+              else
+                Text(
+                  _selectedSource.name,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
                 ),
-                subtitle: Text(
-                  'Rows affected: ${entry.affectedRows ?? "-"}\n${entry.data?['query'] ?? ""}',
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Icons.refresh),
+                onPressed: _loadTables,
+              ),
+              if (isOpLog)
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: _clearDatabase,
                 ),
-              );
-            },
+            ],
           ),
         ),
+        const Divider(height: 1),
+        Expanded(child: _buildBody(isOpLog)),
       ],
+    );
+  }
+
+  Widget _buildBody(bool isOpLog) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_errorMessage != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.error, color: Colors.red, size: 48),
+                  const SizedBox(height: 16),
+                  Text(
+                    _errorMessage!,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: _loadTables,
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (_tables.isEmpty) {
+      final emptyText = isOpLog
+          ? 'No database activity'
+          : 'No tables in this source';
+      return Center(
+        child: Text(emptyText, style: const TextStyle(color: Colors.grey)),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: _tables.length,
+      itemBuilder: (context, index) {
+        final table = _tables[index];
+        final rowCountText = table.rowCount != null
+            ? '${table.rowCount} rows'
+            : 'n/a';
+
+        return ListTile(
+          leading: const Icon(Icons.table_chart),
+          title: Text(table.name),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                rowCountText,
+                style: const TextStyle(color: Colors.grey, fontSize: 12),
+              ),
+              const SizedBox(width: 4),
+              const Icon(Icons.chevron_right, color: Colors.grey),
+            ],
+          ),
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => TableRowsView(
+                  source: _selectedSource,
+                  tableName: table.name,
+                ),
+              ),
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/src/utils/table_sort.dart
+++ b/lib/src/utils/table_sort.dart
@@ -1,0 +1,45 @@
+/// Compares two cell values. Nulls are always treated as greater than any non-null
+/// value (so they sort to the very end). Numbers are compared numerically, and other
+/// types are compared as strings.
+int compareCells(Object? a, Object? b) {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+
+  if (a is num && b is num) {
+    return a.compareTo(b);
+  }
+
+  return a.toString().compareTo(b.toString());
+}
+
+/// Sorts the given [rows] by the column at [columnIndex].
+/// If [ascending] is false, the order is reversed, but nulls remain at the end.
+List<List<Object?>> sortRows(
+  List<List<Object?>> rows,
+  int columnIndex,
+  bool ascending,
+) {
+  final copied = List<List<Object?>>.from(rows);
+  copied.sort((rowA, rowB) {
+    final a = rowA[columnIndex];
+    final b = rowB[columnIndex];
+
+    if (a == null && b == null) return 0;
+    if (a == null) return 1;
+    if (b == null) return -1;
+
+    final cmp = compareCells(a, b);
+    return ascending ? cmp : -cmp;
+  });
+  return copied;
+}
+
+/// Generates a preview string for a cell value.
+/// Returns 'NULL' for null values, and truncates values longer than [maxLength].
+String cellPreview(Object? value, {int maxLength = 100}) {
+  if (value == null) return 'NULL';
+  final str = value.toString();
+  if (str.length <= maxLength) return str;
+  return '${str.substring(0, maxLength)}…';
+}

--- a/test/core/flutter_inspector_impl_test.dart
+++ b/test/core/flutter_inspector_impl_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_inspector_kit/src/core/flutter_inspector_impl.dart';
+import 'package:flutter_inspector_kit/src/models/database_browser_source.dart';
 import 'package:flutter_inspector_kit/src/models/database_operation.dart';
 import 'package:flutter_inspector_kit/src/models/log_level.dart';
 import 'package:flutter_inspector_kit/src/models/network_entry.dart';
@@ -51,4 +52,67 @@ void main() {
       expect(observer, isNotNull);
     });
   });
+
+  group('Database Browser Sources API', () {
+    test('default source is always first and named Operation log', () {
+      final inspector = FlutterInspector();
+      expect(inspector.databaseSources.length, 1);
+      expect(inspector.databaseSources.first.name, 'Operation log');
+    });
+
+    test('constructor injects custom database sources', () {
+      final source = FakeDatabaseBrowserSource();
+      final inspector = FlutterInspector(databaseSources: [source]);
+      expect(inspector.databaseSources.length, 2);
+      expect(inspector.databaseSources[0].name, 'Operation log');
+      expect(inspector.databaseSources[1], source);
+    });
+
+    test('registerDatabaseSource registers custom source dynamically', () {
+      final inspector = FlutterInspector();
+      final source = FakeDatabaseBrowserSource();
+      inspector.registerDatabaseSource(source);
+      expect(inspector.databaseSources.length, 2);
+      expect(inspector.databaseSources[1], source);
+    });
+
+    test('databaseSources returns an unmodifiable list', () {
+      final inspector = FlutterInspector();
+      final sources = inspector.databaseSources;
+      expect(
+        () => (sources as List).add(FakeDatabaseBrowserSource()),
+        throwsUnsupportedError,
+      );
+    });
+
+    test(
+      'logs logged to database are visible via OperationLogSource',
+      () async {
+        final inspector = FlutterInspector();
+        inspector.database(DatabaseOperation.insert, 'users');
+
+        final opLogSource = inspector.databaseSources.first;
+        final tables = await opLogSource.listTables();
+        expect(tables.length, 1);
+        expect(tables.first.name, 'users');
+      },
+    );
+  });
+}
+
+class FakeDatabaseBrowserSource extends DatabaseBrowserSource {
+  @override
+  String get name => 'FakeSource';
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async => [];
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    return const DatabaseTablePage(columns: [], rows: []);
+  }
 }

--- a/test/models/database_browser_source_test.dart
+++ b/test/models/database_browser_source_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Fake implementation to test default parameters
+class FakeDatabaseBrowserSource extends DatabaseBrowserSource {
+  @override
+  String get name => 'FakeSource';
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async {
+    return [];
+  }
+
+  // We capture the limit and offset passed to verify defaults
+  int? lastLimit;
+  int? lastOffset;
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    lastLimit = limit;
+    lastOffset = offset;
+    return DatabaseTablePage(columns: [], rows: []);
+  }
+}
+
+void main() {
+  group('DatabaseTableInfo', () {
+    test('supports construction and equality', () {
+      final info1 = DatabaseTableInfo(name: 'users', rowCount: 10);
+      final info2 = DatabaseTableInfo(name: 'users', rowCount: 10);
+      final info3 = DatabaseTableInfo(name: 'users', rowCount: null);
+      final info4 = DatabaseTableInfo(name: 'posts', rowCount: 10);
+
+      expect(info1, equals(info2));
+      expect(info1.hashCode, equals(info2.hashCode));
+      expect(info1, isNot(equals(info3)));
+      expect(info1, isNot(equals(info4)));
+      expect(info1.toString(), contains('users'));
+    });
+  });
+
+  group('DatabaseTablePage', () {
+    test('supports construction and equality', () {
+      final page1 = DatabaseTablePage(
+        columns: ['id', 'name'],
+        rows: [
+          [1, 'Alice'],
+          [2, 'Bob'],
+        ],
+        totalRows: 2,
+      );
+      final page2 = DatabaseTablePage(
+        columns: ['id', 'name'],
+        rows: [
+          [1, 'Alice'],
+          [2, 'Bob'],
+        ],
+        totalRows: 2,
+      );
+      final page3 = DatabaseTablePage(
+        columns: ['id', 'name'],
+        rows: [
+          [1, 'Alice'],
+        ],
+        totalRows: 2,
+      );
+
+      expect(page1, equals(page2));
+      expect(page1.hashCode, equals(page2.hashCode));
+      expect(page1, isNot(equals(page3)));
+    });
+  });
+
+  group('DatabaseBrowserSource Interface', () {
+    test('verifies default parameters of fetchRows', () async {
+      final source = FakeDatabaseBrowserSource();
+      await source.fetchRows('users');
+      expect(source.lastLimit, equals(200));
+      expect(source.lastOffset, equals(0));
+    });
+  });
+}

--- a/test/sources/operation_log_source_test.dart
+++ b/test/sources/operation_log_source_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter_inspector_kit/src/inspectors/database_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/database_entry.dart';
+import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/sources/operation_log_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('OperationLogSource', () {
+    late DatabaseInspector inspector;
+    late OperationLogSource source;
+
+    setUp(() {
+      inspector = DatabaseInspector();
+      source = OperationLogSource(inspector);
+    });
+
+    test('name is Operation log', () {
+      expect(source.name, equals('Operation log'));
+    });
+
+    test('listTables returns empty list when no entries', () async {
+      final tables = await source.listTables();
+      expect(tables, isEmpty);
+    });
+
+    test(
+      'listTables groups and sorts tables alphabetically with row counts',
+      () async {
+        inspector.add(
+          DatabaseEntry(
+            operation: DatabaseOperation.insert,
+            tableName: 'users',
+          ),
+        );
+        inspector.add(
+          DatabaseEntry(
+            operation: DatabaseOperation.insert,
+            tableName: 'posts',
+          ),
+        );
+        inspector.add(
+          DatabaseEntry(
+            operation: DatabaseOperation.update,
+            tableName: 'users',
+          ),
+        );
+
+        final tables = await source.listTables();
+        expect(tables.length, equals(2));
+        expect(tables[0].name, equals('posts'));
+        expect(tables[0].rowCount, equals(1));
+        expect(tables[1].name, equals('users'));
+        expect(tables[1].rowCount, equals(2));
+      },
+    );
+
+    test(
+      'fetchRows for non-existent table returns empty page with metadata columns',
+      () async {
+        final page = await source.fetchRows('non-existent');
+        expect(page.columns, equals(['#time', '#op', '#rows']));
+        expect(page.rows, isEmpty);
+        expect(page.totalRows, equals(0));
+      },
+    );
+
+    test(
+      'fetchRows builds columns union based on oldest-first first appearance',
+      () async {
+        // Oldest entry (first added): has 'id' and 'name'
+        final entry1 = DatabaseEntry(
+          operation: DatabaseOperation.insert,
+          tableName: 'users',
+          data: {'id': 1, 'name': 'Alice'},
+          timestamp: DateTime(2026, 6, 11, 10, 0),
+        );
+        // Middle entry: has 'name' and 'age'
+        final entry2 = DatabaseEntry(
+          operation: DatabaseOperation.insert,
+          tableName: 'users',
+          data: {'name': 'Bob', 'age': 25},
+          timestamp: DateTime(2026, 6, 11, 10, 5),
+        );
+        // Newest entry: has 'email'
+        final entry3 = DatabaseEntry(
+          operation: DatabaseOperation.update,
+          tableName: 'users',
+          data: {'email': 'carol@example.com'},
+          timestamp: DateTime(2026, 6, 11, 10, 10),
+        );
+
+        // We add them. Remember RingBuffer outputs newest first.
+        // But we determine column union order by scanning oldest-first (entry1 -> entry2 -> entry3).
+        // Order of appearance:
+        // entry1: 'id', 'name'
+        // entry2: 'age' (name already seen)
+        // entry3: 'email'
+        // Final columns: '#time', '#op', '#rows', 'id', 'name', 'age', 'email'
+        inspector.add(entry1);
+        inspector.add(entry2);
+        inspector.add(entry3);
+
+        final page = await source.fetchRows('users');
+        expect(
+          page.columns,
+          equals(['#time', '#op', '#rows', 'id', 'name', 'age', 'email']),
+        );
+      },
+    );
+
+    test(
+      'fetchRows returns rows newest first and fills missing keys with null',
+      () async {
+        final time1 = DateTime(2026, 6, 11, 10, 0);
+        final time2 = DateTime(2026, 6, 11, 10, 5);
+
+        final entry1 = DatabaseEntry(
+          operation: DatabaseOperation.insert,
+          tableName: 'users',
+          data: {'id': 1, 'name': 'Alice'},
+          affectedRows: 1,
+          timestamp: time1,
+        );
+        final entry2 = DatabaseEntry(
+          operation: DatabaseOperation.update,
+          tableName: 'users',
+          data: {'name': 'Bob', 'age': 25},
+          affectedRows: 2,
+          timestamp: time2,
+        );
+
+        inspector.add(entry1);
+        inspector.add(entry2);
+
+        // Columns should be: '#time', '#op', '#rows', 'id', 'name', 'age'
+        final page = await source.fetchRows('users');
+
+        expect(page.rows.length, equals(2));
+        // First row (newest: entry2)
+        expect(
+          page.rows[0],
+          equals([
+            time2.toIso8601String(),
+            'update',
+            2,
+            null, // id is missing
+            'Bob',
+            25,
+          ]),
+        );
+        // Second row (oldest: entry1)
+        expect(
+          page.rows[1],
+          equals([
+            time1.toIso8601String(),
+            'insert',
+            1,
+            1,
+            'Alice',
+            null, // age is missing
+          ]),
+        );
+        expect(page.totalRows, equals(2));
+      },
+    );
+
+    test('fetchRows supports pagination (limit and offset)', () async {
+      for (var i = 1; i <= 5; i++) {
+        inspector.add(
+          DatabaseEntry(
+            operation: DatabaseOperation.insert,
+            tableName: 'users',
+            data: {'id': i},
+            timestamp: DateTime(2026, 6, 11, 10, i),
+          ),
+        );
+      }
+
+      // 5 entries: id=5 (newest) down to id=1 (oldest)
+      // fetch with limit 2, offset 1 should give id=4 and id=3
+      final page = await source.fetchRows('users', limit: 2, offset: 1);
+      expect(page.totalRows, equals(5));
+      expect(page.rows.length, equals(2));
+      // Index of 'id' column is 3 (after #time, #op, #rows)
+      expect(page.rows[0][3], equals(4));
+      expect(page.rows[1][3], equals(3));
+    });
+  });
+}

--- a/test/ui/tabs/database_tab_test.dart
+++ b/test/ui/tabs/database_tab_test.dart
@@ -1,20 +1,53 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector_impl.dart';
+import 'package:flutter_inspector_kit/src/models/database_browser_source.dart';
 import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/database/table_rows_view.dart';
 import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/database_tab.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class FakeCustomSource extends DatabaseBrowserSource {
+  @override
+  String get name => 'custom.db';
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async {
+    return [const DatabaseTableInfo(name: 'custom_table', rowCount: 42)];
+  }
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    return const DatabaseTablePage(columns: [], rows: []);
+  }
+}
+
 void main() {
-  group('DatabaseTab', () {
-    testWidgets('displays database entries and supports clearing', (
+  group('DatabaseTab New UI', () {
+    testWidgets('displays database tables grouped and supports clearing', (
       tester,
     ) async {
       final inspector = FlutterInspector();
       inspector.database(
         DatabaseOperation.insert,
         'users',
-        affectedRows: 2,
-        data: {'query': 'INSERT INTO users'},
+        affectedRows: 1,
+        data: {'name': 'Alice'},
+      );
+      inspector.database(
+        DatabaseOperation.update,
+        'users',
+        affectedRows: 1,
+        data: {'name': 'Bob'},
+      );
+      inspector.database(
+        DatabaseOperation.insert,
+        'posts',
+        affectedRows: 1,
+        data: {'title': 'Hello'},
       );
 
       await tester.pumpWidget(
@@ -23,14 +56,110 @@ void main() {
         ),
       );
 
-      expect(find.text('INSERT on users'), findsOneWidget);
-      expect(find.textContaining('Rows affected: 2'), findsOneWidget);
-      expect(find.textContaining('INSERT INTO users'), findsOneWidget);
+      await tester.pumpAndSettle();
 
+      // Check table list shows grouped tables sorted alphabetically
+      expect(find.text('posts'), findsOneWidget);
+      expect(find.text('1 rows'), findsOneWidget); // posts table has 1 entry
+
+      expect(find.text('users'), findsOneWidget);
+      expect(find.text('2 rows'), findsOneWidget); // users table has 2 entries
+
+      // Clear action
       await tester.tap(find.byIcon(Icons.delete));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
-      expect(find.text('INSERT on users'), findsNothing);
+      // Check empty state
+      expect(find.text('No database activity'), findsOneWidget);
+      expect(find.text('users'), findsNothing);
+      expect(find.text('posts'), findsNothing);
+    });
+
+    testWidgets('shows empty state for empty sources', (tester) async {
+      final inspector = FlutterInspector();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: DatabaseTab(inspector: inspector)),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('No database activity'), findsOneWidget);
+    });
+
+    testWidgets('dropdown is shown for multiple sources, and switches source', (
+      tester,
+    ) async {
+      final customSource = FakeCustomSource();
+      final inspector = FlutterInspector(databaseSources: [customSource]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: DatabaseTab(inspector: inspector)),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Dropdown should be visible
+      expect(
+        find.byType(DropdownButton<DatabaseBrowserSource>),
+        findsOneWidget,
+      );
+      // Delete icon is visible because default Operation log is selected
+      expect(find.byIcon(Icons.delete), findsOneWidget);
+
+      // Open dropdown and select custom.db
+      await tester.tap(find.byType(DropdownButton<DatabaseBrowserSource>));
+      await tester.pumpAndSettle();
+
+      // Select 'custom.db'
+      await tester.tap(find.text('custom.db').last);
+      await tester.pumpAndSettle();
+
+      // Check custom tables are shown
+      expect(find.text('custom_table'), findsOneWidget);
+      expect(find.text('42 rows'), findsOneWidget);
+
+      // Delete icon is NOT visible since custom.db is selected (not OperationLogSource)
+      expect(find.byIcon(Icons.delete), findsNothing);
+    });
+
+    testWidgets('dropdown is not shown for single source, only text name', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector(); // Only default Operation log
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: DatabaseTab(inspector: inspector)),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DropdownButton<DatabaseBrowserSource>), findsNothing);
+      expect(find.text('Operation log'), findsOneWidget);
+    });
+
+    testWidgets('tapping table pushes TableRowsView', (tester) async {
+      final inspector = FlutterInspector();
+      inspector.database(DatabaseOperation.insert, 'users');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: DatabaseTab(inspector: inspector)),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('users'));
+      await tester.pumpAndSettle();
+
+      // Verify TableRowsView was pushed
+      expect(find.byType(TableRowsView), findsOneWidget);
     });
   });
 }

--- a/test/ui/tabs/table_rows_view_test.dart
+++ b/test/ui/tabs/table_rows_view_test.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inspector_kit/src/models/database_browser_source.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/database/table_rows_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MockDatabaseBrowserSource extends DatabaseBrowserSource {
+  MockDatabaseBrowserSource({
+    required this.name,
+    this.rowsResponse,
+    this.shouldThrow = false,
+    this.delay,
+  });
+
+  @override
+  final String name;
+  DatabaseTablePage? rowsResponse;
+  bool shouldThrow;
+  Duration? delay;
+  int fetchCallCount = 0;
+  String? lastTableName;
+  int? lastLimit;
+  int? lastOffset;
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async => [];
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    fetchCallCount++;
+    lastTableName = tableName;
+    lastLimit = limit;
+    lastOffset = offset;
+    if (delay != null) {
+      await Future.delayed(delay!);
+    }
+    if (shouldThrow) throw Exception('Database error occurred');
+    return rowsResponse ?? const DatabaseTablePage(columns: [], rows: []);
+  }
+}
+
+void main() {
+  group('TableRowsView T5a', () {
+    testWidgets('renders table columns and rows correctly', (tester) async {
+      final source = MockDatabaseBrowserSource(
+        name: 'test.db',
+        rowsResponse: const DatabaseTablePage(
+          columns: ['id', 'name', 'age'],
+          rows: [
+            [1, 'Alice', 30],
+            [2, 'Bob', null],
+          ],
+          totalRows: 2,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TableRowsView(source: source, tableName: 'users'),
+          ),
+        ),
+      );
+
+      // Loading state
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await tester.pumpAndSettle();
+
+      // Check header rendering
+      expect(find.text('id'), findsOneWidget);
+      expect(find.text('name'), findsOneWidget);
+      expect(find.text('age'), findsOneWidget);
+
+      // Check cell values
+      expect(find.text('1'), findsOneWidget);
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('2'), findsOneWidget);
+      expect(find.text('Bob'), findsOneWidget);
+
+      // Check NULL italic grey text
+      final nullTextFinder = find.byWidgetPredicate(
+        (widget) =>
+            widget is Text &&
+            widget.data == 'NULL' &&
+            widget.style?.fontStyle == FontStyle.italic &&
+            widget.style?.color == Colors.grey,
+      );
+      expect(nullTextFinder, findsOneWidget);
+
+      // Check bottom status text
+      expect(find.text('Showing 2 of 2'), findsOneWidget);
+    });
+
+    testWidgets('renders empty table without crashing DataTable', (
+      tester,
+    ) async {
+      final source = MockDatabaseBrowserSource(
+        name: 'test.db',
+        rowsResponse: const DatabaseTablePage(
+          columns: [],
+          rows: [],
+          totalRows: 0,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TableRowsView(source: source, tableName: 'users'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('No rows'), findsOneWidget);
+      expect(find.byType(DataTable), findsNothing);
+      expect(find.text('Showing 0 of 0'), findsOneWidget);
+    });
+
+    testWidgets('handles error state with retry button', (tester) async {
+      final source = MockDatabaseBrowserSource(
+        name: 'test.db',
+        shouldThrow: true,
+        delay: const Duration(milliseconds: 10),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TableRowsView(source: source, tableName: 'users'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Error message check
+      expect(find.textContaining('Database error occurred'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+
+      // Fix error and retry
+      source.shouldThrow = false;
+      source.rowsResponse = const DatabaseTablePage(
+        columns: ['id'],
+        rows: [
+          [1],
+        ],
+        totalRows: 1,
+      );
+
+      await tester.tap(find.text('Retry'));
+      await tester.pump(); // Show loading
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await tester.pumpAndSettle();
+
+      expect(find.text('id'), findsOneWidget);
+      expect(find.text('1'), findsOneWidget);
+      expect(source.fetchCallCount, equals(2));
+    });
+
+    testWidgets('app bar refresh button reloads data', (tester) async {
+      final source = MockDatabaseBrowserSource(
+        name: 'test.db',
+        rowsResponse: const DatabaseTablePage(
+          columns: ['id'],
+          rows: [
+            [1],
+          ],
+          totalRows: 1,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TableRowsView(source: source, tableName: 'users'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(source.fetchCallCount, equals(1));
+
+      await tester.tap(find.byIcon(Icons.refresh));
+      await tester.pumpAndSettle();
+
+      expect(source.fetchCallCount, equals(2));
+    });
+  });
+
+  group('TableRowsView T5b', () {
+    testWidgets('supports local column sorting and null last', (tester) async {
+      final source = MockDatabaseBrowserSource(
+        name: 'test.db',
+        rowsResponse: const DatabaseTablePage(
+          columns: ['id', 'val'],
+          rows: [
+            [2, 'banana'],
+            [3, null],
+            [1, 'apple'],
+          ],
+          totalRows: 3,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TableRowsView(source: source, tableName: 'users'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Tap 'id' header to sort ascending
+      await tester.tap(find.text('id'));
+      await tester.pumpAndSettle();
+
+      // Tap 'id' header again to sort descending
+      await tester.tap(find.text('id'));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+      'tapping cell opens bottom sheet with complete value and copy',
+      (tester) async {
+        String? clipboardText;
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          (call) async {
+            if (call.method == 'Clipboard.setData') {
+              clipboardText = (call.arguments as Map)['text'] as String?;
+            }
+            return null;
+          },
+        );
+
+        final source = MockDatabaseBrowserSource(
+          name: 'test.db',
+          rowsResponse: const DatabaseTablePage(
+            columns: ['data'],
+            rows: [
+              ['very long cell data string'],
+            ],
+            totalRows: 1,
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TableRowsView(source: source, tableName: 'users'),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Tap the cell
+        await tester.tap(find.text('very long cell data string'));
+        await tester.pumpAndSettle();
+
+        // Bottom sheet is open
+        expect(find.byType(SelectableText), findsOneWidget);
+        expect(find.text('Copy Value'), findsOneWidget);
+
+        await tester.tap(find.text('Copy Value'));
+        await tester.pumpAndSettle();
+
+        expect(clipboardText, equals('very long cell data string'));
+        expect(find.text('Value copied to clipboard'), findsOneWidget);
+      },
+    );
+
+    testWidgets('supports loading more rows when available', (tester) async {
+      final source = MockDatabaseBrowserSource(
+        name: 'test.db',
+        rowsResponse: DatabaseTablePage(
+          columns: ['id'],
+          rows: List.generate(200, (i) => [i]),
+          totalRows: 250,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TableRowsView(source: source, tableName: 'users'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Showing 200 of 250'), findsOneWidget);
+      expect(find.text('Load More'), findsOneWidget);
+
+      // Mock next page response
+      source.rowsResponse = DatabaseTablePage(
+        columns: ['id'],
+        rows: List.generate(50, (i) => [200 + i]),
+        totalRows: 250,
+      );
+
+      await tester.tap(find.text('Load More'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Showing 250 of 250'), findsOneWidget);
+      expect(find.text('Load More'), findsNothing);
+      expect(source.fetchCallCount, equals(2));
+      expect(source.lastOffset, equals(200));
+    });
+  });
+}

--- a/test/utils/table_sort_test.dart
+++ b/test/utils/table_sort_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_inspector_kit/src/utils/table_sort.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('compareCells', () {
+    test('compares numbers correctly', () {
+      expect(compareCells(5, 10), isNegative);
+      expect(compareCells(10, 5), isPositive);
+      expect(compareCells(5, 5), equals(0));
+      expect(compareCells(9, 10.5), isNegative);
+    });
+
+    test('compares strings correctly', () {
+      expect(compareCells('apple', 'banana'), isNegative);
+      expect(compareCells('banana', 'apple'), isPositive);
+      expect(compareCells('apple', 'apple'), equals(0));
+    });
+
+    test('compares mixed types as string representation', () {
+      expect(
+        compareCells(5, '10'),
+        isPositive,
+      ); // '5'.compareTo('10') is positive
+      expect(compareCells(5, '5'), equals(0));
+    });
+
+    test('treats null as maximum', () {
+      expect(compareCells(null, 100), isPositive);
+      expect(compareCells(100, null), isNegative);
+      expect(compareCells(null, null), equals(0));
+    });
+  });
+
+  group('sortRows', () {
+    final rows = [
+      [2, 'banana'],
+      [null, 'cherry'],
+      [1, 'apple'],
+      [3, null],
+    ];
+
+    test('sorts ascending on number column with null last', () {
+      final sorted = sortRows(rows, 0, true);
+      expect(sorted, [
+        [1, 'apple'],
+        [2, 'banana'],
+        [3, null],
+        [null, 'cherry'],
+      ]);
+      // Ensure immutability
+      expect(rows[0][0], equals(2));
+    });
+
+    test('sorts descending on number column with null last', () {
+      final sorted = sortRows(rows, 0, false);
+      expect(sorted, [
+        [3, null],
+        [2, 'banana'],
+        [1, 'apple'],
+        [null, 'cherry'],
+      ]);
+    });
+
+    test('sorts ascending on string column with null last', () {
+      final sorted = sortRows(rows, 1, true);
+      expect(sorted, [
+        [1, 'apple'],
+        [2, 'banana'],
+        [null, 'cherry'],
+        [3, null],
+      ]);
+    });
+
+    test('sorts descending on string column with null last', () {
+      final sorted = sortRows(rows, 1, false);
+      expect(sorted, [
+        [null, 'cherry'],
+        [2, 'banana'],
+        [1, 'apple'],
+        [3, null],
+      ]);
+    });
+  });
+
+  group('cellPreview', () {
+    test('renders null as NULL', () {
+      expect(cellPreview(null), equals('NULL'));
+    });
+
+    test('renders short values without truncation', () {
+      expect(cellPreview('hello'), equals('hello'));
+      expect(cellPreview(123), equals('123'));
+    });
+
+    test('truncates long values and appends ellipsis', () {
+      final longStr = 'a' * 105;
+      final preview = cellPreview(longStr, maxLength: 100);
+      expect(preview.length, equals(101)); // 100 chars + 1 ellipsis char
+      expect(preview.endsWith('…'), isTrue);
+      expect(preview.substring(0, 100), equals('a' * 100));
+    });
+
+    test('handles boundary lengths', () {
+      expect(cellPreview('a' * 99, maxLength: 100).length, equals(99));
+      expect(cellPreview('a' * 100, maxLength: 100).length, equals(100));
+      expect(cellPreview('a' * 101, maxLength: 100).length, equals(101));
+    });
+  });
+}


### PR DESCRIPTION
Resolves #12

### Description
This PR replaces the chronological database operations list view in the Database tab with a SQL-administrator style database table browser. It introduces a two-level UI (Table List -> Row Grid) powered by a clean, extensible data source interface.

### Changes
#### Core Package
- **Abstract interface**: Added `DatabaseBrowserSource`, `DatabaseTableInfo`, and `DatabaseTablePage` representing a database source, its tables, and paginated rows.
- **Default source**: Added `OperationLogSource` wrapping `DatabaseInspector` to group database entry history into virtual tables.
- **Registration**: Added constructor argument `databaseSources` and `registerDatabaseSource()` API in `FlutterInspector` to dynamically registry database adapters.
- **UI Components**:
  - `DatabaseTab`: Rewritten to display the table list (grouping, row counts, source selection dropdown, refresh, clear).
  - `TableRowsView`: Displays a paginated data grid with double scrolling (horizontal/vertical), local sorting (NULLs sort last), and cell detailed preview sheet with clipboard copy.
- **Helpers**: Added `table_sort.dart` containing pure cell comparison, sorting, and cell preview formatting functions.

#### Example App
- Added `SqfliteBrowserSource` SQLite reference adapter.
- Injected `demo.db` seed data and registered the SQLite source in `main.dart` upon tap of a new "Seed SQLite Demo" button.

#### Tests & Docs
- Comprehensive unit tests added for `DatabaseBrowserSource`, `OperationLogSource`, and `table_sort.dart`.
- Widget tests added for `DatabaseTab` and `TableRowsView`.
- Excluded long-running `magical_tap_test.dart` from general suite run.
- Documented usage and adapters in `README.md` and top of `CHANGELOG.md`.

### Testing
- `flutter analyze` runs clean with 0 warnings.
- `flutter test` runs clean (all 160 tests passed).
