### PR TITLE
fix: resolve iOS/macOS foreground notification banner issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Once enabled, the inspector requests notification permission for you when it ini
 **Notification behaviour**:
 
 - **Android**: appears as a silent heads-up banner (no sound or vibration) when a new API call arrives. The banner animates in and dismisses automatically. Subsequent calls within a 2-second window silently update the notification content without re-alerting. After 2 seconds, the next call triggers another heads-up alert.
-- **iOS / macOS**: displays a silent foreground banner when enabled.
+- **iOS / macOS**: displays a foreground banner when a new API call arrives, throttled the same way as Android. **This requires one line of setup in your `AppDelegate` — see [Required iOS / macOS setup](#required-ios--macos-setup) below.** Without it, iOS silently suppresses the foreground banner (the entry is still delivered to Notification Center).
 - The notification uses a dedicated high-priority Android channel (`flutter_inspector_network_v2`) — if you upgrade from an earlier version, the old notification channel is automatically deleted and will not appear in system settings.
 
 To make **tapping the notification open the dashboard on the Network tab**, pass a `navigatorKey` that is also wired into your `MaterialApp`:
@@ -173,7 +173,20 @@ Also ensure a notification icon exists at `@mipmap/ic_launcher` (default Flutter
 
 </details>
 
-On iOS / macOS, the user is prompted for notification permission when the inspector initialises.
+#### Required iOS / macOS setup
+
+On iOS / macOS, the user is prompted for notification permission when the inspector initialises. The permission alone is **not** enough to show a banner while your app is in the **foreground**: iOS only presents a foreground notification when a `UNUserNotificationCenterDelegate` returns it from `willPresentNotification`. `FlutterAppDelegate` forwards that callback to plugins but does **not** assign itself as the delegate, so your host app must do it once in `AppDelegate`. Add the single delegate line to whatever `AppDelegate` your project already has:
+
+```swift
+import UserNotifications // add this import
+
+// ...inside application(_:didFinishLaunchingWithOptions:), before `return super...`:
+if #available(iOS 10.0, *) {
+  UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
+}
+```
+
+`FlutterAppDelegate` already conforms to `UNUserNotificationCenterDelegate`, so no extra protocol or method is needed — only the assignment. Keep the rest of your `AppDelegate` (including any `GeneratedPluginRegistrant` registration) unchanged. For macOS, add the same line to `macos/Runner/AppDelegate.swift`. See [`example/ios/Runner/AppDelegate.swift`](example/ios/Runner/AppDelegate.swift) and [`example/macos/Runner/AppDelegate.swift`](example/macos/Runner/AppDelegate.swift) for working references. **Without this line no foreground banner appears on iOS / macOS** — the notification is still delivered silently to Notification Center, and tapping it still works.
 
 If permission is denied or the platform isn't supported, the notifier degrades silently to a no-op — it never crashes your app.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,10 @@ Also ensure a notification icon exists at `@mipmap/ic_launcher` (default Flutter
 
 #### Required iOS / macOS setup
 
-On iOS / macOS, the user is prompted for notification permission when the inspector initialises. The permission alone is **not** enough to show a banner while your app is in the **foreground**: iOS only presents a foreground notification when a `UNUserNotificationCenterDelegate` returns it from `willPresentNotification`. `FlutterAppDelegate` forwards that callback to plugins but does **not** assign itself as the delegate, so your host app must do it once in `AppDelegate`. Add the single delegate line to whatever `AppDelegate` your project already has:
+On iOS / macOS, the user is prompted for notification permission when the inspector initialises. The permission alone is **not** enough to show a banner while your app is in the **foreground**: the system only presents a foreground notification when a `UNUserNotificationCenterDelegate` returns it from `willPresentNotification`.
+
+##### iOS Setup
+`FlutterAppDelegate` on iOS already implements that forwarding and conforms to `UNUserNotificationCenterDelegate`, so your host app only needs to assign it in `AppDelegate.swift`:
 
 ```swift
 import UserNotifications // add this import
@@ -186,7 +189,31 @@ if #available(iOS 10.0, *) {
 }
 ```
 
-`FlutterAppDelegate` already conforms to `UNUserNotificationCenterDelegate`, so no extra protocol or method is needed — only the assignment. Keep the rest of your `AppDelegate` (including any `GeneratedPluginRegistrant` registration) unchanged. For macOS, add the same line to `macos/Runner/AppDelegate.swift`. See [`example/ios/Runner/AppDelegate.swift`](example/ios/Runner/AppDelegate.swift) and [`example/macos/Runner/AppDelegate.swift`](example/macos/Runner/AppDelegate.swift) for working references. **Without this line no foreground banner appears on iOS / macOS** — the notification is still delivered silently to Notification Center, and tapping it still works.
+##### macOS Setup
+Unlike iOS, `FlutterAppDelegate` on macOS does **not** conform to `UNUserNotificationCenterDelegate`. You must explicitly declare compliance and implement the callback in `macos/Runner/AppDelegate.swift`:
+
+```swift
+import UserNotifications // add this import
+
+@main
+class AppDelegate: FlutterAppDelegate, UNUserNotificationCenterDelegate {
+  override func applicationDidFinishLaunching(_ notification: Notification) {
+    UNUserNotificationCenter.current().delegate = self
+    super.applicationDidFinishLaunching(notification)
+  }
+
+  // Handle foreground notifications on macOS
+  func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.alert, .sound])
+  }
+}
+```
+
+See [`example/ios/Runner/AppDelegate.swift`](example/ios/Runner/AppDelegate.swift) and [`example/macos/Runner/AppDelegate.swift`](example/macos/Runner/AppDelegate.swift) for working references. **Without this setup no foreground banner appears on iOS / macOS** — the notification is still delivered silently to Notification Center, and tapping it still works.
 
 If permission is denied or the platform isn't supported, the notifier degrades silently to a no-op — it never crashes your app.
 

--- a/docs/features/2026-06-17-ios-foreground-notification.md
+++ b/docs/features/2026-06-17-ios-foreground-notification.md
@@ -1,0 +1,48 @@
+# Feature: 修復 iOS 前景無法跳出網路通知 banner
+
+- 日期：2026-06-17
+- 類型：Bug fix（iOS 整合缺口）+ 文件 + 程式碼硬化
+
+## What & Why
+
+`FlutterInspector(showNetworkNotification: true)` 在 iOS 上、app 處於**前景**時，
+即使有網路請求觸發 `NetworkNotifier.showOrUpdate()`，也不會跳出系統通知 banner。
+
+### 根因（已由對抗式驗證確認，HIGH confidence）
+
+iOS 只有在某個 `UNUserNotificationCenterDelegate.willPresentNotification` 回傳
+`.banner` / `.alert` 時，才會在前景顯示本地通知。
+
+- `flutter_local_notifications` v22 只透過 `addApplicationDelegate` 註冊，**自己不設** UN delegate。
+- `FlutterAppDelegate` 有實作 `willPresentNotification`，但**不會把自己指派**為 active UN delegate。
+- example app 的 `AppDelegate.swift` 也沒設 → **沒有任何人擁有 delegate** →
+  `willPresentNotification` 從不被呼叫 → iOS 前景把每一個 banner 都壓掉，
+  與 `presentBanner:true`、throttler、init race 全部無關。
+
+對照證據：`flutter_local_notifications` 自己的 example `AppDelegate.swift` 明確設了
+`UNUserNotificationCenter.current().delegate = self`，本專案 example 漏了這一行。
+
+這是 **host-app 整合缺口**，不是 package 程式碼 bug。package 不含 iOS native code，
+無法替下游 host app 設 delegate，因此「真正的修復」是文件指引（每個使用者都得自己做這步）。
+
+## 使用者故事
+
+- 作為使用 `flutter_inspector` 的開發者，當我開啟 `showNetworkNotification` 且 app 在前景時，
+  我希望能看到網路通知 banner 提醒有 API 呼叫。
+- 作為套件使用者，我希望 README 清楚告訴我 iOS 上必須做哪一步整合，否則通知靜默失效。
+
+## 驗收條件
+
+1. example app 的 `AppDelegate.swift` 設定 `UNUserNotificationCenter.current().delegate = self`。
+2. README 有「Required iOS setup」段，說明 host app 必須在自己的 `AppDelegate` 設 UN delegate，
+   否則 iOS 前景不顯示通知。
+3. `flutter_inspector.dart` 的 init race 清除：`onAdd` 只在 `init()` resolve 後才掛上。
+4. 既有的 `presentAlert: alert`（network_notifier_io.dart）一併納入。
+5. `flutter test` 全綠；`flutter analyze` 無新增 warning。
+
+## 範圍邊界
+
+- **不改** `AlertThrottler`（2 秒節流是設計，已驗證非成因，且有單元測試保護）。
+- **不改** `DarwinInitializationSettings()` 預設（已驗證會在 initialize 時請求權限，非成因）。
+- **不改** `presentSound`（與 banner 無關）。
+- 真機驗證（banner 實際顯示）由使用者在實體 iOS 裝置完成；模擬器通知不可靠。

--- a/docs/plans/2026-06-17-ios-foreground-notification.md
+++ b/docs/plans/2026-06-17-ios-foreground-notification.md
@@ -1,0 +1,60 @@
+# 實作計畫：修復 iOS 前景無法跳出網路通知 banner
+
+- 對應規格：docs/features/2026-06-17-ios-foreground-notification.md
+- 日期：2026-06-17
+
+## 資料結構 / 機制
+
+無新資料結構。三處異動皆為「補上 iOS 通知鏈缺口」與「修正 callback 掛載時序」。
+
+## 任務拆分
+
+各任務寫入路徑互不重疊，但數量少、且 C 涉及測試驗證，採**序列**執行較穩。
+逐任務複雜度標註供 model 分級。
+
+### Task 1 — Fix A：example AppDelegate 設定 UN delegate
+- **複雜度**：機械性（單檔、規格完整）→ 快/便宜 model
+- **寫入**：`example/ios/Runner/AppDelegate.swift`
+- **內容**：
+  - `import UserNotifications`
+  - 在 `didFinishLaunchingWithOptions` 內、`super` 呼叫前：
+    ```swift
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
+    }
+    ```
+  - `FlutterAppDelegate` 已 conform `UNUserNotificationCenterDelegate` 並轉發，無需額外 protocol/method。
+
+### Task 2 — Fix B：README 加「Required iOS setup」
+- **複雜度**：機械性（文件）→ 快/便宜 model
+- **寫入**：`README.md`（找通知相關段落，或在 iOS 設定／Getting Started 附近新增）
+- **內容**：說明使用 `showNetworkNotification` 的 host app 必須在 `AppDelegate` 設
+  `UNUserNotificationCenter.current().delegate = self`，附上對齊 example 的程式碼片段，
+  並註明沒設的話 iOS 前景不顯示通知（背景仍會進通知中心）。
+
+### Task 3 — Fix C：清除 init race + 納入既有 presentAlert
+- **複雜度**：整合（觸及核心建構子時序，需確認測試）→ 標準 model
+- **寫入**：`lib/src/core/flutter_inspector.dart`（line 41-47 區段）
+- **內容**：
+  ```dart
+  _notifier = notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
+  _notifier!.init().then((_) {
+    _registry.network.onAdd = (entry, total) {
+      _notifier!.showOrUpdate(entry, total);
+    };
+  });
+  ```
+  - 既有未 commit 的 `presentAlert: alert`（network_notifier_io.dart）保留，一併納入。
+  - 注意：`flutter_inspector.dart` 需 `import 'dart:async'` 若用到 `unawaited`；
+    用 `.then()` 不需要額外 import，優先用 `.then()`。
+
+## 驗證
+
+- `flutter analyze`（無新增 warning）
+- `flutter test`（全綠，特別是 test/notifications/network_notifier_test.dart）
+- example app 編譯確認（`flutter build ios --no-codesign` 或至少 analyze）
+
+## 不做（範圍邊界）
+
+- 不改 AlertThrottler、DarwinInitializationSettings()、presentSound。
+- 真機 banner 顯示由使用者在實體裝置驗證。

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
@@ -7,6 +8,13 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Required for flutter_inspector's network notification: iOS only shows a
+    // foreground local-notification banner when a UNUserNotificationCenterDelegate
+    // returns it from willPresentNotification. FlutterAppDelegate implements that
+    // forwarding but does not assign itself as the delegate, so the host app must.
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
+    }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,8 +1,19 @@
 import Cocoa
 import FlutterMacOS
+import UserNotifications
 
 @main
 class AppDelegate: FlutterAppDelegate {
+  override func applicationDidFinishLaunching(_ notification: Notification) {
+    // Required for flutter_inspector's network notification: macOS only shows a
+    // foreground notification banner when a UNUserNotificationCenterDelegate
+    // returns it from willPresentNotification. FlutterAppDelegate forwards that
+    // callback to plugins but does not assign itself as the delegate, so the host
+    // app must. Uses `as?` so it degrades to nil if the SDK ever stops conforming.
+    UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    super.applicationDidFinishLaunching(notification)
+  }
+
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -3,14 +3,12 @@ import FlutterMacOS
 import UserNotifications
 
 @main
-class AppDelegate: FlutterAppDelegate {
+class AppDelegate: FlutterAppDelegate, UNUserNotificationCenterDelegate {
   override func applicationDidFinishLaunching(_ notification: Notification) {
     // Required for flutter_inspector's network notification: macOS only shows a
     // foreground notification banner when a UNUserNotificationCenterDelegate
-    // returns it from willPresentNotification. FlutterAppDelegate forwards that
-    // callback to plugins but does not assign itself as the delegate, so the host
-    // app must. Uses `as?` so it degrades to nil if the SDK ever stops conforming.
-    UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    // returns it from willPresentNotification.
+    UNUserNotificationCenter.current().delegate = self
     super.applicationDidFinishLaunching(notification)
   }
 
@@ -20,5 +18,14 @@ class AppDelegate: FlutterAppDelegate {
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
+  }
+
+  // Handle foreground notifications on macOS
+  func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.alert, .sound])
   }
 }

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -41,10 +41,17 @@ class FlutterInspector {
     if (showNetworkNotification) {
       _notifier =
           notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
-      _notifier!.init();
-      _registry.network.onAdd = (entry, total) {
-        _notifier!.showOrUpdate(entry, total);
-      };
+      // Wire onAdd only after init() resolves. init() never rejects (it catches
+      // and swallows platform errors internally), so this callback always runs.
+      // Requests that arrive before init completes are not forwarded to the
+      // notifier — which is correct, since _available isn't true until init
+      // succeeds, so showOrUpdate would no-op on them anyway. This just avoids
+      // holding a callback that fires into an uninitialised notifier.
+      _notifier!.init().then((_) {
+        _registry.network.onAdd = (entry, total) {
+          _notifier!.showOrUpdate(entry, total);
+        };
+      });
     }
   }
 

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -51,6 +51,10 @@ class FlutterInspector {
         _registry.network.onAdd = (entry, total) {
           _notifier!.showOrUpdate(entry, total);
         };
+        final entries = _registry.network.entries;
+        if (entries.isNotEmpty) {
+          _notifier!.showOrUpdate(entries.first, entries.length);
+        }
       });
     }
   }

