### PR TITLE
chore(skill): add gen-update-publish-info skill

### DIFF
--- a/.claude/skills/gen-update-publish-info/SKILL.md
+++ b/.claude/skills/gen-update-publish-info/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: gen-update-publish-info
+description: 當使用者要為已合入 main 的變更發布新版本——更新版號（pubspec.yaml / README.md）、補上 CHANGELOG、並打 git tag 推上去時使用。觸發語如「更新版本資訊」、「bump 版號」、「調整版號為 vX.Y.Z 下 tag push」、「release vX.Y.Z」、「gen-update-publish-info vX.Y.Z」。
+---
+
+# Gen Update & Publish Info
+
+依使用者指定的新版號，為**已合入 main 的變更**更新版本資訊並打 tag。範圍止於 push tag——**不執行 `flutter pub publish`**（互動認證且不可逆，留給使用者手動）。
+
+## 觸發與輸入
+
+- 輸入格式：`gen-update-publish-info <version>`，例如 `gen-update-publish-info v0.2.4` 或 `0.2.4`。
+- 版號由**使用者明確指定**，skill 不自行猜測或從 commit 推導。未提供時，向使用者詢問目標版號。
+- 記正規化後的版號：`$VERSION`（純語意版號，如 `0.2.4`）、`$TAG`（如 `v0.2.4`）。
+
+## 前置檢查（缺一不可）
+
+```bash
+git branch --show-current        # 確認所在分支
+git status --short               # 工作區必須乾淨；有未 commit 變更先停下問使用者
+gh pr view <PR> --json state,mergedAt   # 若變更來自某 PR，確認已 MERGED
+git checkout main && git pull --ff-only origin main   # 同步最新 main
+grep "^version:" pubspec.yaml     # 確認當前版號
+```
+
+- **變更必須已在 main 上**。若對應 PR 尚未合併，停下告知使用者，不在未合併狀態打 tag。
+- 工作區不乾淨 → 停，不要把無關變更混進 release commit。
+
+## 流程
+
+### 1. 從 main 開 release 分支
+
+分支命名固定格式 `release/release-<version>`：
+
+```bash
+git checkout -b release/release-$VERSION main
+```
+
+> **禁止**直接在 main 上 commit 版號變更——一律走分支 + PR。
+
+### 2. 更新三處版本資訊
+
+| 檔案 | 改什麼 |
+|------|--------|
+| `pubspec.yaml` | `version: <舊版>` → `version: $VERSION` |
+| `README.md` | 安裝範例 `flutter_inspector_kit: ^<舊版>` → `^$VERSION`（依實際 package 名） |
+| `CHANGELOG.md` | 在最上方新增 `## $VERSION` 區塊 |
+
+### 3. 撰寫 CHANGELOG 區塊
+
+分析 release 涵蓋的 commits，**只收錄使用者可見的改動**，依類別分組（沿用既有 CHANGELOG 的英文 + `### Added/Changed/Fixed` 慣例）：
+
+```bash
+git log --oneline <上個 tag 或 main 分歧點>..HEAD
+git show <sha> --stat --format="%s%n%n%b"   # 逐個確認 commit 實際做了什麼
+```
+
+- **Added**：新功能、新 API。
+- **Changed**：既有行為調整。
+- **Fixed**：bug 修正。
+- **排除純內部 refactor**（如重構 private helper 簽名）——使用者不可見，不寫進 CHANGELOG。
+- 描述要具體：寫「Status 列 value 與其他欄位對齊」而非「修了個 UI bug」。
+
+### 4. 驗證、commit、push、開 PR
+
+```bash
+git diff                          # 親自核對三處變更正確
+git add pubspec.yaml README.md CHANGELOG.md
+git commit -m "chore(release): bump version to $VERSION"
+git push -u origin release/release-$VERSION
+gh pr create --base main --title "chore(release): bump version to $VERSION" --body "<摘要>"
+```
+
+⏸ **暫停點**：展示 PR 連結，問使用者要自行 review 合併，還是要 skill 幫忙 `gh pr merge`。
+
+### 5. 合併後才打 tag（順序不可顛倒）
+
+PR 合併進 main 後：
+
+```bash
+git checkout main && git pull --ff-only origin main
+grep "^version:" pubspec.yaml     # 驗證 main 上版號 = $VERSION
+git tag -a $TAG -m "Release $TAG" <merge-commit-sha>
+git push origin $TAG
+git ls-remote --tags origin $TAG  # 驗證 tag 已上 remote
+```
+
+- tag 打在**合併後的 merge commit** 上，不是 release 分支的 commit。
+- 用 annotated tag（`-a`），tag message 簡述本次 release 重點。
+
+## 完成後
+
+報告：PR 連結、tag、main 版號驗證結果。**主動提醒**使用者：打 tag **不等於**發布到 pub.dev；若需發布套件需另外手動跑 `flutter pub publish`（可先 `--dry-run` 驗證）。
+
+## Quick Reference
+
+| 步驟 | 關鍵動作 | 守則 |
+|------|---------|------|
+| 前置 | 同步 main、確認 PR MERGED、工作區乾淨 | 變更必須已在 main |
+| 開分支 | `release/release-$VERSION` from main | 不在 main 直接工作 |
+| 改三處 | pubspec / README / CHANGELOG | CHANGELOG 只收使用者可見改動 |
+| PR | commit + push + `gh pr create` | 暫停讓使用者決定合併方式 |
+| tag | 合併後打在 merge commit、push | **先合併才打 tag** |
+
+## Common Mistakes
+
+| 錯誤 | 正解 |
+|------|------|
+| 在 PR 合併前就打 tag | 一律「合併進 main → 打 tag」，順序不可顛倒 |
+| tag 打在 release 分支 commit 上 | 打在 main 的 merge commit 上 |
+| 把內部 refactor 寫進 CHANGELOG | 只寫使用者可見的 Added/Changed/Fixed |
+| 自己猜版號 | 版號由使用者指定，未提供就問 |
+| 直接在 main commit 版號 | 走 `release/release-<version>` 分支 + PR |
+| 順手跑 `flutter pub publish` | 不在範圍內；只提醒使用者，由其手動執行 |
+| 忘記改 README 的安裝版號 | pubspec / README / CHANGELOG 三處都要改 |


### PR DESCRIPTION
## Summary
新增 release 流程 skill `gen-update-publish-info`,把版本發布流程固化為可複用步驟。

### Skill 行為
- **輸入**:使用者明確指定版號(如 `gen-update-publish-info v0.2.4`),skill 不自行猜測。
- **流程**:前置檢查(同步 main、確認 PR MERGED、工作區乾淨)→ 開 `release/release-<version>` 分支 → 更新 pubspec / README / CHANGELOG 三處 → commit + PR → **合併後**在 merge commit 打 annotated tag 並 push。
- **範圍邊界**:止於 push tag,**不執行 `flutter pub publish`**(互動認證且不可逆,留給使用者手動,僅提醒)。
- CHANGELOG 只收錄使用者可見改動,排除純內部 refactor。

### 關鍵守則(寫進 Common Mistakes)
- 先合併進 main 才打 tag,順序不可顛倒。
- tag 打在 merge commit,非 release 分支 commit。
- 不在 main 直接 commit 版號。