### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## Unreleased
+## 0.3.0
 
 ### Added
-* **Uncaught error capture (opt-in)**: pass `captureUncaughtErrors: true` to `FlutterInspector(...)`, or wrap `runApp` with `FlutterInspector.runGuarded(...)`, to capture uncaught errors from `FlutterError.onError`, `PlatformDispatcher.instance.onError`, `ErrorWidget.builder` and guarded zones as `LogLevel.error` logs in the Console tab. Defaults to **off**; when on, every hook chains/wraps the existing host handler — errors are always forwarded downstream, never swallowed.
+* **Uncaught error capture (opt-in)**: pass `captureUncaughtErrors: true` to `FlutterInspector(...)` to capture uncaught errors from `FlutterError.onError`, `PlatformDispatcher.instance.onError` (including unawaited `Future` errors) and `ErrorWidget.builder` as `LogLevel.error` logs in the Console tab. Defaults to **off**; when on, every hook chains/wraps the existing host handler — errors are always forwarded downstream, never swallowed.
 * **Expandable Console error logs**: tapping a Console log that carries a `stackTrace` or structured `data` now opens a detail view (`LogDetailView`) showing the message, level, timestamp, a selectable/copyable stack trace, and the structured data — with copy/share actions.
+* Expandable Console rows now show a trailing chevron, matching the Network tab, so it is clear at a glance which logs open a detail view.
+
+### Fixed
+* A log carrying an empty-string `stackTrace` is no longer treated as expandable, so it neither appears tappable in the Console nor renders an empty stack-trace section in the detail view.
 
 ## 0.2.4
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^0.2.4
+  flutter_inspector_kit: ^0.3.0
 ```
 
 Then run `flutter pub get`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 0.2.4
+version: 0.3.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
## Summary

Release **v0.3.0**, covering the uncaught-error-capture feature merged via PR #30.

## 版本資訊更新

- `pubspec.yaml`：`0.2.4` → `0.3.0`
- `README.md`：安裝範例 `^0.2.4` → `^0.3.0`
- `CHANGELOG.md`：`## Unreleased` 定版為 `## 0.3.0`

## CHANGELOG 重點（使用者可見）

**Added**
- Uncaught error capture（opt-in，`captureUncaughtErrors: true`）
- Expandable Console error logs（`LogDetailView`）
- 可展開的 Console 列顯示 trailing chevron，與 Network tab 一致

**Fixed**
- 空字串 `stackTrace` 不再被視為可展開（Console 不顯示可點、detail 不渲染空白區段）

> 註：`CHANGELOG` 原 `Unreleased` 段提及的 `runGuarded` 已在 PR #30 移除，本次定版同步移除該描述，改以 `PlatformDispatcher.onError` 涵蓋非同步錯誤。純內部 refactor 不列入 CHANGELOG。