--- a/lib/src/notifications/network_notifier_io.dart
+++ b/lib/src/notifications/network_notifier_io.dart
@@ -157,6 +157,7 @@ class NetworkNotifier {
       showWhen: false,
     );
     final darwinDetails = DarwinNotificationDetails(
+      presentAlert: alert,
       presentBanner: alert,
       presentList: true,
       presentSound: false,

--- a/test/notifications/network_notifier_test.dart
+++ b/test/notifications/network_notifier_test.dart
@@ -122,6 +122,10 @@ void main() {
         expect(details.iOS!.presentBanner, isTrue);
       });
 
+      test('iOS presentAlert is true (foreground alert on iOS < 14)', () {
+        expect(details.iOS!.presentAlert, isTrue);
+      });
+
       test('iOS presentList is true (stays in notification centre)', () {
         expect(details.iOS!.presentList, isTrue);
       });
@@ -171,6 +175,10 @@ void main() {
 
       test('iOS presentBanner is false (no banner when throttled)', () {
         expect(details.iOS!.presentBanner, isFalse);
+      });
+
+      test('iOS presentAlert is false (no alert when throttled)', () {
+        expect(details.iOS!.presentAlert, isFalse);
       });
 
       test(

--- a/test/ui/magical_tap_test.dart
+++ b/test/ui/magical_tap_test.dart
@@ -16,13 +16,14 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
 
       final finder = find.byType(SizedBox);
-      await tester.tap(finder);
-      await Future.delayed(const Duration(milliseconds: 10));
-      await tester.tap(finder);
-      await Future.delayed(const Duration(milliseconds: 10));
-      await tester.tap(finder);
+      await tester.tap(finder, warnIfMissed: false);
+      await tester.runAsync(() => Future.delayed(const Duration(milliseconds: 10)));
+      await tester.tap(finder, warnIfMissed: false);
+      await tester.runAsync(() => Future.delayed(const Duration(milliseconds: 10)));
+      await tester.tap(finder, warnIfMissed: false);
 
       expect(tapped, isTrue);
     });
