### PR TITLE
chore(release): bump version to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.2.4
+
+### Added
+* Network requests and responses captured by `FlutterInspectorDioInterceptor` are now mirrored to the Console tab (at `debug` level), so HTTP traffic is visible alongside other logs.
+* `FlutterInspectorNavigatorObserver` now mirrors route changes (push / pop / replace / remove) to the Console tab at `warning` level, in addition to the Navigator history.
+
+### Changed
+* Adjusted the `LogLevel.debug` text color in the Console tab to blue-grey for better visibility.
+
+### Fixed
+* Fixed the `Status` row in the Network detail view's General section so its value aligns with the other fields (Method, URL, Duration, etc.) instead of starting at an inconsistent position.
+
 ## 0.2.3
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^0.2.3
+  flutter_inspector_kit: ^0.2.4
 ```
 
 Then run `flutter pub get`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 0.2.3
+version: 0.2.4
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
## Summary
發布 v0.2.4。更新版號(pubspec / README)並補上 CHANGELOG,涵蓋 PR #26 合入 main 的使用者可見改動。

### 變更內容
- `pubspec.yaml`:`0.2.3` → `0.2.4`
- `README.md`:安裝範例版號 `^0.2.3` → `^0.2.4`
- `CHANGELOG.md`:新增 `## 0.2.4` 區塊
  - **Added**:network 請求/回應鏡射到 Console(debug level);navigator 路由切換鏡射到 Console(warning level)。
  - **Changed**:Console tab 的 `LogLevel.debug` 文字顏色改為 blue-grey。
  - **Fixed**:Network 詳細頁 General 區塊 `Status` 列對齊修正。

合併後將打 tag `v0.2.4`。