### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0
+
+### Added
+* **Network Request Replay**: You can now resend captured HTTP requests directly within the Network detail view. It replays the request locally using the same Dio client (carrying the same headers, base URL, and interceptors). Replayed requests automatically show up as new entries in the Network tab, marked with a dedicated "Replay" label.
+
+### Changed
+* **Breaking Change**: `FlutterInspector` constructor no longer takes a `dio` parameter, and does not provide a default fallback Dio. To use the Network Request Replay feature, you must explicitly pass the source `Dio` instance when creating `FlutterInspectorDioInterceptor`.
+* **Dio Interceptor Signature**: `FlutterInspectorDioInterceptor` now takes an optional named `sourceDio` parameter (`FlutterInspectorDioInterceptor(inspector, {sourceDio: dio})`). Without passing the `sourceDio`, the "Resend" action in the Network detail view will be disabled.
+
 ## 0.3.1
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ final dio = Dio();
 dio.interceptors.add(FlutterInspectorDioInterceptor(inspector, sourceDio: dio));
 ```
 
+##### Multiple Dio Instances
+
+If your app uses multiple `Dio` instances (e.g., `authDio` for authenticated API calls, `publicDio` for public assets), register the interceptor on each instance and make sure to pass the respective instance as `sourceDio`:
+
+```dart
+// Authenticated API client
+final authDio = Dio();
+authDio.interceptors.add(FlutterInspectorDioInterceptor(inspector, sourceDio: authDio));
+
+// Public API client
+final publicDio = Dio();
+publicDio.interceptors.add(FlutterInspectorDioInterceptor(inspector, sourceDio: publicDio));
+```
+
+This guarantees that replaying a request in the Network detail view uses the exact same `Dio` instance, maintaining the correct baseUrl, interceptors, and authentication state.
+
 #### With other HTTP clients
 
 Build a `NetworkEntry` yourself and pass it in:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^0.3.1
+  flutter_inspector_kit: ^1.0.0
 ```
 
 Then run `flutter pub get`.
@@ -91,11 +91,11 @@ Remove it again with `inspector.detach()`.
 
 #### With Dio
 
-Add the interceptor to your `Dio` instance and every request/response is captured automatically.
+Add the interceptor to your `Dio` instance and every request/response is captured automatically. Pass the `sourceDio` instance to enable the **Resend (Replay)** feature in the Network detail view.
 
 ```dart
 final dio = Dio();
-dio.interceptors.add(FlutterInspectorDioInterceptor(inspector));
+dio.interceptors.add(FlutterInspectorDioInterceptor(inspector, sourceDio: dio));
 ```
 
 #### With other HTTP clients
@@ -119,6 +119,7 @@ inspector.logNetwork(completedEntry, replaces: pending);
 - **Search & filter**: filter the call list by URL, method, or status code (case-insensitive); method and status (`2xx`/`3xx`/`4xx`/`5xx`/`Failed`) chips narrow it further.
 - **Call details**: tap any call for a structured view — General (method, URL, status with color coding, duration, request/response sizes), Query Parameters, Headers, and JSON-pretty bodies. Truncated bodies are clearly marked.
 - **Sharing**: copy the call as a runnable `cURL` command, copy the full details as text, or open the system share sheet (native via `share_plus`, web via the browser Web Share API — falls back to the clipboard when unavailable).
+- **Replay / Resend**: for requests captured with a `sourceDio` provided to the interceptor, you can trigger a "Resend" action in the detail view to replay the request locally using the same Dio client (carrying the same headers, base URL, and interceptors). Replayed requests automatically show up as new entries with a dedicated "Replay" label.
 
 ### Live notification (opt-in)
 

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -19,7 +19,7 @@ import 'inspector_registry.dart';
 /// The core entry point for the Flutter Inspector.
 class FlutterInspector {
   /// Package version.
-  static const String version = '0.2.3';
+  static const String version = '1.0.0';
 
   /// Creates a new FlutterInspector instance.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 0.3.1
+version: 1.0.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
Bump version to 1.0.0 for the release of the Network Request Replay feature (breaking change). Packs the changes implemented in #35 (merged via #36).