@@ -39,16 +40,17 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
 
       final finder = find.byType(SizedBox);
-      await tester.tap(finder);
-      await Future.delayed(const Duration(milliseconds: 10));
-      await tester.tap(finder);
+      await tester.tap(finder, warnIfMissed: false);
+      await tester.runAsync(() => Future.delayed(const Duration(milliseconds: 10)));
+      await tester.tap(finder, warnIfMissed: false);
 
       // exceed timeout
-      await Future.delayed(const Duration(milliseconds: 150));
+      await tester.runAsync(() => Future.delayed(const Duration(milliseconds: 150)));
 
-      await tester.tap(finder); // tap 3
+      await tester.tap(finder, warnIfMissed: false); // tap 3
 
       expect(tapped, isFalse);
     });


### PR DESCRIPTION
### Summary
[#18](https://github.com/Yomiamy/flutter_inspector_kit/issues/18) iOS/macOS foreground notification delegate issue

**[修正問題]**

iOS/macOS 主程式在前景（foreground）運作時，無法正確彈出網路呼叫通知（network notification banner）。這是因為 iOS/macOS 系統規範要求必須將 `UNUserNotificationCenter` 的 `delegate` 設定為 `FlutterAppDelegate` 才能在前景展示 Banner，而原實作中 host app 的 `AppDelegate` 未進行此 delegate 設定。此外，在 `FlutterInspector` 的初始化流程中，`NetworkNotifier` 與網路 registry 的綁定順序存在 Race Condition，可能導致第一個 API 呼叫的通知漏發。在測試方面，`magical_tap_test.dart` 使用了 `Future.delayed` 且未配合 `runAsync`，導致 Flutter Widget 測試在多個測試排程中容易 hang 住（卡在 165）。

**[修正方式]**

1. **設定 UN delegate**：在 `example/ios/Runner/AppDelegate.swift` 與 `example/macos/Runner/AppDelegate.swift` 中，於 `applicationDidFinishLaunching` / `didFinishLaunchingWithOptions` 內將 `UNUserNotificationCenter.current().delegate` 指向 `self`（即 conform 了 `UNUserNotificationCenterDelegate` 的 AppDelegate）。
2. **修復初始化 race condition**：在 `lib/src/core/flutter_inspector.dart` 中，使用 `.then()` 非同步完成 `init()` 之後，才掛載 `onAdd` 監聽器，確保 notifier 已準備完畢，並在 `lib/src/notifications/network_notifier_io.dart` 中將 `DarwinNotificationDetails` 的 `presentAlert` 設定為 `true`。
3. **更新 README 文件**：於 `README.md` 中新增「Required iOS setup」與「Required macOS setup」說明，引導套件使用者進行對應的 AppDelegate delegate 設定。
4. **測試修正**：在 `test/notifications/network_notifier_test.dart` 中新增 `presentAlert` 的測試案例；並在 `test/ui/magical_tap_test.dart` 中將 `Future.delayed` 用 `tester.runAsync` 包裹，並加入 `tester.pumpAndSettle()` 與 `warnIfMissed: false`，完全解決測試 hang 且消除 hit test 警告。