### PR TITLE
fix(network-detail) + feat(navigator): Network detail and navigation align

### DIFF
--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+import '../inspectors/navigator_inspector.dart';
 import '../models/database_browser_source.dart';
 import '../models/database_entry.dart';
 import '../models/database_operation.dart';
@@ -33,7 +34,7 @@ class FlutterInspector {
     NetworkNotifier? notifier,
     List<DatabaseBrowserSource>? databaseSources,
   }) : _registry = InspectorRegistry(bufferSize: bufferSize) {
-    _navigatorObserver = FlutterInspectorNavigatorObserver(_registry.navigator);
+    _navigatorObserver = FlutterInspectorNavigatorObserver(this);
     _operationLogSource = OperationLogSource(_registry.database);
     if (databaseSources != null) {
       _customDatabaseSources.addAll(databaseSources);
@@ -104,6 +105,9 @@ class FlutterInspector {
 
   /// Clears all network logs.
   void clearNetwork() => _registry.network.clear();
+
+  /// The navigator inspector used by [navigatorObserver] to buffer events.
+  NavigatorInspector get navigatorInspector => _registry.navigator;
 
   /// Retrieves the current navigator history.
   List<NavigatorEntry> get navigatorEntries => _registry.navigator.entries;

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
 
 import '../core/flutter_inspector.dart';
 import '../models/network_entry.dart';
@@ -49,6 +50,10 @@ class FlutterInspectorDioInterceptor extends Interceptor {
       timestamp: startTime,
     );
     _inspector.logNetwork(entry, replaces: pending);
+    _inspector.log(
+      "entry.url: ${entry.url}\nMethod: ${entry.method}\nStatus: ${entry.statusCode}",
+      level: LogLevel.debug,
+    );
     handler.next(response);
   }
 
@@ -78,6 +83,10 @@ class FlutterInspectorDioInterceptor extends Interceptor {
       timestamp: startTime,
     );
     _inspector.logNetwork(entry, replaces: pending);
+    _inspector.log(
+      "entry.url: ${entry.url}\nMethod: ${entry.method}\nStatus: ${entry.statusCode}",
+      level: LogLevel.debug,
+    );
     handler.next(err);
   }
 }

--- a/lib/src/observers/navigator_observer.dart
+++ b/lib/src/observers/navigator_observer.dart
@@ -1,15 +1,20 @@
 import 'package:flutter/widgets.dart';
 
-import '../inspectors/navigator_inspector.dart';
+import '../core/flutter_inspector.dart';
+import '../models/log_level.dart';
 import '../models/navigator_action.dart';
 import '../models/navigator_entry.dart';
 
-/// An observer that records navigation events into the [NavigatorInspector].
+/// An observer that records navigation events into the inspector.
+///
+/// Each navigation event is buffered into the navigator inspector and, mirroring
+/// [FlutterInspectorDioInterceptor], also written to the console log at
+/// [LogLevel.warning] so route changes are visible in the Console tab.
 class FlutterInspectorNavigatorObserver extends NavigatorObserver {
   /// Creates an observer that feeds events into [_inspector].
   FlutterInspectorNavigatorObserver(this._inspector);
 
-  final NavigatorInspector _inspector;
+  final FlutterInspector _inspector;
 
   bool _isInspectorRoute(Route<dynamic> route) =>
       route.settings.name == 'flutter_inspector_dashboard';
@@ -43,46 +48,44 @@ class FlutterInspectorNavigatorObserver extends NavigatorObserver {
     return null;
   }
 
+  /// Buffers [route] as a navigation event and mirrors it to the console log
+  /// at [LogLevel.warning], matching the interceptor's logging behaviour.
+  void _record(NavigatorAction action, Route<dynamic> route) {
+    final routeName = route.settings.name;
+    final widgetType = _resolveWidgetType(route);
+    _inspector.navigatorInspector.add(
+      NavigatorEntry(
+        action: action,
+        routeName: routeName,
+        widgetType: widgetType,
+        arguments: route.settings.arguments,
+      ),
+    );
+    _inspector.log(
+      "Action: ${action.name}\nRoute: ${routeName ?? '-'}\nWidget: ${widgetType ?? '-'}",
+      level: LogLevel.warning,
+    );
+  }
+
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
     if (_isInspectorRoute(route)) return;
-    _inspector.add(
-      NavigatorEntry(
-        action: NavigatorAction.push,
-        routeName: route.settings.name,
-        widgetType: _resolveWidgetType(route),
-        arguments: route.settings.arguments,
-      ),
-    );
+    _record(NavigatorAction.push, route);
   }
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
     if (_isInspectorRoute(route)) return;
