### PR TITLE
chore(release): 0.3.1 - update snapshots for  uncaught error / database browse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.1
+
+### Documentation
+* Refreshed the README screenshots: re-captured the database browser view and added Uncaught Error and Database Browse captures sourced from the example app.
+* Removed the legacy Database (operation-log) screenshot in favor of the Database Browse capture, and re-flowed the Screenshots grid to a clean 3-column layout.
+
 ## 0.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^0.3.0
+  flutter_inspector_kit: ^0.3.1
 ```
 
 Then run `flutter pub get`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
## Summary

Documentation-only release **0.3.1**。重新整理 README 操作截圖並 bump 版號,無任何 code/API 變更。

## 修正方式

- 重拍並新增截圖:`uncaught_error.png`(Console error log detail + stack trace)、`database_browse.png`(真實 SQLite 表瀏覽)
- 移除舊的 `database.png`(operation-log 虛擬表截圖),由 Database Browse 取代,Screenshots 區塊重排為乾淨 3 欄
- 版號更新至 0.3.1:`pubspec.yaml`、README 安裝範例、`CHANGELOG.md`(`### Documentation`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)