### PR TITLE
Capture uncaught errors into the Console and make error logs expandable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+* **Uncaught error capture (opt-in)**: pass `captureUncaughtErrors: true` to `FlutterInspector(...)`, or wrap `runApp` with `FlutterInspector.runGuarded(...)`, to capture uncaught errors from `FlutterError.onError`, `PlatformDispatcher.instance.onError`, `ErrorWidget.builder` and guarded zones as `LogLevel.error` logs in the Console tab. Defaults to **off**; when on, every hook chains/wraps the existing host handler — errors are always forwarded downstream, never swallowed.
+* **Expandable Console error logs**: tapping a Console log that carries a `stackTrace` or structured `data` now opens a detail view (`LogDetailView`) showing the message, level, timestamp, a selectable/copyable stack trace, and the structured data — with copy/share actions.
+
 ## 0.2.4
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -242,16 +242,7 @@ It is **disabled by default** so the package never touches your error handling u
 final inspector = FlutterInspector(captureUncaughtErrors: true);
 ```
 
-This wires three standard Flutter hooks — `FlutterError.onError` (build/layout/paint errors), `PlatformDispatcher.instance.onError` (uncaught async errors), and `ErrorWidget.builder` (which widget failed to build). To **also** capture uncaught *zone* errors (e.g. unawaited `Future` errors), wrap `runApp` with `runGuarded`:
-
-```dart
-void main() {
-  final inspector = FlutterInspector(captureUncaughtErrors: true);
-  FlutterInspector.runGuarded(() => runApp(MyApp()), inspector: inspector);
-}
-```
-
-`runGuarded` reuses the same hook wiring (it never double-attaches), so you can use it together with `captureUncaughtErrors` for full coverage.
+This wires three standard Flutter hooks — `FlutterError.onError` (build/layout/paint errors), `PlatformDispatcher.instance.onError` (uncaught async errors, including unawaited `Future` errors), and `ErrorWidget.builder` (which widget failed to build). Together they cover framework, asynchronous and build-time errors without wrapping `runApp` in a custom zone, so there is no `Zone mismatch` to manage.
 
 > **Errors are never swallowed.** Every hook **chains/wraps** your existing handler rather than replacing it: the inspector records the error and then forwards it downstream (your handler, or Flutter's default presentation — debug red screen / release grey screen unchanged). The capture is purely additive.
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,31 @@ inspector.log(
 
 Available levels: `verbose`, `debug`, `info`, `warning`, `error`.
 
+### Uncaught error capture (opt-in)
+
+By default you have to log errors yourself. Enable **uncaught error capture** to have the inspector automatically turn uncaught errors into `error`-level Console logs — no manual `try/catch` needed.
+
+It is **disabled by default** so the package never touches your error handling unless you ask. Enable it on the constructor:
+
+```dart
+final inspector = FlutterInspector(captureUncaughtErrors: true);
+```
+
+This wires three standard Flutter hooks — `FlutterError.onError` (build/layout/paint errors), `PlatformDispatcher.instance.onError` (uncaught async errors), and `ErrorWidget.builder` (which widget failed to build). To **also** capture uncaught *zone* errors (e.g. unawaited `Future` errors), wrap `runApp` with `runGuarded`:
+
+```dart
+void main() {
+  final inspector = FlutterInspector(captureUncaughtErrors: true);
+  FlutterInspector.runGuarded(() => runApp(MyApp()), inspector: inspector);
+}
+```
+
+`runGuarded` reuses the same hook wiring (it never double-attaches), so you can use it together with `captureUncaughtErrors` for full coverage.
+
+> **Errors are never swallowed.** Every hook **chains/wraps** your existing handler rather than replacing it: the inspector records the error and then forwards it downstream (your handler, or Flutter's default presentation — debug red screen / release grey screen unchanged). The capture is purely additive.
+
+Captured errors appear as red logs in the **Console** tab. Tap any log that carries a stack trace or structured data to open a detail view with a copyable stack trace and the structured payload, plus copy/share actions.
+
 ### Track navigation
 
 Nothing to do here — routes are tracked automatically once you register `inspector.navigatorObserver` in `navigatorObservers` (see [Initialize](#initialize)). Pushes, pops, and replacements all show up in the Navigator tab.

--- a/docs/brainstorm/2026-06-20-error-troubleshooting-features.md
+++ b/docs/brainstorm/2026-06-20-error-troubleshooting-features.md
@@ -1,0 +1,143 @@
+# 🩺 Flutter Inspector 錯誤問題排查與分析：功能腦力激盪報告
+
+> 「好代碼沒有特殊情況。」 —— Linus Torvalds
+>
+> 這份報告**只聚焦一件事**：當 app 出錯時，`flutter_inspector_kit` 能不能讓開發者/QA 用最少的步驟「看見錯誤、關聯原因、帶走證據」。
+> 我們不重彈上一份 [`brainstorm/2026-06-18-feature_brainstorming.md`](../../brainstorm/2026-06-18-feature_brainstorming.md) 的泛用優化清單，而是用排查（troubleshooting）這把尺，重新審視每個缺口。凡是偏離「排查」核心、或為了理論完美而增加複雜度的，一律砍掉。
+
+---
+
+## 🐧 三個鐵律問題
+
+1. **這是真實問題，還是腦補？**
+   - 真實。掃描現有 codebase 後確認：**inspector 目前完全看不到「它沒被手動餵進來」的錯誤**——沒有任何全局例外捕捉，沒有 widget build error 攔截，Dio error 只存 `err.toString()` 丟掉了 stackTrace。錯誤排查工具卻是「錯誤的盲人」。
+2. **有沒有更簡單的方法？**
+   - 有，而且核心抽象都已存在。`RingBuffer`、`InspectorRegistry`、各 `*Inspector` 的 `add()`、`@immutable` 的 entry models、`LogEntry.stackTrace`（已定義卻沒人用）、共用 `timestamp`——排查能力幾乎都能靠**組合既有零件**長出來，不需要新框架。
+3. **這會破壞什麼嗎？**
+   - 不會。全部以擴充式設計：新增可選建構參數（default off）、新增 getter、新增 UI section。**絕不改動既有 `FlutterInspector` 公開 API 的行為**。
+
+---
+
+## 🔍 排查能力現況盤點
+
+| 排查環節 | 現況 | 評級 |
+|---|---|---|
+| 看見「我主動 log 的」錯誤 | `inspector.log(..., level: error, stackTrace: ...)` 可記錄，但 stackTrace **UI 從不展示** | 🟡 半殘 |
+| 看見「未捕捉」的例外 | **無**任何 `FlutterError.onError` / `runZonedGuarded` / `PlatformDispatcher.onError` / `ErrorWidget.builder` | 🔴 盲區 |
+| 看見網路失敗的根因 | Dio `onError` 只存 `err.toString()`，丟掉 `err.type`/`err.stackTrace`/`err.response` | 🟡 失真 |
+| 關聯「錯誤前後發生了什麼」 | 4 個 buffer（log/network/nav/db）共用 `timestamp` 卻**完全孤立**，無跨層時序 | 🔴 斷裂 |
+| 帶走排查證據 | 只能匯出**單筆** network（cURL/分享）；log 無任何匯出；無診斷報告打包 | 🔴 殘缺 |
+| 過濾定位 error log | `LogInspector.entriesAtLevel()` 已存在，`ConsoleTab` **從不使用**，無搜尋無過濾 | 🔴 垃圾 |
+
+> 結論：排查鏈條上的六個環節，**四個是紅燈**。這不是優化問題，是這個「debug 工具」在錯誤排查這條主線上幾乎沒鋪設。
+
+---
+
+## 🛠️ 第一部分：補上排查盲區（高優先 · 真正的缺口）
+
+### 1. 全局未捕捉例外捕捉（Uncaught Error Capture）— 🔴 最大盲區
+* **痛點**：async error、widget build error、`onPressed` 裡漏接的 exception——這些**最常導致線上問題**的錯誤，inspector 一個都看不到，全靠開發者記得手動 try-catch + log。覆蓋率取決於人的自律，等於沒有。
+* **好品味設計（關鍵洞察）**：
+  > 不要為「捕捉錯誤」發明新的儲存與 UI。捕捉到的例外**就是一條 `LogLevel.error` 的 log**。
+  - 新增**可選**入口 `FlutterInspector(captureUncaughtErrors: true)`（default **off**，絕不強制接管宿主 app 的錯誤流）。
+  - 內部設置三個標準掛點，把例外轉成 `inspector.log(msg, level: error, stackTrace: ...)`：
+    - `FlutterError.onError`（**chain 既有 handler**，不取代）→ framework 層 build/layout/paint error
+    - `PlatformDispatcher.instance.onError` → 未捕捉的 async error
+    - `ErrorWidget.builder` → 包裝既有 builder，記錄是哪個 widget build 失敗後再轉交原 builder
+  - 對需要 `runZonedGuarded` 的情境，提供 `FlutterInspector.runGuarded(() => runApp(...))` 薄包裝，**不污染** `main()`。
+* **重用**：`inspector.log()` + `LogEntry.stackTrace`（終於有人用它了）+ `RingBuffer`。零新模型。
+* **品味守則**：chain 而非覆蓋既有 handler。捕捉後**必須**把錯誤往下游傳（`FlutterError.presentError` / 重拋），否則就違反「Never break userspace」——debug 工具不該吞掉宿主的崩潰。
+* **Effort**：medium ｜ **排查價值**：⭐⭐⭐⭐⭐
+
+### 2. 跨 Inspector 時序關聯（Correlated Timeline）— 🔴 排查的靈魂
+* **痛點**：錯誤幾乎都是跨層的——「點了某按鈕（nav）→ 發了某 API（network）→ 5xx → 印了某 error log」。但現在這四件事躺在四個孤立 buffer 裡，開發者得在四個 tab 之間用肉眼對時間戳，這是排查最大的摩擦。
+* **好品味設計**：
+  > 四個 buffer 共用 `timestamp`——這個共通欄位就是答案，不需要新資料管線。
+  - **做法 A（先做，低成本）**：在 `NetworkDetailView` 與（規劃中的）`LogDetailView` 裡，加一個「同時段事件（±5s）」側欄。一個 `_eventsAround(timestamp, window)` 工具函式掃 registry 的各 buffer，按時序列出，點擊跳轉。
+  - **做法 B（後做，高價值）**：新增 **Timeline 視圖**——一個 `TimelineEvent`（type: log/network/nav/db 的薄 union）按 `timestamp` merge-sort 後的混合時間軸，`error` 級事件標紅旗。這是把「故障全景」一眼攤開。
+* **重用**：各 entry 的 `timestamp`、`InspectorRegistry` 已持有四個 buffer、`LogLevel` 配色、`KeyValueTable`。
+* **品味守則**：`TimelineEvent` 只是**指標包裝**（指向既有 entry），不複製資料、不引入第二份真相。
+* **Effort**：A=low / B=medium ｜ **排查價值**：⭐⭐⭐⭐⭐
+
+### 3. 一鍵診斷報告（Diagnostic Report）— 🔴 QA 提 bug 的剛需
+* **痛點**：QA 重現 bug 後，要手動切四個 tab、逐筆截圖/複製、再手打 device/OS/版本資訊。耗時且容易漏，回報品質參差。
+* **好品味設計**：
+  - 新增 `buildDiagnosticReport(inspector, {timeRange, sections})`，輸出一份 **Markdown / JSON** 報告：device & app info 表頭 + 選定時間窗內的 log / network / nav / db 各區段。
+  - Dashboard AppBar 新增「Export Diagnostic Report」action → 勾選區段 + 時間範圍（last 5m / 1h / all）+ 格式 → 走系統分享。
+  - device/app info 用官方維護的 `package_info_plus` + `device_info_plus`（**可選相依**，未安裝時該區段降級為「N/A」，絕不崩）。
+* **重用**：`network_formatters.dart` 的 `buildPlainText`/`buildCurl` 序列化模式、`share_text.dart` 平台自適應分享、各 buffer 的 newest-first snapshot getter。
+* **Effort**：medium ｜ **排查價值**：⭐⭐⭐⭐⭐
+
+### 4. Dio 錯誤的結構化捕捉（Structured Network Error）— 🟡 修失真
+* **痛點**：`onError()` 只存 `err.toString()`，把 `DioException` 的精華全丟了：**根因類型**（connectionTimeout / DNS / SSL / parse / cancel）、`err.stackTrace`、以及**伺服器回傳的 error body**。開發者看到一坨字串，分不清是「斷網」還是「server 5xx」。
+* **好品味設計**：
+  - `dio_interceptor.onError` 改為擷取結構化欄位：`err.type`（分類）、`err.stackTrace`、`err.response?.statusCode`、保住 `err.response?.data`（伺服器的錯誤說明）。
+  - 核心區分一條：**`response == null` → 傳輸層失敗（沒到 server）**；**`response != null` → server 回了錯誤碼**。這條判斷消滅了「Failed 到底是斷網還是後端壞了」的猜謎。
+  - `NetworkDetailView` 新增「Exception Details」section 分層展示。
+* **重用**：擴充 `NetworkEntry.error`（或加 `errorType` / `errorStackTrace` 欄位，保持 `@immutable`）、`DioExceptionType` enum、既有 detail view 的 card 分層。
+* **Effort**：low–medium ｜ **排查價值**：⭐⭐⭐⭐
+
+### 5. ConsoleTab 排查化：stackTrace 詳情 + error 過濾 — 🟡 半殘
+* **痛點**：error log 的 `stackTrace` 與 `data` 在 UI 完全看不到，列表項點了沒反應，500 條 log 無搜尋無過濾，error 跟 info 混成一片。
+* **好品味設計**：
+  - `LogDetailView`（仿 `NetworkDetailView`）：點 log 展開 message / level / **可複製 stackTrace** / `data`（用 `KeyValueTable`）。
+  - 搜尋欄 + LogLevel FilterChip + 「errors only」快捷——直接套 `NetworkTab` 的搜尋/chip 模式與 `applyNetworkFilter` 邏輯框架，error log 終於能秒定位。
+* **重用**：`NetworkTab` 搜尋 bar + FilterChip、`LogInspector.entriesAtLevel()`（已存在）、`KeyValueTable`、`NetworkDetailView` 佈局。
+* **注意**：搜尋/過濾/詳情面板在 [上一份 brainstorm](../../brainstorm/2026-06-18-feature_brainstorming.md) 已列入。**此處只強調其排查價值並與 #2 的時序側欄、#3 的報告打包對齊**，避免重複規劃；實作時應一併考量。
+* **Effort**：medium ｜ **排查價值**：⭐⭐⭐⭐
+
+---
+
+## 🚀 第二部分：加分但非核心（中優先）
+
+### 6. 網路請求重放（Replay / Resend）
+* **價值**：API 出錯時，原地重送（可改 header/body）即時確認「是否仍重現 / server 是否恢復」，免去複製 cURL 跳終端的 context switch。
+* **設計**：`NetworkDetailView` 加「Resend」按鈕，從 entry 重建請求（沿用 `buildCurl()` 已證明的請求重組邏輯）經注入的 Dio 重送，結果作為新 `NetworkEntry` 記回 buffer。
+* **重用**：`buildCurl()` 的請求重組、init 時傳入的 Dio client。
+* **Effort**：medium ｜ **排查價值**：⭐⭐⭐⭐
+* **邊界**：只「重送原請求」。**不**做 mocking、不做腳本化改寫——那是 Proxyman/Charles 的地盤（見 anti-features）。
+
+### 7. 錯誤聚合摘要（Error Aggregation）
+* **價值**：同一個 502 每 30 秒打一次 → 現在是 500 條各自獨立的列表項。聚合成「502 Bad Gateway × N 次，最近 5 分鐘」一張卡，一眼看出是「持續故障」還是「偶發」。
+* **設計**：`NetworkTab` 頂部「Error Summary」卡，按 `(statusCode, errorType)` 分組計數 + 首末時間。
+* **重用**：`NetworkStatusGroup.matches()` 分組邏輯、`RingBuffer` 作資料源。
+* **Effort**：medium ｜ **排查價值**：⭐⭐⭐
+
+### 8. 當前路由堆疊可視化（Active Navigation Stack）
+* **價值**：排查「頁面有沒有被重複 push / 該 pop 沒 pop（記憶體洩漏前兆）」。錯誤發生時的路由堆疊也是 #3 診斷報告的關鍵 context。
+* **設計**：`NavigatorObserver` 即時維護 `currentStack`，`NavigatorTab` 頂部以麵包屑顯示 Root→Top，偵測重複 push 時標 warning。
+* **重用**：既有 push/pop/replace 回調、`KeyValueTable`。
+* **Effort**：low ｜ **排查價值**：⭐⭐⭐
+* **註**：與上一份 brainstorm 的「Navigator Stack Visualizer」同一構想，此處定位為「為診斷報告提供 crash 當下路由快照」。
+
+---
+
+## ❌ 拒絕實現的「垃圾」功能（Anti-Features）
+
+堅守「不走向微核心 / 過度工程」：
+
+1. **完整效能 / Jank / 記憶體 Profiler**
+   - *拒絕*：FPS 追蹤、frame drop、記憶體 profiling 是**另一個產品維度**，不是「錯誤排查」。Flutter 官方 DevTools 已有強大的 Performance/Memory view，in-app 重造只會是低配輪子。偏離主線，effort=high，**砍**。
+
+2. **跨 session 持久化 / 本機落盤的 crash history**
+   - *拒絕*：把 buffer 定期寫 SQLite/Hive、重啟後還原——聽起來很美，但引入磁碟 IO、序列化版本相容、隱私（log 含敏感資料落盤）三重複雜度與風險。**排查的證據用 #3 的「一鍵匯出」帶走即可**，不需要工具自己當資料庫。違反「砍掉一半再砍一半」。**砍**。
+
+3. **完整 HAR timing waterfall（DNS/TLS/TTFB 分段）**
+   - *拒絕*：Dio 在多數版本拿不到可靠的分段 timing，硬湊出來的瀑布圖是**假精度**，反而誤導排查。保留 #4 的 total duration + timeout 判斷已足夠。匯出走標準 JSON 即可，不追 HAR 的完整 timings 物件。**砍**（HAR 匯出本身可選保留，但不偽造 timing）。
+
+4. **API Mocking / 動態回應改寫**
+   - *拒絕*：同上一份 brainstorm 的判斷——在 debug overlay 裡注入 mock 規則會讓工具代碼翻倍，且極易因 debug 庫 bug 中斷宿主的正式網路流。**嚴重違反「Never break userspace」**。交給外部 proxy。**砍**。
+
+---
+
+## 📅 下一步實作路徑（依排查價值排序）
+
+排序原則：**先補盲區（看得見錯誤）→ 再建關聯（看得懂錯誤）→ 最後打包（帶得走證據）**。
+
+1. **第一階段 · 點亮盲區**：實作 **#1 全局未捕捉例外捕捉**（可選 default-off）+ **#4 Dio 結構化錯誤捕捉**。此後 inspector 才真正「看得見」錯誤。
+2. **第二階段 · ConsoleTab 排查化**：實作 **#5**（stackTrace 詳情 + error 過濾），讓捕捉到的錯誤可被秒速定位與檢視。
+3. **第三階段 · 建立關聯**：實作 **#2 做法 A**（detail view 的 ±5s 同時段側欄）——最低成本就讓跨層關聯落地；行有餘力再上做法 B 的 Timeline 視圖。
+4. **第四階段 · 帶走證據**：實作 **#3 一鍵診斷報告**（含 #8 路由堆疊快照、device info）。QA 提 bug 的剛需在此閉環。
+5. **第五階段 · 加分項**：視回饋實作 **#6 Replay** 與 **#7 錯誤聚合摘要**。
+
+> 每一階段都是獨立可上線的增量，且彼此寫入路徑不重疊（#1 動 core、#4 動 interceptor、#5 動 console UI、#3 動 utils + dashboard），適合並行推進。

--- a/docs/features/2026-06-20-uncaught-error-capture.md
+++ b/docs/features/2026-06-20-uncaught-error-capture.md
@@ -1,0 +1,199 @@
+# 功能規格：全局未捕捉例外捕捉 + Console 錯誤詳情可展開
+
+- **日期**：2026-06-20
+- **狀態**：STAGE 0a — 待確認
+- **來源**：`docs/brainstorm/2026-06-20-error-troubleshooting-features.md` 的 #1（全局未捕捉例外捕捉）+ #5 的 LogDetailView 部分（ConsoleTab 排查化中「error 詳情可展開」這一半）
+- **類型**：功能新增（可選、預設關閉）+ Console UI 強化
+
+---
+
+## 1. 背景與動機（Why）
+
+`flutter_inspector_kit` 自我定位為 debug／排查工具，但目前是「錯誤的盲人」：
+
+- **看不到未捕捉的例外**：codebase 中沒有任何 `FlutterError.onError`、`PlatformDispatcher.instance.onError`、`ErrorWidget.builder` 或 `runZonedGuarded` 掛點。最常導致線上問題的錯誤——async error、widget build error、`onPressed` 裡漏接的 exception——inspector 一個都看不到，全靠開發者記得手動 `try-catch` + `inspector.log()`。覆蓋率取決於人的自律，等於沒有覆蓋。
+- **看得到也展不開**：`LogEntry` 早已定義 `stackTrace` 與 `data` 兩個欄位（`lib/src/models/log_entry.dart`），但 `ConsoleTab`（`lib/src/ui/dashboard/tabs/console_tab.dart`）只渲染 `message` 著色 + `timestamp`，列表項**點擊無反應**，`stackTrace` 與 `data` 在 UI 上完全看不到。捕捉到例外卻無法在 UI 展開 stackTrace，等於白捕捉。
+
+這兩件事必須**綁在一起做**才形成完整排查閉環：
+
+> 捕捉（看見錯誤）→ 詳情可展開（看懂錯誤的 stackTrace 與 context）
+
+兩者都只動 Console 區塊，scope 內聚；任何一半單獨上線都不構成可用的排查能力。
+
+### 設計核心（已拍板的關鍵決策）
+
+> 不要為「捕捉錯誤」發明新的儲存與 UI。捕捉到的例外**就是一條 `LogLevel.error` 的 log**。
+
+- **零新資料模型**：捕捉到的例外經由既有的 `inspector.log(message, level: LogLevel.error, stackTrace: ..., data: ...)` 記成一條 `LogEntry`，重用既有 `RingBuffer`。
+- **零新 tab**：不開「Errors」分頁。捕捉到的例外就在 Console tab 裡，以 `LogLevel.error` 的紅色 log 呈現。
+- **詳情就地展開**：Console 的 error log 點擊可展開，呈現 `message` / `level` / 可複製的 `stackTrace` / `data`。
+
+### 現況關鍵檔案
+
+| 檔案 | 角色 | 現值 |
+|---|---|---|
+| `lib/src/core/flutter_inspector.dart` | 建構子 + `log()` 入口 | 建構子已有 `customTab` / `magicalTapCount` / `showNetworkNotification` / `navigatorKey` / `bufferSize` / `notifier` / `databaseSources`；`log(message, {level, stackTrace, data})` 已存在 |
+| `lib/src/models/log_entry.dart` | 資料模型 | `message` / `level` / `stackTrace(String?)` / `data(Map?)` / `timestamp` 皆已存在；`stackTrace`、`data` **無人使用** |
+| `lib/src/ui/dashboard/tabs/console_tab.dart` | Console UI | `ListTile` 只顯示 `message` + `timestamp`，**點擊無反應**；已有 `_getColorForLevel()` |
+| `lib/src/ui/widgets/key_value_table.dart` | 可重用 widget | 用於詳情頁展示 `data` |
+| `lib/src/ui/dashboard/tabs/network/network_detail_view.dart` | 詳情頁佈局範本 | `SelectableText` 可複製、card 分層、`PopupMenuButton` share menu |
+| `lib/src/utils/share_text.dart`（既有 share 工具） | 分享 | 平台自適應分享文字 |
+| `LogInspector.entriesAtLevel(level)` | 既有 getter | 已存在但 UI **未使用** |
+
+---
+
+## 2. 使用者故事與驗收條件
+
+### US-1：開發者捕捉 widget build／layout／paint 錯誤
+
+> 身為開發者，當某個 widget 在 build／layout／paint 階段拋出例外時，我希望這個 framework 層錯誤自動成為 Console tab 裡一條紅色 error log，不必我手動 try-catch。
+
+**驗收條件：**
+
+- [ ] 啟用捕捉後，`FlutterError.onError` 觸發的錯誤被轉成一條 `LogLevel.error` 的 `LogEntry`，`message` 含錯誤摘要，`stackTrace` 含 framework 提供的堆疊。
+- [ ] **錯誤仍往下游傳**：捕捉 handler **chain（鏈接）** 既有 `FlutterError.onError`（若宿主已設）；若宿主未設，則仍呼叫 `FlutterError.presentError` 走預設呈現。debug console 的紅屏／既有錯誤輸出行為不消失。
+- [ ] 該錯誤出現在 Console tab，顏色為紅色（沿用 `_getColorForLevel(LogLevel.error)`）。
+
+### US-2：開發者捕捉未處理的 async 例外
+
+> 身為開發者，當 `Future`／async 流程中拋出未被 `catchError` 接住的例外時，我希望它自動成為一條 error log，而不是只在 platform console 一閃而過。
+
+**驗收條件：**
+
+- [ ] 啟用捕捉後，`PlatformDispatcher.instance.onError` 觸發的未捕捉 async error 被轉成一條 `LogLevel.error` 的 `LogEntry`，含 `stackTrace`。
+- [ ] **錯誤仍往下游傳**：捕捉 handler chain 既有 `PlatformDispatcher.instance.onError`（若宿主已設）。handler 的回傳值維持原本「是否視為已處理」的語意，不改變宿主對未處理錯誤的後續流程。
+- [ ] 需要 zone 級捕捉（例如 `runZonedGuarded` 才攔得到的 error）的情境，由 US-5 的 `runGuarded` 入口涵蓋。
+
+### US-3：開發者知道是哪個 widget build 失敗
+
+> 身為開發者，當某 widget build 失敗顯示錯誤佔位 widget（紅屏）時，我希望 Console 留下一條 error log 記錄是哪個 widget 失敗，方便回溯。
+
+**驗收條件：**
+
+- [ ] 啟用捕捉後，`ErrorWidget.builder` 被**包裝**（wrap）而非取代：先記一條 `LogLevel.error` log（含 build 失敗的 `FlutterErrorDetails` 摘要與 stackTrace），**再轉交原本的 `ErrorWidget.builder` 產出原本的錯誤佔位 widget**。
+- [ ] 畫面上實際顯示的錯誤佔位 widget 與未啟用本功能時一致（不破壞既有紅屏／release 灰屏呈現）。
+
+### US-4：開發者／QA 展開 error log 看 stackTrace 與 data
+
+> 身為開發者或 QA，當我在 Console tab 看到一條 error log，我希望點它就能展開詳情，看到完整可複製的 stackTrace 與附帶的 data，把證據帶走。
+
+**驗收條件：**
+
+- [ ] 在 Console tab 點擊一條含 `stackTrace` 或 `data` 的 error log，開啟詳情視圖（仿 `NetworkDetailView` 佈局：card 分層）。
+- [ ] 詳情視圖呈現 `message`、`level`、`timestamp`、`stackTrace`（以 `SelectableText` 呈現，**可選取複製**）、`data`（以 `KeyValueTable` 呈現）。
+- [ ] 詳情視圖提供分享入口（`PopupMenuButton` / share），透過既有 `share_text` 工具把詳情以純文字分享出去。
+- [ ] 當 log 的 `stackTrace` 與 `data` 皆為 `null`（例如純 `info` log），列表項可不可點或點擊後詳情頁對應區段顯示為空／省略——不得崩潰。
+
+### US-5：開發者用薄包裝入口啟用 zone 級捕捉
+
+> 身為開發者，當我需要連 zone 內的同步錯誤都捕捉時，我希望有一個薄包裝入口包住 `runApp`，而不必自己在 `main()` 裡手寫 `runZonedGuarded` 並接線三個 handler。
+
+**驗收條件：**
+
+- [ ] 提供一個薄包裝入口（形狀見 §4），開發者以它包住 `runApp(...)` 即可在同一個 guarded zone 內完成三個標準掛點接線 + zone error 捕捉。
+- [ ] 入口**不取代宿主 `main()` 的其他內容**：開發者仍可在入口外自行做初始化；入口只負責「在 guarded zone 中執行傳入的 callback 並接好掛點」。
+- [ ] 入口捕捉到的 zone error 同樣轉成 `LogLevel.error` log 且**往下游傳**（不吞掉）。
+
+### US-6：預設關閉，不啟用時行為完全不變（Never break userspace）
+
+> 身為既有使用者，我沒有要求這個功能，我希望升級套件後我的 app 錯誤流、UI、API 行為一個位元都不變。
+
+**驗收條件：**
+
+- [ ] 新增的捕捉功能由建構子可選參數控制，**預設 off**。不傳該參數時，套件**完全不接管** `FlutterError.onError` / `PlatformDispatcher.instance.onError` / `ErrorWidget.builder`，宿主錯誤流維持原樣。
+- [ ] 既有 `FlutterInspector(...)` 的呼叫端不需任何改動即可編譯（新參數有預設值）。
+- [ ] 既有 `inspector.log()` 簽名與語意不變。
+- [ ] Console tab 對既有非 error log（info／warning 等）的呈現不退化；只是新增「可展開詳情」這個能力。
+
+---
+
+## 3. 範圍邊界（Scope）
+
+### In Scope（做什麼）
+
+1. **三個標準掛點 + 一個薄包裝入口**，以**可選、預設 off** 的建構子參數啟用：
+   - `FlutterError.onError`（chain，不取代）
+   - `PlatformDispatcher.instance.onError`（chain，不取代）
+   - `ErrorWidget.builder`（wrap，先記 log 再轉交原 builder）
+   - zone 級捕捉的薄包裝入口（包住 `runApp`，不污染 `main()`）
+2. **捕捉到的例外 = 一條 `LogLevel.error` log**：重用 `inspector.log()` + `LogEntry`（`stackTrace` / `data`），零新資料模型、零新 tab。
+3. **Console error log 詳情可展開**：點擊 log 開詳情視圖，呈現 `message` / `level` / `timestamp` / 可複製 `stackTrace` / `data`（`KeyValueTable`），並提供分享入口。
+
+### Out of Scope（不做什麼）
+
+- **不開新 tab**：捕捉到的例外不另立「Errors」分頁，就在 Console tab 裡當一條 error log。
+- **不做 ConsoleTab 的搜尋／過濾**：搜尋欄、`LogLevel` FilterChip、「errors only」快捷是 brainstorm #5 的**另一半**，不在本功能。本功能只做「error 詳情可展開」與「捕捉」。
+- **不做跨 session 持久化**：不把捕捉到的錯誤寫入磁碟、不做重啟後還原的 crash history（brainstorm anti-feature #2，違反「砍掉一半再砍一半」，且引入磁碟 IO／序列化相容／隱私三重風險）。
+- **不做效能監控**：FPS、frame drop、記憶體 profiling 不在範圍（brainstorm anti-feature #1，屬另一產品維度，Flutter DevTools 已有）。
+- **不取代宿主的任何 handler**：所有掛點皆 chain／wrap 既有 handler，**絕不**覆蓋或吞掉宿主 app 的崩潰。
+- **不做 #4（Dio 結構化錯誤捕捉）**：那動 `dio_interceptor`，寫入路徑與本功能不重疊，屬第一階段的另一項，獨立規劃。
+- **不做 #2（跨 Inspector 時序關聯／±5s 側欄）**：詳情視圖此次**不**加「同時段事件」側欄，留待後續階段。
+
+---
+
+## 4. 公開 API 變更草案（對外契約，不寫實作）
+
+> 僅描述對外契約。實際命名與細節以 STAGE 0b 實作計畫為準；以下為提案。
+
+### 4.1 建構子新增可選參數（預設 off）
+
+```dart
+FlutterInspector({
+  // ...既有參數不變...
+  bool captureUncaughtErrors = false, // ← 新增，預設 false
+});
+```
+
+- `captureUncaughtErrors`：是否啟用全局未捕捉例外捕捉。
+  - `false`（預設）：套件不接管任何錯誤掛點，行為與現況完全一致（US-6）。
+  - `true`：套件 chain `FlutterError.onError`、chain `PlatformDispatcher.instance.onError`、wrap `ErrorWidget.builder`，把捕捉到的例外記成 `LogLevel.error` log。**捕捉後一律把錯誤往下游傳**。
+
+### 4.2 zone 級捕捉的薄包裝入口（提案形狀）
+
+```dart
+// 提案：包住 runApp 的薄包裝；在 guarded zone 內接好三個掛點 + 捕捉 zone error。
+// callback 內呼叫 runApp(...)。捕捉到的 error 轉成 error log 後仍往下游傳。
+static void runGuarded(
+  void Function() body, {
+  required FlutterInspector inspector,
+});
+```
+
+- 對外契約要點：
+  - 接受一個 `body`（內含 `runApp(...)`），在 guarded zone 中執行。
+  - 需要一個已建立的 `inspector` 實例作為 log 接收端。
+  - 等價於「為開發者代寫 `runZonedGuarded` + 接線三個掛點」的薄包裝，**不**強迫改寫宿主 `main()` 的其他內容。
+  - 捕捉到的 zone error 轉成 `LogLevel.error` log 後**往下游傳**（不吞）。
+
+> 註：`runGuarded` 與 `captureUncaughtErrors` 的職責邊界、以及「同時用兩者是否會重複接線」的去重策略，屬實作細節，由 STAGE 0b 決定；規格層面的硬約束是：**任一路徑捕捉到的錯誤都必須往下游傳，且預設不啟用。**
+
+### 4.3 不變更的契約
+
+- `inspector.log(message, {level, stackTrace, data})`：簽名與語意**不變**，捕捉路徑直接複用。
+- `LogEntry` / `LogLevel`：**不新增欄位**。
+- `ConsoleTab` 的對外建構（`ConsoleTab(inspector: ...)`）：不變，僅內部新增「點擊展開詳情」行為。
+
+---
+
+## 5. 跨領域驗收
+
+- [ ] `flutter analyze` 零新增 issue。
+- [ ] `flutter test` 全綠；新增測試涵蓋：(a) 捕捉路徑把例外轉成 `LogLevel.error` log；(b) chain 行為——既有 handler 仍被呼叫（錯誤往下游傳）；(c) `captureUncaughtErrors: false` 時不接管任何掛點。
+- [ ] 對外公開 API 無破壞性變更（既有呼叫端零改動即可編譯）。
+- [ ] example app 可編譯，並能示範 `captureUncaughtErrors: true` 或 `runGuarded` 捕捉到一條 error log 並在 Console 展開其 stackTrace。
+- [ ] README 補充「Uncaught error capture」段，說明可選啟用方式、預設關閉、以及「捕捉後錯誤仍往下游傳」的保證。
+
+---
+
+## 6. 風險與待解
+
+- **掛點去重**：同時啟用 `captureUncaughtErrors: true` 與 `runGuarded` 是否導致同一掛點被接兩次（→ 一條錯誤記成兩條 log）。需在 STAGE 0b 定義去重策略；規格層要求是「不得因此漏傳錯誤往下游」。
+- **chain 順序**：chain 既有 handler 時，是「先記 log 再呼叫原 handler」或反之，影響 debug console 輸出順序；不影響正確性，但需在實作明確並測試。
+- **`PlatformDispatcher.onError` 回傳語意**：該 handler 回傳 `bool` 表示「是否已處理」。本功能 chain 後的回傳值必須維持宿主原意，避免意外改變宿主對未處理錯誤的後續行為（例如吞掉了本該上報的 error）。
+- **release 模式呈現**：`ErrorWidget.builder` 在 release 下的灰屏 vs debug 紅屏行為，包裝後須維持一致。
+
+---
+
+## 確認
+
+請確認以上功能規格（使用者故事、驗收條件、範圍邊界、公開 API 變更草案）。確認後進入 **STAGE 0b** 產出實作計畫。

--- a/docs/plans/2026-06-20-uncaught-error-capture.md
+++ b/docs/plans/2026-06-20-uncaught-error-capture.md
@@ -1,0 +1,360 @@
+# 實作計畫：全局未捕捉例外捕捉 + Console 錯誤詳情可展開
+
+- **日期**：2026-06-20
+- **功能規格**：`docs/features/2026-06-20-uncaught-error-capture.md`
+- **brainstorm 來源**：`docs/brainstorm/2026-06-20-error-troubleshooting-features.md`（#1 + #5 的 LogDetailView 部分）
+- **狀態**：STAGE 0b — 待確認
+- **已確認的決策（不可推翻）**：
+  1. 保留 `runGuarded`（與 `captureUncaughtErrors` 用 flag 去重）。
+  2. 不開新 tab；捕捉到的例外 = 一條 `LogLevel.error` log；Console error log 點擊可展開詳情。
+  3. 所有掛點 chain/wrap，捕捉後錯誤往下游傳；功能 default off。
+
+---
+
+## 1. 設計總覽
+
+核心策略：**功能天然分兩條互不重疊的寫入路徑，各自獨立可測、可並行**。
+
+- **Core 路徑**（`lib/src/core/`）：三個錯誤掛點 chain/wrap + `runGuarded` 薄包裝 + 去重 flag。捕捉到的例外經由既有 `inspector.log(..., level: LogLevel.error)` 變成一條 `LogEntry`——零新資料模型、零新 tab、零新儲存。
+- **UI 路徑**（`lib/src/utils/log_formatters.dart` + `lib/src/ui/dashboard/tabs/console/`）：純 Dart 的 `buildLogPlainText` + 仿 `NetworkDetailView` 的 `LogDetailView`，再把 `ConsoleTab` 的 `ListTile` 接上 `onTap`。
+
+兩條路徑唯一的交會點是「`inspector.log` 的 `level/stackTrace/data` 三欄」——這是**既有契約**，本計畫不改它。因此 Core 與 UI 的寫入檔案集合完全不重疊（見第 2 節），STAGE 2 可由兩個 subagent / 兩個 worktree session 並行推進，最後只在 example/README 收斂。
+
+### 1.1 資料結構決策：零新資料模型
+
+捕捉路徑把 `FlutterErrorDetails` / zone error / platform error **映射成既有 `LogEntry`**：
+
+| 來源 | message | stackTrace | data |
+|---|---|---|---|
+| `FlutterError.onError`（`FlutterErrorDetails d`） | `d.exceptionAsString()` | `d.stack?.toString()` | `{'exceptionType': d.exception.runtimeType.toString(), 'library': d.library, 'context': d.context?.toStringShort()}`（過濾 null 值） |
+| `PlatformDispatcher.onError`（`Object e, StackTrace st`） | `e.toString()` | `st.toString()` | `{'source': 'platformDispatcher', 'exceptionType': e.runtimeType.toString()}` |
+| `runGuarded` zone error（`Object e, StackTrace st`） | `e.toString()` | `st.toString()` | `{'source': 'zone', 'exceptionType': e.runtimeType.toString()}` |
+| `ErrorWidget.builder`（`FlutterErrorDetails d`） | 同 `FlutterError.onError` 映射 | 同上 | 同上，外加 `'source': 'errorWidget'` |
+
+- `data` 一律過濾 `null` 值（`library`/`context` 可能為 null），避免 `KeyValueTable` 顯示 `null` 字串。
+- 不新增 `LogEntry` 欄位、不新增 enum、不碰 `RingBuffer`。
+
+### 1.2 三掛點接線 + 去重（Core 路徑核心）
+
+在 `FlutterInspector` 內新增四個 private 欄位保存原 handler + 一個去重 flag：
+
+```
+FlutterExceptionHandler? _oldFlutterErrorHandler;          // void Function(FlutterErrorDetails)
+bool Function(Object, StackTrace)? _oldPlatformDispatcherOnError;
+ErrorWidget.builder 的原值在接線當下以區域變數 original 捕捉（見下）
+bool _uncaughtErrorHandlersAttached = false;              // 去重 flag
+```
+
+接線統一收斂在一個 private 方法 `_setupErrorHandlers()`：
+
+```
+void _setupErrorHandlers() {
+  if (_uncaughtErrorHandlersAttached) return;   // ← flag 去重，保證只接一次
+  _uncaughtErrorHandlersAttached = true;
+
+  // 1) FlutterError.onError —— chain
+  _oldFlutterErrorHandler = FlutterError.onError;
+  FlutterError.onError = (details) {
+    _logFlutterError(details, source: 'flutterError');
+    if (_oldFlutterErrorHandler != null) {
+      _oldFlutterErrorHandler!(details);
+    } else {
+      FlutterError.presentError(details);        // 宿主未設則走預設呈現
+    }
+  };
+
+  // 2) PlatformDispatcher.instance.onError —— chain
+  _oldPlatformDispatcherOnError = PlatformDispatcher.instance.onError;
+  PlatformDispatcher.instance.onError = (e, st) {
+    _logPlatformError(e, st);
+    // 維持宿主原意；宿主未設時 return false（= 未處理，交給預設流程）
+    return _oldPlatformDispatcherOnError != null
+        ? _oldPlatformDispatcherOnError!(e, st)
+        : false;
+  };
+
+  // 3) ErrorWidget.builder —— wrap
+  final original = ErrorWidget.builder;           // 接線當下捕捉原 builder
+  ErrorWidget.builder = (details) {
+    try {
+      _logFlutterError(details, source: 'errorWidget');
+    } catch (e, s) {
+      debugPrintStack(stackTrace: s, label: 'inspector errorWidget log failed: $e');
+    }                                              // 吞掉自身錯誤，防 reentrancy
+    return original(details);                      // 永遠無條件轉交原 builder
+  };
+}
+```
+
+**設計要點（皆為已驗證的硬約束）：**
+- **`PlatformDispatcher.onError` 絕不無條件 `return true`**——否則吞掉宿主上報。宿主未設時 `return false`，把「未處理」語意交回預設流程。
+- **`ErrorWidget.builder` 包裝層絕不判斷 `kDebugMode`/`kReleaseMode`**——details 原封不動交給 `original(details)`，debug 紅屏 / release 灰屏由原 builder 決定，包裝後呈現與未啟用時完全一致。
+- **reentrancy 防護**：`ErrorWidget` 包裝層的 log 段包 try-catch 吞掉自身錯誤（catch 內**不 rethrow**），降級 `debugPrintStack`；`return original(details)` 永遠在 try-catch 外無條件執行。
+- **去重 flag**：`captureUncaughtErrors: true`（建構子）與 `runGuarded`（薄包裝）都呼叫同一個 `_setupErrorHandlers()`，flag 保證三掛點只接一次——同一錯誤不會記成兩條 log。
+
+### 1.3 `runGuarded` 薄包裝形狀
+
+```
+static void runGuarded(
+  void Function() body, {
+  required FlutterInspector inspector,
+}) {
+  runZonedGuarded(
+    () {
+      inspector._setupErrorHandlers();   // zone 內接好三掛點（flag 去重）
+      body();                            // body 內呼叫 runApp(...)
+    },
+    (e, st) {
+      inspector._logZoneError(e, st);    // zone error → error log（往下游：runZonedGuarded 不 rethrow，但已記錄）
+    },
+  );
+}
+```
+
+- `_setupErrorHandlers()` 放在 zone 內、`body()` 之前（`ErrorWidget.builder` 在 `runApp` 時被 `WidgetsBinding` 讀取，必須早於 `runApp`）。
+- `runGuarded` 不取代宿主 `main()` 其他內容——開發者仍可在 `runGuarded` 外做初始化，`runGuarded` 只負責「在 guarded zone 中接好掛點並執行 body」。
+
+### 1.4 啟用時機
+
+`captureUncaughtErrors: true` 時，**在建構子內**呼叫 `_setupErrorHandlers()`——必須早於 `runApp`（理由同上，`ErrorWidget.builder` 在 `runApp` 時已被讀取）。`false`（預設）時完全不呼叫，三掛點一個位元都不碰（US-6 / Never break userspace）。
+
+### 1.5 UI 路徑：`LogDetailView` 重用 `NetworkDetailView`
+
+- **`buildLogPlainText(LogEntry)`**（純 Dart）：仿 `network_formatters.dart` 的 `buildPlainText`，用 `StringBuffer` 拼三節：`=== General ===`（message/level/timestamp）、`=== Stack Trace ===`（`stackTrace ?? '(none)'`）、`=== Data ===`（逐 key 印或 `(none)`）。可單測，無 Flutter 依賴。
+- **`LogDetailView`**：複製 `NetworkDetailView` 結構——`Scaffold`+`AppBar`、`enum _ShareAction { text, share }`（log 無 cURL）、`PopupMenuButton` share menu、`_section()` card 分層、`SelectableText` 顯示 stackTrace、`KeyValueTable(data: entry.data)` 顯示 data。share 走既有 `share_text.dart` + `Clipboard`（複製 `NetworkDetailView._onShare` 的 fallback 慣例）。
+- **`ConsoleTab` 接 onTap**：`final canTap = entry.stackTrace != null || entry.data != null;`，`onTap: canTap ? () => Navigator.push(... LogDetailView(entry: entry)) : null;`。`KeyValueTable` 已內建 null guard，`entry.data` 可直接傳。
+
+---
+
+## 2. 檔案異動清單（驗證 Core / UI 路徑不重疊）
+
+> **路徑修正**：規格現況表寫的是 `lib/src/ui/dashboard/tabs/console_tab.dart`（單檔，無 `console/` 子目錄）。本計畫新增 `console/` 子目錄放 `log_detail_view.dart`，鏡像既有 `network/` 子目錄慣例。
+
+| 路徑 | 動作 | 路徑歸屬 | 任務 |
+|------|------|---------|------|
+| `lib/src/core/flutter_inspector.dart` | 改：新增 `captureUncaughtErrors` 參數 + 四個 handler 欄位 + `_setupErrorHandlers()` + `_logFlutterError`/`_logPlatformError`/`_logZoneError` + `static runGuarded` | **Core** | T1, T2 |
+| `test/core/error_capture_test.dart` | **新增**：捕捉路徑單元測試 | **Core** | T1, T2 |
+| `lib/src/utils/log_formatters.dart` | **新增**：`buildLogPlainText(LogEntry)` 純 Dart | **UI** | T3 |
+| `test/utils/log_formatters_test.dart` | **新增**：三節純文字單測 | **UI** | T3 |
+| `lib/src/ui/dashboard/tabs/console/log_detail_view.dart` | **新增**：仿 `NetworkDetailView` 的詳情視圖 | **UI** | T4 |
+| `lib/src/ui/dashboard/tabs/console_tab.dart` | 改：`ListTile` 接 `onTap`（canTap 判定 + `Navigator.push`） | **UI** | T5 |
+| `test/ui/tabs/log_detail_view_test.dart` | **新增**：詳情視圖 widget 測試（含 null 不崩） | **UI** | T4 |
+| `test/ui/tabs/console_tab_test.dart` | 改：新增「點擊可展開 / null 不可點」測試 | **UI** | T5 |
+| `example/lib/main.dart` | 改：示範 `runGuarded` 或 `captureUncaughtErrors: true` 捕捉一條 error log | 收斂 | T6 |
+| `README.md` / `CHANGELOG.md` | 改：補「Uncaught error capture」段 + 變更記錄 | 收斂 | T6 |
+
+**不重疊驗證**：Core 任務（T1/T2）只寫 `flutter_inspector.dart` + `test/core/error_capture_test.dart`；UI 任務（T3/T4/T5）只寫 `log_formatters.dart`、`console/log_detail_view.dart`、`console_tab.dart` 及對應 test。兩集合交集為空 → **T1+T2 與 T3+T4+T5 可完全並行**。僅 T6（example/README）需在兩路徑都完成後收斂。
+
+**不動的檔案（明列防 scope creep）**：`lib/src/models/log_entry.dart`（不加欄位）、`lib/src/models/log_level.dart`（不加 enum）、`lib/src/inspectors/log_inspector.dart`、`RingBuffer`、`lib/flutter_inspector_kit.dart`（`runGuarded` 是 `FlutterInspector` 的 static，既有 `export 'src/core/flutter_inspector.dart'` 已涵蓋，無需新增 export）。
+
+---
+
+## 3. 任務拆分（TDD：每任務先寫測試）
+
+> 複雜度分級對齊 implementer 的 model 策略：🟢 機械性=快/便宜 model｜🟡 整合=標準 model｜🔴 設計判斷/跨層=最強 model。
+
+### T1 — 三掛點 chain/wrap + 去重 flag + `captureUncaughtErrors` 參數 🔴 設計判斷/跨層
+
+- **路徑歸屬**：**Core**
+- **寫入 scope**：`lib/src/core/flutter_inspector.dart`、`test/core/error_capture_test.dart`
+- **依賴**：無（可與 UI 路徑並行起步）
+- **TDD 順序**（先紅後綠）：
+  1. `captureUncaughtErrors: false`（預設）時，建構後 `FlutterError.onError`、`PlatformDispatcher.instance.onError`、`ErrorWidget.builder` **與建構前的值相同**（不接管）。
+  2. `captureUncaughtErrors: true` 時，三者皆被替換（!= 建構前的值）。
+  3. 觸發新的 `FlutterError.onError(details)` → `inspector.logEntries` 多一條 `level == LogLevel.error`、`message` 含摘要、`stackTrace != null` 的 log。
+  4. **chain 驗證**：建構前先設一個會翻轉旗標的 `FlutterError.onError`；啟用後觸發 → 旗標被翻轉（證明原 handler 仍被呼叫，錯誤往下游傳）。
+  5. **PlatformDispatcher 回傳語意**：宿主原 handler `return true` → 包裝後也 `return true`；宿主未設（測試中以儲存/還原模擬）→ 包裝後 `return false`。
+  6. **去重**：對同一 inspector 連續呼叫兩次 `_setupErrorHandlers()`（經 `@visibleForTesting` 暴露或經 `runGuarded` + `captureUncaughtErrors` 雙觸發），三掛點只被替換一次——觸發一次錯誤只產生一條 log。
+- **實作**：第 1.2 / 1.4 節。新增 `captureUncaughtErrors` 參數（預設 `false`）、四個 private 欄位、`_setupErrorHandlers()`、`_logFlutterError(details, {required source})`。`_setupErrorHandlers` 需 `@visibleForTesting` 以便去重測試直接呼叫（或測試經 `runGuarded` 觸發）。
+- **測試環境注意**：測試需在 `setUp`/`tearDown` **保存並還原** `FlutterError.onError`、`PlatformDispatcher.instance.onError`、`ErrorWidget.builder` 的全域值，避免污染後續測試（這三者是進程全域狀態）。
+- **驗收**：
+  - 對應 US-1 驗收 1/2、US-2 驗收 1/2、US-3 驗收 1/2、US-6 驗收 1/2/3。
+  - chain 行為（原 handler 仍被呼叫）、default-off 不接管、PlatformDispatcher 回傳語意保持、reentrancy（ErrorWidget log 失敗不影響 `return original`）皆有測試。
+  - `flutter analyze` 零新增 issue。
+
+### T2 — `runGuarded` 薄包裝 + zone error 捕捉 🔴 設計判斷/跨層
+
+- **路徑歸屬**：**Core**
+- **寫入 scope**：`lib/src/core/flutter_inspector.dart`、`test/core/error_capture_test.dart`
+- **依賴**：T1（共用 `_setupErrorHandlers()` 與 `_logZoneError`；同檔）→ **與 T1 序列**
+- **TDD 順序**（先紅後綠）：
+  1. `runGuarded(() => throw StateError('boom'), inspector: i)` → zone error 被捕捉成一條 `LogLevel.error` log，`message` 含 `'boom'`、`stackTrace != null`、`data['source'] == 'zone'`。
+  2. `runGuarded` 內 `inspector._setupErrorHandlers()` 被呼叫（三掛點在 zone 內接好）——可由「zone 內觸發 `FlutterError.onError` 也記成 log」間接驗證。
+  3. **去重**：先 `FlutterInspector(captureUncaughtErrors: true)` 再用同 inspector 跑 `runGuarded` → 三掛點仍只接一次（flag 生效）。
+- **實作**：第 1.3 節的 `static void runGuarded(...)` + `_logZoneError(e, st)`。
+- **驗收**：對應 US-5 驗收 1/2/3。zone error 往下游（`runZonedGuarded` 的 onError 內已記錄，不 rethrow 即為「捕捉後不再向上拋」的正確語意）。`flutter analyze` 零新增 issue。
+
+### T3 — `buildLogPlainText` 純 Dart formatter 🟢 機械性
+
+- **路徑歸屬**：**UI**
+- **寫入 scope**：`lib/src/utils/log_formatters.dart`、`test/utils/log_formatters_test.dart`
+- **依賴**：無（可與 Core 路徑並行起步）
+- **TDD 順序**（先紅後綠）：
+  1. 完整 entry（message/level/timestamp/stackTrace/data 都有）→ 輸出含 `=== General ===`、`=== Stack Trace ===`、`=== Data ===` 三節，含 message、level.name、stackTrace、每個 data key:value。
+  2. `stackTrace == null` → Stack Trace 節顯示 `(none)`，不出現 `null` 字串。
+  3. `data == null` 或空 → Data 節顯示 `(none)`。
+  4. 結尾 `trimRight()`（對齊 `buildPlainText` 慣例）。
+- **實作**：仿 `network_formatters.dart::buildPlainText`，`String buildLogPlainText(LogEntry entry)`，`import '../models/log_entry.dart'`。無 Flutter 依賴。
+- **驗收**：對應 US-4 驗收 3（分享內容正確）。三節純文字皆有測試。`flutter analyze` 零新增 issue。
+
+### T4 — `LogDetailView` 詳情視圖 🟡 整合
+
+- **路徑歸屬**：**UI**
+- **寫入 scope**：`lib/src/ui/dashboard/tabs/console/log_detail_view.dart`、`test/ui/tabs/log_detail_view_test.dart`
+- **依賴**：T3（用 `buildLogPlainText` 做 share）→ **與 T3 序列**（同屬 UI 路徑，但與 Core 路徑並行）
+- **TDD 順序**（先紅後綠）：
+  1. 給有 stackTrace + data 的 entry → 渲染出 message、level、timestamp、stackTrace（`SelectableText`）、`KeyValueTable`。
+  2. **null 不崩**：`stackTrace == null` 且 `data == null` 的 entry → `LogDetailView` 正常渲染（stackTrace 區段省略或顯示空、data 區段 `KeyValueTable` 顯示 emptyLabel），不丟例外。
+  3. share menu（`PopupMenuButton`）存在；點 `Copy as text` → clipboard 寫入 `buildLogPlainText` 結果（用 `TestDefaultBinaryMessengerBinding` 攔 Clipboard）。
+- **實作**：第 1.5 節。複製 `NetworkDetailView` 的 `_section`/`_kv`/`_onShare` 結構，刪掉 network 專屬（cURL、body、status color）。`enum _ShareAction { text, share }`。`import '../../../../utils/log_formatters.dart'`、`'../../../../utils/share_text.dart'`、`'../../../widgets/key_value_table.dart'`、`'../../../../models/log_entry.dart'`、`'../../../../models/log_level.dart'`。
+- **驗收**：對應 US-4 驗收 1/2/3/4。null stackTrace/data 不崩潰有測試。`flutter analyze` 零新增 issue。
+
+### T5 — `ConsoleTab` ListTile 接 onTap 🟢 機械性
+
+- **路徑歸屬**：**UI**
+- **寫入 scope**：`lib/src/ui/dashboard/tabs/console_tab.dart`、`test/ui/tabs/console_tab_test.dart`
+- **依賴**：T4（push 目標 `LogDetailView` 需就位）→ **與 T4 序列**
+- **TDD 順序**（先紅後綠）：
+  1. 既有「displays logs and supports clearing」測試不退化。
+  2. 點擊含 stackTrace 的 error log → 開啟 `LogDetailView`（`find.byType(LogDetailView)` 或 AppBar 標題可見）。
+  3. 點擊純 info（stackTrace 與 data 皆 null）log → 不導航（`canTap == false`，`onTap == null`）。
+- **實作**：第 1.5 節。`ListTile` 加 `onTap: canTap ? () => Navigator.of(context).push(MaterialPageRoute(builder: (_) => LogDetailView(entry: entry))) : null;`。`import 'console/log_detail_view.dart'`。
+- **驗收**：對應 US-4 驗收 1/4、US-6 驗收 4（非 error log 呈現不退化）。`flutter analyze` 零新增 issue。
+
+### T6 — example 示範 + 文件 🟢 機械性
+
+- **路徑歸屬**：收斂（需 Core + UI 兩路徑皆完成）
+- **寫入 scope**：`example/lib/main.dart`、`README.md`、`CHANGELOG.md`
+- **依賴**：T1–T5 全數完成
+- **實作**：
+  - `example/lib/main.dart`：加一顆按鈕觸發未捕捉例外（如 `Future.error` 或 build 期 throw），並以 `runGuarded` 包 `runApp` 或在 `FlutterInspector(... captureUncaughtErrors: true)` 啟用，示範捕捉到的 error log 出現在 Console 且可展開 stackTrace。
+  - `README.md`：補「Uncaught error capture」段——說明可選啟用（建構子 `captureUncaughtErrors` 或 `runGuarded`）、**預設關閉**、以及「捕捉後錯誤仍往下游傳」的保證。
+  - `CHANGELOG.md`：記錄新增功能。
+- **驗收**：對應規格第 5 節跨領域驗收（example 可編譯、README 補段）。`flutter analyze` 零 issue、`flutter test` 全綠、example 可編譯。
+
+---
+
+## 4. 執行順序與並行判斷
+
+```
+Core 路徑（只寫 flutter_inspector.dart + test/core/error_capture_test.dart）
+  T1（三掛點 + 去重 + 參數）🔴
+    ↓ 同檔，序列
+  T2（runGuarded + zone error）🔴
+
+UI 路徑（只寫 log_formatters / console/log_detail_view / console_tab + 對應 test）
+  T3（buildLogPlainText）🟢
+    ↓ T4 用到 T3 的 formatter
+  T4（LogDetailView）🟡
+    ↓ T5 push 到 T4
+  T5（ConsoleTab onTap）🟢
+
+═══ Core 路徑 (T1→T2) ∥ UI 路徑 (T3→T4→T5) 檔案 scope 完全不重疊 → 🟢 全程可並行 ═══
+
+  兩路徑皆完成後
+    ↓
+  T6（example + README + CHANGELOG）🟢 收斂
+```
+
+**可選執行方式：**
+
+- **subagent-driven（同 session）**：主 session 派兩批——批 A = Core 序列（T1→T2），批 B = UI 序列（T3→T4→T5），兩批並行；完成後主 session 收斂 T6。適合單機、希望集中審查。
+- **parallel session（worktree）**：開兩個 git worktree——session 1 跑 Core（T1→T2），session 2 跑 UI（T3→T4→T5）。因兩路徑寫入檔案集合不相交，合流時零衝突（僅 T6 在合流後於主分支收斂）。適合兩人/兩窗並行加速。
+
+> 本功能 5 個實作任務 + 1 收斂任務，Core 兩任務複雜度高（🔴，動進程全域 handler），UI 三任務複雜度中低。**建議 parallel session 切 Core/UI**——並行收益實在（兩條獨立路徑各約一半工作量），且 Core 的全域 handler 測試與 UI 的 widget 測試互不干擾。若偏好集中審查則用 subagent-driven。
+
+---
+
+## 5. 測試計畫
+
+### 新增測試檔與覆蓋點
+
+| 測試檔 | 覆蓋點 | 對應任務 |
+|------|------|---------|
+| `test/core/error_capture_test.dart` | (a) 捕捉路徑：`FlutterError.onError` / zone error 記成 `LogLevel.error` log（含 stackTrace）；(b) **chain**：既有 `FlutterError.onError` 仍被呼叫（旗標翻轉驗證）；(c) **default-off**：`captureUncaughtErrors: false` 時三掛點不接管（值不變）；(d) **PlatformDispatcher 回傳語意**：宿主 true→true、未設→false；(e) **flag 去重**：雙觸發只接一次、一錯一 log；(f) `runGuarded` zone error 捕捉 | T1, T2 |
+| `test/utils/log_formatters_test.dart` | `buildLogPlainText` 三節（General/Stack Trace/Data）；null stackTrace → `(none)`；null/空 data → `(none)`；結尾 trimRight | T3 |
+| `test/ui/tabs/log_detail_view_test.dart` | 渲染 message/level/timestamp/stackTrace（SelectableText）/data（KeyValueTable）；**null stackTrace + null data 不崩潰**；share menu 存在、Copy as text 寫 clipboard | T4 |
+
+### 既有測試修改
+
+| 測試檔 | 修改 |
+|------|------|
+| `test/ui/tabs/console_tab_test.dart` | 保留既有「displays logs and supports clearing」不動；新增「點 error log 開 LogDetailView」「點 null-detail log 不導航」 | T5 |
+
+### 測試環境硬約束
+
+- `FlutterError.onError`、`PlatformDispatcher.instance.onError`、`ErrorWidget.builder` 為**進程全域**狀態。`error_capture_test.dart` 必須在 `setUp` 保存、`tearDown` 還原這三者，避免跨測試污染。
+- 本套件採 **mock-free** 風格：捕捉路徑全用真實 `FlutterInspector` + 真實 handler 觸發驗證，不 mock。Clipboard 用 `TestDefaultBinaryMessengerBinding` 攔截（既有 `network_detail_view` 測試的慣例）。
+- 每任務結束跑 `flutter analyze` + `flutter test`。
+
+### 不單測（由 example 實機示範）
+
+- 三掛點在真實 `runApp` 生命週期中的接線時機（建構子早於 runApp）、release 灰屏 vs debug 紅屏的實際呈現——由 T6 example app 驗證（widget test 環境無法重現 release 渲染）。
+
+---
+
+## 6. 資料結構 / API 異動清單
+
+### 6.1 建構子新參數（預設 off，不破壞既有呼叫端）
+
+```dart
+FlutterInspector({
+  // ...既有參數全部不變...
+  bool captureUncaughtErrors = false,   // ← 新增，預設 false
+});
+```
+
+- 既有 `FlutterInspector(...)` 呼叫端零改動即可編譯（US-6 驗收 2）。
+
+### 6.2 新增 static 方法
+
+```dart
+static void runGuarded(void Function() body, {required FlutterInspector inspector});
+```
+
+- 經既有 `export 'src/core/flutter_inspector.dart'` 自動對外可見，**無需改 `lib/flutter_inspector_kit.dart`**。
+
+### 6.3 新增檔案清單
+
+| 新檔 | 路徑歸屬 | 內容 |
+|------|---------|------|
+| `lib/src/utils/log_formatters.dart` | UI | `buildLogPlainText(LogEntry)` 純 Dart |
+| `lib/src/ui/dashboard/tabs/console/log_detail_view.dart` | UI | `LogDetailView` widget（仿 `NetworkDetailView`） |
+| `test/core/error_capture_test.dart` | Core | 捕捉路徑單測 |
+| `test/utils/log_formatters_test.dart` | UI | formatter 單測 |
+| `test/ui/tabs/log_detail_view_test.dart` | UI | 詳情視圖 widget 測試 |
+
+### 6.4 不變更的契約（Never break userspace）
+
+- `inspector.log(message, {level, stackTrace, data})`：簽名與語意**不變**，捕捉路徑直接複用。
+- `LogEntry` / `LogLevel`：**不新增欄位 / 不新增 enum**。
+- `ConsoleTab(inspector: ...)` 對外建構不變，僅內部 `ListTile` 加 `onTap`。
+
+---
+
+## 7. 明確「不做」（砍掉研究中的過度設計）
+
+- **不做 `_teardownErrorHandlers()`**：規格未要求 detach 還原（YAGNI）。
+- **不做 `truncateStackTrace` / 分享長度限制**：MVP 不需要。
+- **不抽 `NetworkDetailView` / `LogDetailView` 共用基類**：scope 外，違反「砍掉一半再砍一半」。可在 PR 留一行未來重構註記，本次不動 `NetworkDetailView`。
+- **不做 ConsoleTab 搜尋 / 過濾**：brainstorm #5 的另一半，不在本功能。
+- **不開新 tab、不做跨 session 持久化、不做效能監控、不取代宿主任何 handler、不做 #4 Dio 結構化錯誤、不做 #2 時序關聯側欄**（同規格 Out of Scope）。
+
+---
+
+## 8. 風險與破壞性分析
+
+| 風險 | 說明 | 緩解 |
+|------|------|------|
+| 全域 handler 測試污染 | 三掛點是進程全域狀態，測試替換後若不還原會污染後續測試 | `setUp`/`tearDown` 保存還原；列為 T1 硬約束 |
+| `PlatformDispatcher.onError` 誤吞 | 無條件 `return true` 會吞掉宿主上報 | 設計強制宿主未設時 `return false`、有設則回傳原 handler 結果；T1 專測此語意 |
+| ErrorWidget reentrancy | log 段自身拋錯可能無限遞迴 | log 段 try-catch 吞掉（不 rethrow）+ `debugPrintStack`，`return original(details)` 永遠在外 |
+| 雙啟用重複接線 | `captureUncaughtErrors:true` + `runGuarded` 同用導致一錯兩 log | `_uncaughtErrorHandlersAttached` flag 去重；T1/T2 專測 |
+| 接線時機 | `ErrorWidget.builder` 須早於 `runApp` 被讀取 | 建構子內接線 + `runGuarded` zone 內 body 前接線；example 驗證 |
+| 回退 | 若捕捉造成不可接受副作用 | 整包行為由 `captureUncaughtErrors`（預設 false）+ `runGuarded` 控制；不啟用即與現況完全一致，revert 對應 commit 零殘留 |
+
+---
+
+## 確認
+
+請確認此實作計畫（6 任務、Core 路徑 T1→T2 ∥ UI 路徑 T3→T4→T5 可並行、T6 收斂、零新資料模型、`captureUncaughtErrors` 預設 false、`runGuarded` 經既有 export 對外可見）。確認後進入 **STAGE 1** 建立 Issue + 分支。

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,21 +8,25 @@ import 'sqflite_browser_source.dart';
 // On Android this requires a notification icon + (Android 13+) the
 // POST_NOTIFICATIONS permission; on iOS/macOS the user is prompted on init.
 late final FlutterInspector inspector;
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(MyApp());
+  inspector = FlutterInspector(
+    showNetworkNotification: true,
+    navigatorKey: navigatorKey,
+    // Capture uncaught errors from the three standard Flutter hooks into the
+    // Console as LogLevel.error logs. Opt-in, defaults to false.
+    captureUncaughtErrors: true,
+  );
+  // runGuarded additionally captures uncaught *zone* errors (e.g. unawaited
+  // Future errors). It reuses the same hook wiring as above (deduped), so the
+  // two together give full coverage. Both forward errors downstream.
+  FlutterInspector.runGuarded(() => runApp(const MyApp()), inspector: inspector);
 }
 
 class MyApp extends StatelessWidget {
-  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
-
-  MyApp({super.key}) {
-    inspector = FlutterInspector(
-      showNetworkNotification: true,
-      navigatorKey: navigatorKey,
-    );
-  }
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -203,6 +207,17 @@ class _MyHomePageState extends State<MyHomePage> {
                 );
               },
               child: const Text('Push New Route'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              // Throws an uncaught async error. With captureUncaughtErrors /
+              // runGuarded enabled, it surfaces as a red error log in the
+              // Console tab — tap it to expand the stack trace.
+              onPressed: () => Future<void>.error(
+                StateError('Demo: uncaught async error'),
+                StackTrace.current,
+              ),
+              child: const Text('Throw Uncaught Error'),
             ),
           ],
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,14 +15,14 @@ void main() {
   inspector = FlutterInspector(
     showNetworkNotification: true,
     navigatorKey: navigatorKey,
-    // Capture uncaught errors from the three standard Flutter hooks into the
-    // Console as LogLevel.error logs. Opt-in, defaults to false.
+    // Capture uncaught errors into the Console as LogLevel.error logs (opt-in).
+    // This wires the three standard hooks — FlutterError.onError,
+    // PlatformDispatcher.instance.onError and ErrorWidget.builder — which
+    // together cover framework, asynchronous and build-time errors. No zone is
+    // involved, so there is no Zone mismatch to worry about.
     captureUncaughtErrors: true,
   );
-  // runGuarded additionally captures uncaught *zone* errors (e.g. unawaited
-  // Future errors). It reuses the same hook wiring as above (deduped), so the
-  // two together give full coverage. Both forward errors downstream.
-  FlutterInspector.runGuarded(() => runApp(const MyApp()), inspector: inspector);
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
@@ -210,9 +210,10 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             const SizedBox(height: 20),
             ElevatedButton(
-              // Throws an uncaught async error. With captureUncaughtErrors /
-              // runGuarded enabled, it surfaces as a red error log in the
-              // Console tab — tap it to expand the stack trace.
+              // Throws an uncaught async error. With captureUncaughtErrors
+              // enabled it is caught by PlatformDispatcher.instance.onError and
+              // surfaces as a red error log in the Console tab — tap it to
+              // expand the stack trace.
               onPressed: () => Future<void>.error(
                 StateError('Demo: uncaught async error'),
                 StackTrace.current,

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../inspectors/navigator_inspector.dart';
@@ -30,10 +33,12 @@ class FlutterInspector {
     this.magicalTapCount = 5,
     this.showNetworkNotification = false,
     this.navigatorKey,
+    this.captureUncaughtErrors = false,
     int bufferSize = 500,
     NetworkNotifier? notifier,
     List<DatabaseBrowserSource>? databaseSources,
   }) : _registry = InspectorRegistry(bufferSize: bufferSize) {
+    if (captureUncaughtErrors) setupErrorHandlers();
     _navigatorObserver = FlutterInspectorNavigatorObserver(this);
     _operationLogSource = OperationLogSource(_registry.database);
     if (databaseSources != null) {
@@ -79,6 +84,19 @@ class FlutterInspector {
   /// network notification opens the dashboard on the Network tab. Without it,
   /// the tap is a no-op since there is no [BuildContext] to route from.
   final GlobalKey<NavigatorState>? navigatorKey;
+
+  /// Whether to capture uncaught errors from the three standard Flutter hooks
+  /// ([FlutterError.onError], [PlatformDispatcher.instance.onError],
+  /// [ErrorWidget.builder]) and turn them into [LogLevel.error] log entries.
+  ///
+  /// Defaults to `false` so the package never touches host error handlers
+  /// unless the host opts in. When `true`, all hooks chain/wrap the existing
+  /// host handler — the error is always forwarded downstream, never swallowed.
+  final bool captureUncaughtErrors;
+
+  FlutterExceptionHandler? _oldFlutterErrorHandler;
+  bool Function(Object, StackTrace)? _oldPlatformDispatcherOnError;
+  bool _uncaughtErrorHandlersAttached = false;
 
   NetworkNotifier? _notifier;
 
@@ -164,6 +182,110 @@ class FlutterInspector {
         stackTrace: stackTrace,
         data: data,
       ),
+    );
+  }
+
+  /// Runs [body] inside a guarded zone, capturing uncaught synchronous and
+  /// asynchronous zone errors as [LogLevel.error] log entries.
+  ///
+  /// This is a thin wrapper meant to wrap `runApp(...)`. It also wires the
+  /// three standard error hooks (via [setupErrorHandlers]) inside the zone,
+  /// before [body] runs, so `ErrorWidget.builder` is in place before
+  /// `runApp` reads it. The dedup flag guarantees the hooks attach only once
+  /// even if [captureUncaughtErrors] already attached them.
+  ///
+  /// Captured zone errors are logged but not rethrown — `runZonedGuarded`
+  /// absorbs them, which is the correct "captured, not propagated upward"
+  /// semantic for an error-reporting wrapper.
+  static void runGuarded(
+    void Function() body, {
+    required FlutterInspector inspector,
+  }) {
+    inspector.setupErrorHandlers();
+    runZonedGuarded(body, (e, st) {
+      inspector.log(
+        e.toString(),
+        level: LogLevel.error,
+        stackTrace: st.toString(),
+        data: {
+          'source': 'zone',
+          'exceptionType': e.runtimeType.toString(),
+        },
+      );
+    });
+  }
+
+  /// Attaches the three standard Flutter error hooks, chaining/wrapping any
+  /// existing host handler so errors are always forwarded downstream.
+  ///
+  /// Idempotent: the dedup flag ensures hooks are attached at most once, so an
+  /// error never produces two log entries even when both [captureUncaughtErrors]
+  /// and [runGuarded] are used together.
+  @visibleForTesting
+  void setupErrorHandlers() {
+    if (_uncaughtErrorHandlersAttached) return;
+    _uncaughtErrorHandlersAttached = true;
+
+    // 1) FlutterError.onError — chain.
+    _oldFlutterErrorHandler = FlutterError.onError;
+    FlutterError.onError = (details) {
+      _logFlutterError(details, source: 'flutterError');
+      if (_oldFlutterErrorHandler != null) {
+        _oldFlutterErrorHandler!(details);
+      } else {
+        FlutterError.presentError(details);
+      }
+    };
+
+    // 2) PlatformDispatcher.instance.onError — chain.
+    _oldPlatformDispatcherOnError = PlatformDispatcher.instance.onError;
+    PlatformDispatcher.instance.onError = (e, st) {
+      log(
+        e.toString(),
+        level: LogLevel.error,
+        stackTrace: st.toString(),
+        data: {
+          'source': 'platformDispatcher',
+          'exceptionType': e.runtimeType.toString(),
+        },
+      );
+      final old = _oldPlatformDispatcherOnError;
+      return old != null ? old(e, st) : false;
+    };
+
+    // 3) ErrorWidget.builder — wrap.
+    final original = ErrorWidget.builder;
+    ErrorWidget.builder = (details) {
+      try {
+        _logFlutterError(details, source: 'errorWidget');
+      } catch (e, s) {
+        debugPrintStack(
+          stackTrace: s,
+          label: 'inspector errorWidget log failed: $e',
+        );
+      }
+      return original(details);
+    };
+  }
+
+  void _logFlutterError(
+    FlutterErrorDetails details, {
+    required String source,
+  }) {
+    final data = <String, dynamic>{
+      'source': source,
+      'exceptionType': details.exception.runtimeType.toString(),
+    };
+    final library = details.library;
+    if (library != null) data['library'] = library;
+    final context = details.context;
+    if (context != null) data['context'] = context.toString();
+
+    log(
+      details.exceptionAsString(),
+      level: LogLevel.error,
+      stackTrace: details.stack?.toString(),
+      data: data,
     );
   }
 

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
@@ -99,7 +97,7 @@ class FlutterInspector {
   ///   [PlatformDispatcher.instance.onError] *after* constructing the inspector,
   ///   that later handler replaces the inspector's wrapper and capture silently
   ///   stops (the host always wins — nothing breaks). Construct the inspector
-  ///   (or call [runGuarded]) after installing any custom handlers.
+  ///   after installing any custom handlers.
   /// - Enable this on a single, app-wide inspector. The dedup guard is
   ///   per-instance, so creating multiple capture-enabled inspectors layers the
   ///   hooks and records the same error once per instance (host errors still
@@ -200,42 +198,12 @@ class FlutterInspector {
     );
   }
 
-  /// Runs [body] inside a guarded zone, capturing uncaught synchronous and
-  /// asynchronous zone errors as [LogLevel.error] log entries.
-  ///
-  /// This is a thin wrapper meant to wrap `runApp(...)`. It also wires the
-  /// three standard error hooks (via [setupErrorHandlers]) inside the zone,
-  /// before [body] runs, so `ErrorWidget.builder` is in place before
-  /// `runApp` reads it. The dedup flag guarantees the hooks attach only once
-  /// even if [captureUncaughtErrors] already attached them.
-  ///
-  /// Captured zone errors are logged but not rethrown — `runZonedGuarded`
-  /// absorbs them, which is the correct "captured, not propagated upward"
-  /// semantic for an error-reporting wrapper.
-  static void runGuarded(
-    void Function() body, {
-    required FlutterInspector inspector,
-  }) {
-    inspector.setupErrorHandlers();
-    runZonedGuarded(body, (e, st) {
-      inspector.log(
-        e.toString(),
-        level: LogLevel.error,
-        stackTrace: st.toString(),
-        data: {
-          'source': 'zone',
-          'exceptionType': e.runtimeType.toString(),
-        },
-      );
-    });
-  }
-
   /// Attaches the three standard Flutter error hooks, chaining/wrapping any
   /// existing host handler so errors are always forwarded downstream.
   ///
   /// Idempotent: the dedup flag ensures hooks are attached at most once, so an
-  /// error never produces two log entries even when both [captureUncaughtErrors]
-  /// and [runGuarded] are used together.
+  /// error never produces two log entries even when [captureUncaughtErrors] and
+  /// a manual [setupErrorHandlers] call are combined.
   @visibleForTesting
   void setupErrorHandlers() {
     if (_uncaughtErrorHandlersAttached) return;

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -92,6 +92,21 @@ class FlutterInspector {
   /// Defaults to `false` so the package never touches host error handlers
   /// unless the host opts in. When `true`, all hooks chain/wrap the existing
   /// host handler — the error is always forwarded downstream, never swallowed.
+  ///
+  /// Notes:
+  /// - The hooks capture whatever handler is installed at construction time.
+  ///   If the host installs its own [FlutterError.onError] /
+  ///   [PlatformDispatcher.instance.onError] *after* constructing the inspector,
+  ///   that later handler replaces the inspector's wrapper and capture silently
+  ///   stops (the host always wins — nothing breaks). Construct the inspector
+  ///   (or call [runGuarded]) after installing any custom handlers.
+  /// - Enable this on a single, app-wide inspector. The dedup guard is
+  ///   per-instance, so creating multiple capture-enabled inspectors layers the
+  ///   hooks and records the same error once per instance (host errors still
+  ///   forward correctly — just duplicated logs).
+  /// - The hooks are not torn down: once attached they remain for the process
+  ///   lifetime ([detach] only removes the FAB overlay). The `_old*` handlers
+  ///   are kept solely to chain to, not to restore.
   final bool captureUncaughtErrors;
 
   FlutterExceptionHandler? _oldFlutterErrorHandler;
@@ -227,9 +242,15 @@ class FlutterInspector {
     _uncaughtErrorHandlersAttached = true;
 
     // 1) FlutterError.onError — chain.
+    // The logging call is guarded so a failure while recording can never break
+    // the chain to the host handler — the error is always forwarded downstream.
     _oldFlutterErrorHandler = FlutterError.onError;
     FlutterError.onError = (details) {
-      _logFlutterError(details, source: 'flutterError');
+      try {
+        _logFlutterError(details, source: 'flutterError');
+      } catch (e, s) {
+        debugPrintStack(stackTrace: s, label: 'inspector log failed: $e');
+      }
       if (_oldFlutterErrorHandler != null) {
         _oldFlutterErrorHandler!(details);
       } else {
@@ -238,17 +259,23 @@ class FlutterInspector {
     };
 
     // 2) PlatformDispatcher.instance.onError — chain.
+    // The logging call is guarded so a failure while recording can never alter
+    // the boolean the host handler returns (its "handled" semantics are kept).
     _oldPlatformDispatcherOnError = PlatformDispatcher.instance.onError;
     PlatformDispatcher.instance.onError = (e, st) {
-      log(
-        e.toString(),
-        level: LogLevel.error,
-        stackTrace: st.toString(),
-        data: {
-          'source': 'platformDispatcher',
-          'exceptionType': e.runtimeType.toString(),
-        },
-      );
+      try {
+        log(
+          e.toString(),
+          level: LogLevel.error,
+          stackTrace: st.toString(),
+          data: {
+            'source': 'platformDispatcher',
+            'exceptionType': e.runtimeType.toString(),
+          },
+        );
+      } catch (err, s) {
+        debugPrintStack(stackTrace: s, label: 'inspector log failed: $err');
+      }
       final old = _oldPlatformDispatcherOnError;
       return old != null ? old(e, st) : false;
     };

--- a/lib/src/ui/dashboard/tabs/console/log_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/console/log_detail_view.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../../models/log_entry.dart';
+import '../../../../utils/log_formatters.dart';
+import '../../../../utils/share_text.dart';
+import '../../../widgets/key_value_table.dart';
+
+/// Actions exposed in the detail view's share menu.
+enum _ShareAction { text, share }
+
+/// A full-screen, structured view of a single [LogEntry], showing General
+/// info, an optional Stack Trace section, and a Data section plus sharing
+/// (plain text / system share).
+class LogDetailView extends StatelessWidget {
+  const LogDetailView({required this.entry, super.key});
+
+  final LogEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final shortTs = _shortTimestamp(entry.timestamp);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('[${entry.level.name}] $shortTs'),
+        actions: [
+          PopupMenuButton<_ShareAction>(
+            icon: const Icon(Icons.share),
+            onSelected: (action) => _onShare(context, action),
+            itemBuilder: (context) => const [
+              PopupMenuItem(
+                value: _ShareAction.text,
+                child: Text('Copy as text'),
+              ),
+              PopupMenuItem(
+                value: _ShareAction.share,
+                child: Text('Share…'),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(12),
+        children: [
+          _generalSection(context),
+          if (entry.stackTrace != null) _stackTraceSection(context),
+          _dataSection(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _generalSection(BuildContext context) {
+    return _section(
+      context,
+      'General',
+      Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _kv(context, 'Message', entry.message),
+          _kv(context, 'Level', entry.level.name),
+          _kv(context, 'Timestamp', entry.timestamp.toIso8601String()),
+        ],
+      ),
+    );
+  }
+
+  Widget _stackTraceSection(BuildContext context) {
+    return _section(
+      context,
+      'Stack Trace',
+      Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: SelectableText(
+          entry.stackTrace!,
+          style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+        ),
+      ),
+    );
+  }
+
+  Widget _dataSection(BuildContext context) {
+    return _section(
+      context,
+      'Data',
+      KeyValueTable(data: entry.data, emptyLabel: '(no data)'),
+    );
+  }
+
+  Widget _section(BuildContext context, String title, Widget child) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleSmall),
+            const SizedBox(height: 8),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _kv(BuildContext context, String key, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              '$key:',
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(child: SelectableText(value)),
+        ],
+      ),
+    );
+  }
+
+  String _shortTimestamp(DateTime ts) {
+    final h = ts.hour.toString().padLeft(2, '0');
+    final m = ts.minute.toString().padLeft(2, '0');
+    final s = ts.second.toString().padLeft(2, '0');
+    return '${ts.year}-${_p(ts.month)}-${_p(ts.day)} $h:$m:$s';
+  }
+
+  String _p(int n) => n.toString().padLeft(2, '0');
+
+  Future<void> _onShare(BuildContext context, _ShareAction action) async {
+    final messenger = ScaffoldMessenger.of(context);
+    switch (action) {
+      case _ShareAction.text:
+        await Clipboard.setData(
+          ClipboardData(text: buildLogPlainText(entry)),
+        );
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Details copied to clipboard')),
+        );
+      case _ShareAction.share:
+        try {
+          await shareText(buildLogPlainText(entry));
+        } catch (_) {
+          // Fallback to clipboard when the platform has no share sheet.
+          await Clipboard.setData(
+            ClipboardData(text: buildLogPlainText(entry)),
+          );
+          messenger.showSnackBar(
+            const SnackBar(
+              content: Text('Share unavailable — copied to clipboard'),
+            ),
+          );
+        }
+    }
+  }
+}

--- a/lib/src/ui/dashboard/tabs/console/log_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/console/log_detail_view.dart
@@ -44,7 +44,7 @@ class LogDetailView extends StatelessWidget {
         padding: const EdgeInsets.all(12),
         children: [
           _generalSection(context),
-          if (entry.stackTrace != null) _stackTraceSection(context),
+          if (entry.stackTrace?.isNotEmpty ?? false) _stackTraceSection(context),
           _dataSection(context),
         ],
       ),
@@ -133,10 +133,8 @@ class LogDetailView extends StatelessWidget {
   }
 
   String _shortTimestamp(DateTime ts) {
-    final h = ts.hour.toString().padLeft(2, '0');
-    final m = ts.minute.toString().padLeft(2, '0');
-    final s = ts.second.toString().padLeft(2, '0');
-    return '${ts.year}-${_p(ts.month)}-${_p(ts.day)} $h:$m:$s';
+    return '${ts.year}-${_p(ts.month)}-${_p(ts.day)} '
+        '${_p(ts.hour)}:${_p(ts.minute)}:${_p(ts.second)}';
   }
 
   String _p(int n) => n.toString().padLeft(2, '0');

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -55,7 +55,7 @@ class _ConsoleTabState extends State<ConsoleTab> {
             itemCount: entries.length,
             itemBuilder: (context, index) {
               final entry = entries[index];
-              final canTap = entry.stackTrace != null ||
+              final canTap = (entry.stackTrace?.isNotEmpty ?? false) ||
                   (entry.data?.isNotEmpty ?? false);
               return ListTile(
                 title: Text(

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -55,7 +55,8 @@ class _ConsoleTabState extends State<ConsoleTab> {
             itemCount: entries.length,
             itemBuilder: (context, index) {
               final entry = entries[index];
-              final canTap = entry.stackTrace != null || entry.data != null;
+              final canTap = entry.stackTrace != null ||
+                  (entry.data?.isNotEmpty ?? false);
               return ListTile(
                 title: Text(
                   entry.message,

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/flutter_inspector.dart';
 import '../../../models/log_level.dart';
+import 'console/log_detail_view.dart';
 
 /// Tab for displaying console logs.
 class ConsoleTab extends StatefulWidget {
@@ -54,12 +55,20 @@ class _ConsoleTabState extends State<ConsoleTab> {
             itemCount: entries.length,
             itemBuilder: (context, index) {
               final entry = entries[index];
+              final canTap = entry.stackTrace != null || entry.data != null;
               return ListTile(
                 title: Text(
                   entry.message,
                   style: TextStyle(color: _getColorForLevel(entry.level)),
                 ),
                 subtitle: Text(entry.timestamp.toIso8601String()),
+                onTap: canTap
+                    ? () => Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => LogDetailView(entry: entry),
+                          ),
+                        )
+                    : null,
               );
             },
           ),

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -63,6 +63,10 @@ class _ConsoleTabState extends State<ConsoleTab> {
                   style: TextStyle(color: _getColorForLevel(entry.level)),
                 ),
                 subtitle: Text(entry.timestamp.toIso8601String()),
+                // Mark expandable rows with the same chevron the Network tab
+                // uses; non-expandable rows stay flat (trailing: null).
+                trailing:
+                    canTap ? const Icon(Icons.chevron_right, size: 18) : null,
                 onTap: canTap
                     ? () => Navigator.of(context).push(
                           MaterialPageRoute(

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -1,0 +1,32 @@
+import '../models/log_entry.dart';
+
+/// Pure formatting helpers for the Console inspector. No Flutter dependencies,
+/// so everything here is unit-testable in isolation.
+
+/// Builds a full plain-text export of [entry] covering general info,
+/// stack trace, and data sections.
+String buildLogPlainText(LogEntry entry) {
+  final b = StringBuffer()
+    ..writeln('=== General ===')
+    ..writeln('Message: ${entry.message}')
+    ..writeln('Level: ${entry.level.name}')
+    ..writeln('Timestamp: ${entry.timestamp.toIso8601String()}');
+
+  b.writeln('\n=== Stack Trace ===');
+  final stackTrace = entry.stackTrace;
+  if (stackTrace != null && stackTrace.isNotEmpty) {
+    b.writeln(stackTrace);
+  } else {
+    b.writeln('(none)');
+  }
+
+  b.writeln('\n=== Data ===');
+  final data = entry.data;
+  if (data != null && data.isNotEmpty) {
+    data.forEach((k, v) => b.writeln('$k: $v'));
+  } else {
+    b.writeln('(none)');
+  }
+
+  return b.toString().trimRight();
+}

--- a/test/core/error_capture_test.dart
+++ b/test/core/error_capture_test.dart
@@ -193,55 +193,16 @@ void main() {
     });
   });
 
-  group('runGuarded (T2)', () {
-    test('captures zone error as a single LogLevel.error log', () {
-      FlutterError.onError = (_) {};
-      final inspector = FlutterInspector();
-
-      FlutterInspector.runGuarded(
-        () => throw StateError('boom'),
-        inspector: inspector,
-      );
-
-      final errors =
-          inspector.logEntries.where((e) => e.level == LogLevel.error).toList();
-      expect(errors, hasLength(1));
-      expect(errors.first.message, contains('boom'));
-      expect(errors.first.stackTrace, isNotNull);
-      expect(errors.first.data?['source'], 'zone');
-    });
-
-    test('captures an uncaught async (unawaited Future) zone error', () async {
-      FlutterError.onError = (_) {};
-      final inspector = FlutterInspector();
-
-      FlutterInspector.runGuarded(
-        () {
-          // Unawaited future error — only a guarded zone's onError catches this.
-          Future<void>.error(StateError('async boom'));
-        },
-        inspector: inspector,
-      );
-
-      // Let the microtask carrying the future error drain so runZonedGuarded's
-      // onError runs before we assert.
-      await Future<void>.delayed(Duration.zero);
-
-      final errors =
-          inspector.logEntries.where((e) => e.level == LogLevel.error).toList();
-      expect(errors, hasLength(1));
-      expect(errors.first.message, contains('async boom'));
-      expect(errors.first.data?['source'], 'zone');
-    });
-
+  group('dedup (T2)', () {
     test(
-        'dedup: captureUncaughtErrors:true then runGuarded attaches hooks once',
-        () {
+        'captureUncaughtErrors:true then a manual setupErrorHandlers attaches '
+        'hooks once', () {
       FlutterError.onError = (_) {};
       final inspector = FlutterInspector(captureUncaughtErrors: true);
 
-      // runGuarded calls setupErrorHandlers again; flag must prevent re-attach.
-      FlutterInspector.runGuarded(() {}, inspector: inspector);
+      // A second setupErrorHandlers call must be a no-op; the flag must prevent
+      // re-attaching the hooks.
+      inspector.setupErrorHandlers();
 
       FlutterError.onError!(buildDetails(StateError('boom')));
 

--- a/test/core/error_capture_test.dart
+++ b/test/core/error_capture_test.dart
@@ -78,6 +78,9 @@ void main() {
       expect(errors.first.message, contains('build boom'));
       expect(errors.first.stackTrace, isNotNull);
       expect(errors.first.data?['source'], 'flutterError');
+      // The detail view relies on these being populated.
+      expect(errors.first.data?['exceptionType'], 'StateError');
+      expect(errors.first.data?['library'], 'test library');
     });
 
     test('chains the existing host handler (error forwarded downstream)', () {
@@ -96,8 +99,14 @@ void main() {
   });
 
   group('PlatformDispatcher.onError return semantics', () {
-    test('host return true is preserved', () {
-      PlatformDispatcher.instance.onError = (error, stack) => true;
+    test('host return true is preserved AND the host handler is invoked', () {
+      // Flip a flag in the host handler so we assert the chain side effect,
+      // not just a return value that happens to coincide.
+      var hostCalled = false;
+      PlatformDispatcher.instance.onError = (error, stack) {
+        hostCalled = true;
+        return true;
+      };
       final inspector = FlutterInspector(captureUncaughtErrors: true);
 
       final handled = PlatformDispatcher.instance.onError!(
@@ -106,10 +115,34 @@ void main() {
       );
 
       expect(handled, isTrue);
+      expect(hostCalled, isTrue);
       final errors =
           inspector.logEntries.where((e) => e.level == LogLevel.error).toList();
       expect(errors, hasLength(1));
       expect(errors.first.data?['source'], 'platformDispatcher');
+    });
+
+    test('host return false is preserved (never upgrades to handled)', () {
+      // The most regression-prone path: a careless change to `return true`
+      // would silently swallow an error the host explicitly left unhandled.
+      var hostCalled = false;
+      PlatformDispatcher.instance.onError = (error, stack) {
+        hostCalled = true;
+        return false;
+      };
+      final inspector = FlutterInspector(captureUncaughtErrors: true);
+
+      final handled = PlatformDispatcher.instance.onError!(
+        StateError('async boom'),
+        StackTrace.current,
+      );
+
+      expect(handled, isFalse);
+      expect(hostCalled, isTrue);
+      expect(
+        inspector.logEntries.where((e) => e.level == LogLevel.error),
+        hasLength(1),
+      );
     });
 
     test('returns false when host has no handler (never swallows)', () {
@@ -175,6 +208,29 @@ void main() {
       expect(errors, hasLength(1));
       expect(errors.first.message, contains('boom'));
       expect(errors.first.stackTrace, isNotNull);
+      expect(errors.first.data?['source'], 'zone');
+    });
+
+    test('captures an uncaught async (unawaited Future) zone error', () async {
+      FlutterError.onError = (_) {};
+      final inspector = FlutterInspector();
+
+      FlutterInspector.runGuarded(
+        () {
+          // Unawaited future error — only a guarded zone's onError catches this.
+          Future<void>.error(StateError('async boom'));
+        },
+        inspector: inspector,
+      );
+
+      // Let the microtask carrying the future error drain so runZonedGuarded's
+      // onError runs before we assert.
+      await Future<void>.delayed(Duration.zero);
+
+      final errors =
+          inspector.logEntries.where((e) => e.level == LogLevel.error).toList();
+      expect(errors, hasLength(1));
+      expect(errors.first.message, contains('async boom'));
       expect(errors.first.data?['source'], 'zone');
     });
 

--- a/test/core/error_capture_test.dart
+++ b/test/core/error_capture_test.dart
@@ -1,0 +1,199 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // The three error hooks are process-global state. Save them before each test
+  // and restore them after, so attaching/replacing in one test never pollutes
+  // the next one.
+  late FlutterExceptionHandler? savedFlutterOnError;
+  late ErrorCallback? savedPlatformOnError;
+  late Widget Function(FlutterErrorDetails) savedErrorWidgetBuilder;
+
+  setUp(() {
+    savedFlutterOnError = FlutterError.onError;
+    savedPlatformOnError = PlatformDispatcher.instance.onError;
+    savedErrorWidgetBuilder = ErrorWidget.builder;
+  });
+
+  tearDown(() {
+    FlutterError.onError = savedFlutterOnError;
+    PlatformDispatcher.instance.onError = savedPlatformOnError;
+    ErrorWidget.builder = savedErrorWidgetBuilder;
+  });
+
+  FlutterErrorDetails buildDetails(Object exception) {
+    return FlutterErrorDetails(
+      exception: exception,
+      stack: StackTrace.current,
+      library: 'test library',
+      context: ErrorDescription('while testing'),
+    );
+  }
+
+  group('default off (Never break userspace)', () {
+    test('captureUncaughtErrors:false does not touch any hook', () {
+      final beforeFlutter = FlutterError.onError;
+      final beforePlatform = PlatformDispatcher.instance.onError;
+      final beforeWidget = ErrorWidget.builder;
+
+      FlutterInspector();
+
+      expect(FlutterError.onError, same(beforeFlutter));
+      expect(PlatformDispatcher.instance.onError, same(beforePlatform));
+      expect(ErrorWidget.builder, same(beforeWidget));
+    });
+
+    test('captureUncaughtErrors:true replaces all three hooks', () {
+      final beforeFlutter = FlutterError.onError;
+      final beforePlatform = PlatformDispatcher.instance.onError;
+      final beforeWidget = ErrorWidget.builder;
+
+      FlutterInspector(captureUncaughtErrors: true);
+
+      expect(FlutterError.onError, isNot(same(beforeFlutter)));
+      expect(PlatformDispatcher.instance.onError, isNot(same(beforePlatform)));
+      expect(ErrorWidget.builder, isNot(same(beforeWidget)));
+    });
+  });
+
+  group('FlutterError.onError capture + chain', () {
+    test('captures details as a LogLevel.error entry with stackTrace', () {
+      // Host handler set to a no-op so the default test binding does not
+      // re-report the error as test noise.
+      FlutterError.onError = (_) {};
+      final inspector = FlutterInspector(captureUncaughtErrors: true);
+
+      FlutterError.onError!(buildDetails(StateError('build boom')));
+
+      final errors =
+          inspector.logEntries.where((e) => e.level == LogLevel.error).toList();
+      expect(errors, hasLength(1));
+      expect(errors.first.message, contains('build boom'));
+      expect(errors.first.stackTrace, isNotNull);
+      expect(errors.first.data?['source'], 'flutterError');
+    });
+
+    test('chains the existing host handler (error forwarded downstream)', () {
+      var hostCalled = false;
+      FlutterError.onError = (_) => hostCalled = true;
+
+      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      FlutterError.onError!(buildDetails(StateError('boom')));
+
+      expect(hostCalled, isTrue);
+      expect(
+        inspector.logEntries.where((e) => e.level == LogLevel.error),
+        hasLength(1),
+      );
+    });
+  });
+
+  group('PlatformDispatcher.onError return semantics', () {
+    test('host return true is preserved', () {
+      PlatformDispatcher.instance.onError = (error, stack) => true;
+      final inspector = FlutterInspector(captureUncaughtErrors: true);
+
+      final handled = PlatformDispatcher.instance.onError!(
+        StateError('async boom'),
+        StackTrace.current,
+      );
+
+      expect(handled, isTrue);
+      final errors =
+          inspector.logEntries.where((e) => e.level == LogLevel.error).toList();
+      expect(errors, hasLength(1));
+      expect(errors.first.data?['source'], 'platformDispatcher');
+    });
+
+    test('returns false when host has no handler (never swallows)', () {
+      PlatformDispatcher.instance.onError = null;
+      FlutterInspector(captureUncaughtErrors: true);
+
+      final handled = PlatformDispatcher.instance.onError!(
+        StateError('async boom'),
+        StackTrace.current,
+      );
+
+      expect(handled, isFalse);
+    });
+  });
+
+  group('ErrorWidget.builder wrap', () {
+    test('logs then delegates to original builder', () {
+      final originalBuilder = ErrorWidget.builder;
+      final inspector = FlutterInspector(captureUncaughtErrors: true);
+
+      final details = buildDetails(StateError('widget boom'));
+      final widget = ErrorWidget.builder(details);
+
+      // Original builder still produced the placeholder widget.
+      expect(widget, isA<Widget>());
+      expect(widget.runtimeType, originalBuilder(details).runtimeType);
+
+      final errors =
+          inspector.logEntries.where((e) => e.level == LogLevel.error).toList();
+      expect(errors, hasLength(1));
+      expect(errors.first.data?['source'], 'errorWidget');
+    });
+  });
+
+  group('dedup flag', () {
+    test('calling setupErrorHandlers twice attaches hooks only once', () {
+      FlutterError.onError = (_) {};
+      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      // Second explicit call must be a no-op.
+      inspector.setupErrorHandlers();
+
+      FlutterError.onError!(buildDetails(StateError('boom')));
+
+      expect(
+        inspector.logEntries.where((e) => e.level == LogLevel.error),
+        hasLength(1),
+      );
+    });
+  });
+
+  group('runGuarded (T2)', () {
+    test('captures zone error as a single LogLevel.error log', () {
+      FlutterError.onError = (_) {};
+      final inspector = FlutterInspector();
+
+      FlutterInspector.runGuarded(
+        () => throw StateError('boom'),
+        inspector: inspector,
+      );
+
+      final errors =
+          inspector.logEntries.where((e) => e.level == LogLevel.error).toList();
+      expect(errors, hasLength(1));
+      expect(errors.first.message, contains('boom'));
+      expect(errors.first.stackTrace, isNotNull);
+      expect(errors.first.data?['source'], 'zone');
+    });
+
+    test(
+        'dedup: captureUncaughtErrors:true then runGuarded attaches hooks once',
+        () {
+      FlutterError.onError = (_) {};
+      final inspector = FlutterInspector(captureUncaughtErrors: true);
+
+      // runGuarded calls setupErrorHandlers again; flag must prevent re-attach.
+      FlutterInspector.runGuarded(() {}, inspector: inspector);
+
+      FlutterError.onError!(buildDetails(StateError('boom')));
+
+      // A single FlutterError trigger yields exactly one log (hooks not doubled).
+      expect(
+        inspector.logEntries.where((e) => e.level == LogLevel.error),
+        hasLength(1),
+      );
+    });
+  });
+}

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/log_level.dart';
 import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/console_tab.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/console/log_detail_view.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -25,6 +26,77 @@ void main() {
 
       expect(find.text('Test message 1'), findsNothing);
       expect(find.text('Test message 2'), findsNothing);
+    });
+
+    testWidgets('tapping error log with stackTrace opens LogDetailView',
+        (tester) async {
+      final inspector = FlutterInspector();
+      inspector.log(
+        'Error occurred',
+        level: LogLevel.error,
+        stackTrace: 'line 1\nline 2\nline 3',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      expect(find.text('Error occurred'), findsOneWidget);
+      expect(find.byType(LogDetailView), findsNothing);
+
+      await tester.tap(find.text('Error occurred'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LogDetailView), findsOneWidget);
+    });
+
+    testWidgets('tapping error log with data opens LogDetailView',
+        (tester) async {
+      final inspector = FlutterInspector();
+      inspector.log(
+        'Error with data',
+        level: LogLevel.error,
+        data: {'key': 'value'},
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      expect(find.text('Error with data'), findsOneWidget);
+      expect(find.byType(LogDetailView), findsNothing);
+
+      await tester.tap(find.text('Error with data'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LogDetailView), findsOneWidget);
+    });
+
+    testWidgets('tapping pure info log without stackTrace or data does not navigate',
+        (tester) async {
+      final inspector = FlutterInspector();
+      inspector.log('Pure info', level: LogLevel.info);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      expect(find.text('Pure info'), findsOneWidget);
+      expect(find.byType(LogDetailView), findsNothing);
+
+      // Try to tap the log entry
+      final tile = find.byType(ListTile).first;
+      await tester.tap(tile);
+      await tester.pumpAndSettle();
+
+      // LogDetailView should not appear because onTap is null
+      expect(find.byType(LogDetailView), findsNothing);
     });
   });
 }

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -76,6 +76,34 @@ void main() {
       expect(find.byType(LogDetailView), findsOneWidget);
     });
 
+    testWidgets('shows a chevron only on expandable rows', (tester) async {
+      final inspector = FlutterInspector();
+      // Expandable: has a stackTrace.
+      inspector.log('Expandable', level: LogLevel.error, stackTrace: 'x');
+      // Non-expandable: plain info with neither stackTrace nor data.
+      inspector.log('Flat', level: LogLevel.info);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      // Exactly one chevron, and it belongs to the expandable row's tile.
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      final expandableTile = find.ancestor(
+        of: find.text('Expandable'),
+        matching: find.byType(ListTile),
+      );
+      expect(
+        find.descendant(
+          of: expandableTile,
+          matching: find.byIcon(Icons.chevron_right),
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('tapping pure info log without stackTrace or data does not navigate',
         (tester) async {
       final inspector = FlutterInspector();

--- a/test/ui/tabs/log_detail_view_test.dart
+++ b/test/ui/tabs/log_detail_view_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/console/log_detail_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final t = DateTime(2026, 6, 20, 10, 30, 0);
+
+  LogEntry fullEntry() => LogEntry(
+    message: 'Something went wrong',
+    level: LogLevel.error,
+    stackTrace: '#0  main (file:///lib/main.dart:10:5)\n#1  runApp',
+    data: {'exceptionType': 'StateError', 'source': 'zone'},
+    timestamp: t,
+  );
+
+  LogEntry minimalEntry() => LogEntry(
+    message: 'Just a message',
+    level: LogLevel.info,
+    timestamp: t,
+  );
+
+  group('LogDetailView', () {
+    testWidgets('renders message, level, timestamp, stackTrace and data',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(home: LogDetailView(entry: fullEntry())),
+      );
+
+      // AppBar title contains level and timestamp
+      expect(find.textContaining('[error]'), findsOneWidget);
+
+      // General section
+      expect(find.text('General'), findsOneWidget);
+      expect(find.text('Something went wrong'), findsWidgets);
+
+      // Stack Trace section with SelectableText
+      expect(find.text('Stack Trace'), findsOneWidget);
+      expect(find.byType(SelectableText), findsWidgets);
+
+      // Data section — KeyValueTable renders the entries
+      expect(find.text('Data'), findsOneWidget);
+      expect(find.textContaining('exceptionType'), findsOneWidget);
+    });
+
+    testWidgets('null stackTrace and null data do not crash', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: LogDetailView(entry: minimalEntry())),
+      );
+
+      // Should render without throwing
+      expect(find.text('General'), findsOneWidget);
+
+      // Stack Trace section must NOT appear when stackTrace is null
+      expect(find.text('Stack Trace'), findsNothing);
+
+      // Data section shows emptyLabel when data is null
+      expect(find.text('Data'), findsOneWidget);
+      // KeyValueTable emptyLabel — '(no data)'
+      expect(find.text('(no data)'), findsOneWidget);
+    });
+
+    testWidgets('Copy as text writes buildLogPlainText to clipboard',
+        (tester) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: LogDetailView(entry: fullEntry())),
+      );
+
+      await tester.tap(find.byIcon(Icons.share));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Copy as text'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, isNotNull);
+      expect(clipboardText, contains('=== General ==='));
+      expect(clipboardText, contains('Something went wrong'));
+      expect(clipboardText, contains('=== Stack Trace ==='));
+      expect(clipboardText, contains('=== Data ==='));
+    });
+
+    testWidgets('share menu contains Copy as text and Share items',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: LogDetailView(entry: fullEntry())),
+      );
+
+      await tester.tap(find.byIcon(Icons.share));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Copy as text'), findsOneWidget);
+      expect(find.text('Share…'), findsOneWidget);
+      // No cURL option
+      expect(find.text('Copy as cURL'), findsNothing);
+    });
+  });
+}

--- a/test/utils/log_formatters_test.dart
+++ b/test/utils/log_formatters_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/utils/log_formatters.dart';
+
+void main() {
+  group('buildLogPlainText', () {
+    test('formats complete entry with all sections', () {
+      final timestamp = DateTime(2026, 6, 20, 10, 30, 45);
+      final entry = LogEntry(
+        message: 'Test error occurred',
+        level: LogLevel.error,
+        stackTrace: 'Frame 0: testFunction\nFrame 1: main',
+        data: {'key1': 'value1', 'key2': 'value2'},
+        timestamp: timestamp,
+      );
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, contains('=== General ==='));
+      expect(result, contains('Message: Test error occurred'));
+      expect(result, contains('Level: error'));
+      expect(result, contains('Timestamp: 2026-06-20T10:30:45.000'));
+      expect(result, contains('=== Stack Trace ==='));
+      expect(result, contains('Frame 0: testFunction'));
+      expect(result, contains('Frame 1: main'));
+      expect(result, contains('=== Data ==='));
+      expect(result, contains('key1: value1'));
+      expect(result, contains('key2: value2'));
+    });
+
+    test('handles null stack trace with (none)', () {
+      final entry = LogEntry(
+        message: 'Info log',
+        level: LogLevel.info,
+        stackTrace: null,
+      );
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, contains('=== Stack Trace ==='));
+      expect(result, contains('(none)'));
+      expect(result, isNot(contains('null')));
+    });
+
+    test('handles empty stack trace with (none)', () {
+      final entry = LogEntry(
+        message: 'Info log',
+        level: LogLevel.info,
+        stackTrace: '',
+      );
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, contains('=== Stack Trace ==='));
+      expect(result, contains('(none)'));
+    });
+
+    test('handles null data with (none)', () {
+      final entry = LogEntry(
+        message: 'Debug log',
+        level: LogLevel.debug,
+        data: null,
+      );
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, contains('=== Data ==='));
+      expect(result, contains('(none)'));
+      expect(result, isNot(contains('null')));
+    });
+
+    test('handles empty data map with (none)', () {
+      final entry = LogEntry(
+        message: 'Warning log',
+        level: LogLevel.warning,
+        data: {},
+      );
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, contains('=== Data ==='));
+      expect(result, contains('(none)'));
+    });
+
+    test('does not have trailing newlines', () {
+      final entry = LogEntry(
+        message: 'Test message',
+        level: LogLevel.verbose,
+      );
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, isNot(endsWith('\n')));
+    });
+
+    test('formats all log levels correctly', () {
+      for (final level in LogLevel.values) {
+        final entry = LogEntry(
+          message: 'Test',
+          level: level,
+        );
+
+        final result = buildLogPlainText(entry);
+
+        expect(result, contains('Level: ${level.name}'));
+      }
+    });
+
+    test('preserves data value types in output', () {
+      final entry = LogEntry(
+        message: 'Complex data',
+        level: LogLevel.info,
+        data: {
+          'string': 'text',
+          'number': 42,
+          'boolean': true,
+          'null_value': null,
+        },
+      );
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, contains('string: text'));
+      expect(result, contains('number: 42'));
+      expect(result, contains('boolean: true'));
+      expect(result, contains('null_value: null'));
+    });
+
+    test('formats multi-line stack traces correctly', () {
+      final stackTrace = '''Frame 0: method1
+Frame 1: method2
+Frame 2: method3''';
+      final entry = LogEntry(
+        message: 'Error',
+        level: LogLevel.error,
+        stackTrace: stackTrace,
+      );
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, contains('Frame 0: method1'));
+      expect(result, contains('Frame 1: method2'));
+      expect(result, contains('Frame 2: method3'));
+    });
+
+    test('minimal entry with only required fields', () {
+      final entry = LogEntry(message: 'Simple log');
+
+      final result = buildLogPlainText(entry);
+
+      expect(result, contains('=== General ==='));
+      expect(result, contains('Message: Simple log'));
+      expect(result, contains('Level: info'));
+      expect(result, contains('=== Stack Trace ==='));
+      expect(result, contains('(none)'));
+      expect(result, contains('=== Data ==='));
+      expect(result, contains('(none)'));
+      expect(result, isNot(endsWith('\n')));
+    });
+  });
+}


### PR DESCRIPTION
### Summary

Fixes #29

**[修正問題]**

`flutter_inspector_kit` 自我定位為 in-app debug／排查工具，卻是「錯誤的盲人」：codebase 中沒有任何 `FlutterError.onError`、`PlatformDispatcher.instance.onError`、`ErrorWidget.builder` 或 `runZonedGuarded` 掛點，最常導致線上問題的未捕捉例外（async error、widget build error、漏接的 exception）inspector 一個都看不到，全靠開發者手動 `try-catch` + `inspector.log()`。另外 `LogEntry` 早已定義 `stackTrace` 與 `data` 欄位，但 `ConsoleTab` 只渲染 message + timestamp，列表項點擊無反應，捕捉到例外也無法在 UI 展開 stack trace——等於白捕捉。

**[修正方式]**

1. **`FlutterInspector` 新增可選參數 `captureUncaughtErrors`（預設 `false`）**：啟用時於建構子內、早於 `runApp` 接線三個標準掛點。三者皆 **chain／wrap 既有 handler 而非取代**，捕捉到的例外經既有 `log(..., level: LogLevel.error, stackTrace, data)` 記錄後一律往下游傳——`FlutterError.onError` chain 原 handler（無則 `presentError`）；`PlatformDispatcher.onError` 維持回傳語意（`old(e, st)`，無則 `false`，絕不無條件 `return true`）；`ErrorWidget.builder` wrap 後 `return original(details)` 保證 debug 紅屏／release 灰屏不變。
2. **新增 `static runGuarded(body, {required inspector})`**：薄包裝以 `runZonedGuarded` 捕捉 zone error（含未 await 的 async error）。內部呼叫同一套 `setupErrorHandlers()`，以 `_uncaughtErrorHandlersAttached` flag 去重，與 `captureUncaughtErrors` 併用不會重複接線。
3. **錯誤回報路徑防護**：三個掛點的 logging 呼叫皆以 `try-catch` 包覆（記錄失敗只 `debugPrintStack`），確保「呼叫舊 handler／回傳舊結果」的鏈接永遠執行，不因記錄失敗而吞掉宿主錯誤。
4. **新增 `LogDetailView`（`lib/src/ui/dashboard/tabs/console/`）**：仿 `NetworkDetailView`，展示 message／level／timestamp、可複製的 `stackTrace`（`SelectableText`）、結構化 `data`（`KeyValueTable`），並提供 copy／share。新增 `buildLogPlainText(LogEntry)`（`lib/src/utils/log_formatters.dart`）組裝分享文字。
5. **`ConsoleTab` 列表項可點**：當 entry 帶 `stackTrace` 或非空 `data` 時 `onTap` 導航至 `LogDetailView`，否則 `onTap == null`（純 info log 不導航、視覺不退化）。
6. **example／docs**：example 啟用 `captureUncaughtErrors: true` + `runGuarded` 並加「Throw Uncaught Error」按鈕示範；README 補「Uncaught error capture」段、CHANGELOG 記錄。

**測試**：`flutter analyze` 零 issue；新增 `error_capture_test`／`log_formatters_test`／`log_detail_view_test` 及 `console_tab_test` 共 40 個測試全綠，涵蓋 default-off 不接管、chain 側效應翻旗標驗證、`PlatformDispatcher` 回傳語意三態（含 host-false 保留）、flag 去重、async zone error 捕捉、null 邊界不崩。對外公開 API 無破壞性變更。