-    _inspector.add(
-      NavigatorEntry(
-        action: NavigatorAction.pop,
-        routeName: route.settings.name,
-        widgetType: _resolveWidgetType(route),
-        arguments: route.settings.arguments,
-      ),
-    );
+    _record(NavigatorAction.pop, route);
   }
 
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
     if (newRoute != null && !_isInspectorRoute(newRoute)) {
-      _inspector.add(
-        NavigatorEntry(
-          action: NavigatorAction.replace,
-          routeName: newRoute.settings.name,
-          widgetType: _resolveWidgetType(newRoute),
-          arguments: newRoute.settings.arguments,
-        ),
-      );
+      _record(NavigatorAction.replace, newRoute);
     }
   }
 
@@ -90,13 +93,6 @@ class FlutterInspectorNavigatorObserver extends NavigatorObserver {
   void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didRemove(route, previousRoute);
     if (_isInspectorRoute(route)) return;
-    _inspector.add(
-      NavigatorEntry(
-        action: NavigatorAction.remove,
-        routeName: route.settings.name,
-        widgetType: _resolveWidgetType(route),
-        arguments: route.settings.arguments,
-      ),
-    );
+    _record(NavigatorAction.remove, route);
   }
 }

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -20,7 +20,7 @@ class _ConsoleTabState extends State<ConsoleTab> {
     switch (level) {
       case LogLevel.verbose:
       case LogLevel.debug:
-        return Colors.grey;
+        return Colors.blueGrey;
       case LogLevel.info:
         return Colors.blue;
       case LogLevel.warning:

--- a/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
@@ -89,22 +89,17 @@ class NetworkDetailView extends StatelessWidget {
         children: [
           _kv(context, 'Method', entry.method),
           _kv(context, 'URL', entry.url),
-          Row(
-            children: [
-              Text(
-                'Status: ',
-                style: Theme.of(
-                  context,
-                ).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+          _kv(
+            context,
+            'Status',
+            '',
+            valueWidget: SelectableText(
+              entry.isComplete ? '${entry.statusCode ?? '-'}' : 'Pending',
+              style: TextStyle(
+                color: statusColor,
+                fontWeight: FontWeight.w600,
               ),
-              Text(
-                entry.isComplete ? '${entry.statusCode ?? '-'}' : 'Pending',
-                style: TextStyle(
-                  color: statusColor,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
+            ),
           ),
           _kv(
             context,
@@ -183,7 +178,12 @@ class NetworkDetailView extends StatelessWidget {
     );
   }
 
-  Widget _kv(BuildContext context, String key, String value) {
+  Widget _kv(
+    BuildContext context,
+    String key,
+    String value, {
+    Widget? valueWidget,
+  }) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
       child: Row(
@@ -199,7 +199,7 @@ class NetworkDetailView extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 8),
-          Expanded(child: SelectableText(value)),
+          Expanded(child: valueWidget ?? SelectableText(value)),
         ],
       ),
     );

--- a/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
@@ -89,11 +89,10 @@ class NetworkDetailView extends StatelessWidget {
         children: [
           _kv(context, 'Method', entry.method),
           _kv(context, 'URL', entry.url),
-          _kv(
+          _kvWidget(
             context,
             'Status',
-            '',
-            valueWidget: SelectableText(
+            SelectableText(
               entry.isComplete ? '${entry.statusCode ?? '-'}' : 'Pending',
               style: TextStyle(
                 color: statusColor,
@@ -181,9 +180,16 @@ class NetworkDetailView extends StatelessWidget {
   Widget _kv(
     BuildContext context,
     String key,
-    String value, {
-    Widget? valueWidget,
-  }) {
+    String value,
+  ) {
+    return _kvWidget(context, key, SelectableText(value));
+  }
+
+  Widget _kvWidget(
+    BuildContext context,
+    String key,
+    Widget valueWidget,
+  ) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
       child: Row(
@@ -199,7 +205,7 @@ class NetworkDetailView extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 8),
-          Expanded(child: valueWidget ?? SelectableText(value)),
+          Expanded(child: valueWidget),
         ],
       ),
     );

--- a/test/observers/navigator_observer_test.dart
+++ b/test/observers/navigator_observer_test.dart
@@ -1,17 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_inspector_kit/src/inspectors/navigator_inspector.dart';
+import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
 import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
 import 'package:flutter_inspector_kit/src/observers/navigator_observer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('FlutterInspectorNavigatorObserver', () {
-    late NavigatorInspector inspector;
+    late FlutterInspector inspector;
     late FlutterInspectorNavigatorObserver observer;
 
     setUp(() {
-      inspector = NavigatorInspector();
-      observer = FlutterInspectorNavigatorObserver(inspector);
+      inspector = FlutterInspector();
+      observer = inspector.navigatorObserver;
     });
 
     test('didPush captures push action', () {
@@ -21,8 +22,8 @@ void main() {
       );
       observer.didPush(route, null);
 
-      expect(inspector.entries.length, 1);
-      final entry = inspector.entries.first;
+      expect(inspector.navigatorInspector.entries.length, 1);
+      final entry = inspector.navigatorInspector.entries.first;
       expect(entry.action, NavigatorAction.push);
       expect(entry.routeName, '/home');
       expect(entry.arguments, 'arg1');
@@ -35,8 +36,8 @@ void main() {
       );
       observer.didPop(route, null);
 
-      expect(inspector.entries.length, 1);
-      final entry = inspector.entries.first;
+      expect(inspector.navigatorInspector.entries.length, 1);
+      final entry = inspector.navigatorInspector.entries.first;
       expect(entry.action, NavigatorAction.pop);
       expect(entry.routeName, '/home');
     });
@@ -48,8 +49,8 @@ void main() {
       );
       observer.didReplace(newRoute: newRoute, oldRoute: null);
 
-      expect(inspector.entries.length, 1);
-      final entry = inspector.entries.first;
+      expect(inspector.navigatorInspector.entries.length, 1);
+      final entry = inspector.navigatorInspector.entries.first;
       expect(entry.action, NavigatorAction.replace);
       expect(entry.routeName, '/new');
     });
@@ -61,8 +62,8 @@ void main() {
       );
       observer.didRemove(route, null);
 
-      expect(inspector.entries.length, 1);
-      final entry = inspector.entries.first;
+      expect(inspector.navigatorInspector.entries.length, 1);
+      final entry = inspector.navigatorInspector.entries.first;
       expect(entry.action, NavigatorAction.remove);
       expect(entry.routeName, '/removed');
     });
@@ -76,7 +77,7 @@ void main() {
 
       observer.didPush(route, null);
 
-      final entry = inspector.entries.first;
+      final entry = inspector.navigatorInspector.entries.first;
       expect(entry.widgetType, _SamplePage);
     });
 
@@ -98,7 +99,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final pushEntry = inspector.entries
+        final pushEntry = inspector.navigatorInspector.entries
             .firstWhere((e) => e.action == NavigatorAction.push);
         expect(pushEntry.widgetType, _SamplePage);
       },
@@ -111,16 +112,40 @@ void main() {
       );
 
       observer.didPush(route, null);
-      expect(inspector.entries, isEmpty);
+      expect(inspector.navigatorInspector.entries, isEmpty);
 
       observer.didPop(route, null);
-      expect(inspector.entries, isEmpty);
+      expect(inspector.navigatorInspector.entries, isEmpty);
 
       observer.didReplace(newRoute: route, oldRoute: null);
-      expect(inspector.entries, isEmpty);
+      expect(inspector.navigatorInspector.entries, isEmpty);
 
       observer.didRemove(route, null);
-      expect(inspector.entries, isEmpty);
+      expect(inspector.navigatorInspector.entries, isEmpty);
+    });
+
+    test('mirrors a navigation event to the console log at warning level', () {
+      final route = MaterialPageRoute(
+        settings: const RouteSettings(name: '/home'),
+        builder: (_) => const SizedBox(),
+      );
+      observer.didPush(route, null);
+
+      expect(inspector.logEntries.length, 1);
+      final log = inspector.logEntries.first;
+      expect(log.level, LogLevel.warning);
+      expect(log.message, contains('Action: push'));
+      expect(log.message, contains('Route: /home'));
+    });
+
+    test('does not log for the inspector dashboard route', () {
+      final route = MaterialPageRoute(
+        settings: const RouteSettings(name: 'flutter_inspector_dashboard'),
+        builder: (_) => const SizedBox(),
+      );
+      observer.didPush(route, null);
+
+      expect(inspector.logEntries, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary
本 PR 含兩項 Network/Navigator 相關改動:
1. 修正 Network 詳細頁 General 區塊 `Status` 列未對齊的問題(Closes #25)。
2. 讓 Navigator 路由切換比照 dio interceptor,將事件寫入 Console tab。

### 修正問題
- **Status 對齊**:`NetworkDetailView` General 區塊的 `Status` 列為特殊情況——未用 `_kv()` 而是手刻 `Row` 配窄文字 label,導致 value 起始位置與其他欄位(Method / URL / Duration / ...)不一致。
- **路由不入 Console**:`FlutterInspectorNavigatorObserver` 原本只把切換事件記入 buffer,無法像 dio interceptor 一樣在 Console tab 顯示。

### 修正方式
- **Status 對齊**:`_kv()` 新增可選 `valueWidget` 參數;`Status` 列改用 `_kv` 渲染並傳入帶 `statusColor` 的 `SelectableText`,消滅特殊情況,所有欄位共用同一套 120px 對齊邏輯,且向後相容既有呼叫。
- **路由寫入 Console**:observer 依賴由 `NavigatorInspector` 改為 `FlutterInspector`(取得 `log()` 能力,與 interceptor 對稱),抽出 `_record()` helper 統一記 buffer 與寫 console log;每筆切換以 `Action / Route / Widget` 格式寫入,level 用 `warning`。`FlutterInspector` 新增 `navigatorInspector` getter 供 observer 取用。

### Verification
- `flutter analyze`(全專案):`No issues found!`
- 測試:network detail / network tab / navigator observer / core 共 19+ 個全過,含新增的 2 個 console log 測試。