### PR TITLE
feat(network): wire redactSensitiveData flag to share/export paths (#38)

### DIFF
--- a/docs/features/2026-06-27-sensitive-data-redaction.md
+++ b/docs/features/2026-06-27-sensitive-data-redaction.md
@@ -1,0 +1,144 @@
+# 功能規格：機敏資料遮罩（Sensitive Data Redaction）
+
+- **日期**：2026-06-27
+- **狀態**：STAGE 0a — 待確認
+- **類型**：功能正規化（既有未 commit 改動）＋ 缺口補完（UI 接線）
+- **特殊性質**：這不是從零設計。`main` branch 上已有一批未追蹤／未 commit 的改動實作了大部分機制（pure module、formatters 參數、core flag），但 **flag 目前是死的（dead field）**。本規格涵蓋「既有改動正規化」＋「補完讓 flag 真正生效的 UI 接線」。
+
+---
+
+## 1. 背景與動機（Why）
+
+`flutter_inspector_kit` 的 Network 詳情頁提供三條分享／匯出路徑（`NetworkDetailView` 的 share `PopupMenuButton`）：
+
+1. **Copy as cURL** — 把一筆請求重組成可執行 cURL 字串，寫進剪貼簿。
+2. **Copy as text** — 把整筆請求／回應導出成純文字，寫進剪貼簿。
+3. **Share…** — 經系統 share sheet 把純文字外送（失敗時退回剪貼簿）。
+
+這三條路徑會把 request／response headers 原封不動帶出去。問題在於 headers 裡常常藏著最敏感的東西：`Authorization: Bearer <token>`、`Cookie: session=...`、`Set-Cookie`、`X-Api-Key`。一旦開發者「複製 cURL 貼到 Slack 問同事」「截圖貼 issue」「share 到群組」，這些 secrets 就跟著外洩——**而且開發者多半不會意識到自己剛把 token 貼出去了**。這是一條安靜的洩漏面。
+
+### 設計核心
+
+> 分享路徑預設就該是安全的。要洩漏 secrets 必須是宿主**明確選擇**的結果，而不是預設行為的副作用。
+
+- **Secure by default**：遮罩預設開啟，宿主要關得顯式 opt-out。
+- **固定佔位字串**：遮罩後以固定字串取代，連「原值多長」都不洩漏。
+- **只動分享路徑，不動畫面顯示**：詳情頁的 headers section 在螢幕上仍照常顯示真實值（開發者本來就需要看），遮罩只發生在「值會離開裝置／進剪貼簿／進截圖文字流」的分享匯出環節。
+
+### 既有改動現況（已實地核對 codebase）
+
+| 檔案 | 狀態 | 現況 |
+|---|---|---|
+| `lib/src/utils/redaction.dart` | **新增（未追蹤）** | pure module，無 Flutter 依賴。提供 `kRedactedValue = '••••'`、`kSensitiveHeaderKeys`（4 key，大小寫不敏感）、`redactHeaders(Map)`（回傳遮罩後副本，不改原 map） |
+| `test/utils/redaction_test.dart` | **新增（未追蹤）** | 已覆蓋 redaction.dart：大小寫、多值 header、非敏感 header 不動、原 map 不被 mutate、保留原 key 大小寫 |
+| `lib/src/utils/network_formatters.dart` | **已修改** | `buildCurl` / `buildPlainText` / `_writeHeaders` 都加了 `{bool redact = true}`，預設 true。redact 時對 headers 套 `redactHeaders` |
+| `test/utils/network_formatters_test.dart` | **已修改** | 已覆蓋 formatters 的 redact 行為 |
+| `lib/src/core/flutter_inspector.dart` | **已修改** | 建構子新增 `final bool redactSensitiveData`（預設 `true`），含文件註解承諾「secrets never leak unless host explicitly opts out」 |
+
+### 🔴 核心缺口：`redactSensitiveData` 是一個死欄位
+
+經實地核對 `lib/src/ui/dashboard/tabs/network/network_detail_view.dart`：
+
+- `_onShare` 的三個呼叫點全部呼叫 `buildCurl(entry)` / `buildPlainText(entry)`，**完全沒有傳入 `redact` 參數**：
+  - line 227：`buildCurl(entry)`
+  - line 232：`buildPlainText(entry)`
+  - line 238：`shareText(buildPlainText(entry))`
+  - line 241：`buildPlainText(entry)`（share 失敗的剪貼簿 fallback）
+- `NetworkDetailView` 是 `StatelessWidget`，建構子只有 `entry`（`const NetworkDetailView({required this.entry, super.key})`），**沒有任何途徑取得 `FlutterInspector` 實例或 `redactSensitiveData` 值**。
+- 結果：`redactSensitiveData` 被宣告、被文件化，但**沒有任何程式碼讀它**。預設遮罩之所以還能生效，純粹是因為 formatters 參數預設 `true`，**與這個 flag 毫無關聯**。宿主設 `redactSensitiveData: false` 想關掉遮罩，會**完全無效**——文件承諾的 opt-out 是假的。
+
+### 資料流可行性（已核對，傳遞鏈現成）
+
+要讓 flag 真正生效，必須把 `redactSensitiveData` 的值送進 `NetworkDetailView` 的呼叫點。核對結果證明這條鏈是現成的，不需要新造任何全域機制：
+
+- `NetworkDetailView` 由 `network_tab.dart:188` 建立：`NetworkDetailView(entry: entry)`。
+- `NetworkTab` 已持有 `widget.inspector`（type `FlutterInspector`，見 `network_tab.dart:11/13`），而 `redactSensitiveData` 是 `FlutterInspector` 的公開欄位。
+- 因此 flag 值可沿 `NetworkTab` → `NetworkDetailView` → `_onShare` 三個呼叫點傳遞，**不需要 `InheritedWidget`、不需要全域 singleton**。
+
+---
+
+## 2. 使用者故事與驗收條件
+
+### US-1：宿主預設就受到保護，分享路徑不洩漏 secrets
+
+> 身為使用此套件的 app 開發者，我希望在沒有特別設定的情況下，從 Network 詳情頁複製 cURL／複製文字／分享出去的內容，敏感 header 就已經被遮罩，這樣我隨手分享也不會把 token 洩漏出去。
+
+**驗收條件：**
+
+- [ ] 在預設設定（`redactSensitiveData == true`）下，**三條分享路徑全部**（Copy as cURL／Copy as text／Share，含 share 失敗的剪貼簿 fallback）輸出的內容中，`Authorization` / `Cookie` / `Set-Cookie` / `X-Api-Key` 的值都被替換為固定佔位字串 `••••`。
+- [ ] 遮罩採固定字串，**不透露原值長度**（不可用 `*` 重複原長度之類的做法）。
+- [ ] header 的 key（名稱）保留原樣，只有 value 被遮；非敏感 header 的 key 與 value 完全不變。
+- [ ] 敏感 key 的比對**大小寫不敏感**（`Authorization` / `authorization` / `AUTHORIZATION` 都被遮）。
+
+### US-2：宿主可顯式 opt-out 取得原始值（且 opt-out 真的生效）
+
+> 身為需要把完整請求（含真實 token）導出去做深度除錯的開發者，我希望能明確關掉遮罩，拿到未遮罩的原始內容；而且這個開關必須真的有效，不能是個裝飾品。
+
+**驗收條件：**
+
+- [ ] 當宿主建構 `FlutterInspector(redactSensitiveData: false)` 時，三條分享路徑輸出的內容**不遮罩**，敏感 header 顯示真實值。
+- [ ] **flag 真的被 UI 呼叫點讀取**：`NetworkDetailView` 的分享呼叫點所用的 `redact` 值，來源是 `FlutterInspector.redactSensitiveData`（而非寫死在 formatters 的預設值）。亦即把 flag 改成 `false` 必須能觀察到輸出差異——這是本功能相對既有改動最關鍵的補完點。
+
+### US-3：開發者在螢幕上仍看得到真實 header 值
+
+> 身為開發者，我在詳情頁本來就是要看真實的 header 內容來除錯，我不希望遮罩讓畫面上的值也被蓋掉變得沒法看。
+
+**驗收條件：**
+
+- [ ] 不論 `redactSensitiveData` 為 true 或 false，`NetworkDetailView` 畫面上的 Request Headers／Response Headers section（`KeyValueTable`）顯示的都是**真實值**，遮罩**不影響**螢幕渲染。
+- [ ] 遮罩只發生在「值會離開裝置／進剪貼簿／進系統 share」的分享匯出路徑。
+
+### US-4：遮罩不破壞既有 Network 功能
+
+> 身為使用者，我希望加入遮罩接線後，詳情頁與既有匯出格式除了「敏感值被遮」之外，行為與輸出結構完全不變。
+
+**驗收條件：**
+
+- [ ] cURL 與純文字匯出的**整體結構**（區段順序、格式、非敏感欄位內容）維持原樣，差異僅限敏感 header 的 value。
+- [ ] Resend 動作不受本功能影響（它走的是重建請求送出，不是分享匯出路徑；其重組仍使用真實 header，否則重送會帶著 `••••` 必然失敗——這點屬範圍邊界，見 §3）。
+- [ ] 既有 `redaction.dart` / `network_formatters.dart` / 對應測試的行為不被回退或弱化。
+
+---
+
+## 3. 範圍邊界（Scope）
+
+### In-Scope
+
+- 正規化既有未 commit 改動：`redaction.dart`（pure module）、`network_formatters.dart`（redact 參數）、`flutter_inspector.dart`（`redactSensitiveData` flag）及其既有測試。
+- **補完 UI 接線（本功能主要工作）**：讓 `redactSensitiveData` 的值流到 `NetworkDetailView` 的三條分享呼叫點，使 flag 真正生效（opt-out 可被觀察到）。
+- **遮罩範圍：只遮 4 個 header key** —— `Authorization` / `Cookie` / `Set-Cookie` / `X-Api-Key`（大小寫不敏感），且只在分享／匯出路徑。
+
+### Out-of-Scope（明確排除）
+
+- **URL query string 內的 token**（例如 `?access_token=...`、`?sig=...`）：本次**不**遮罩。純文字匯出的 `=== Query Parameters ===` 與 cURL 的 URL 都照原樣輸出。列為後續可選迭代。
+- **request／response body 內的敏感欄位**（例如 JSON body 裡的 `password` / `token` / `refresh_token`）：本次**不**遮罩。body 內容照原樣匯出。
+- **畫面顯示遮罩**：詳情頁螢幕上的 headers/body 一律顯示真實值，不在遮罩範圍（見 US-3）。
+- **log／console／database 等其他外洩面**：本功能只處理 Network 詳情頁的分享匯出路徑，不擴及其他 tab 或日誌輸出。
+- **Resend（重送）路徑的遮罩**：重送需要真實 header 才能成功，**不可**遮罩；本功能不改動重送行為。
+- **可設定的敏感 key 清單／自訂遮罩規則**：本次採固定 4 key 清單，不開放宿主自訂。列為後續可選迭代。
+
+---
+
+## 4. 既有改動盤點與缺口
+
+| 項目 | 既有改動是否已具備 | 本功能要做的事 |
+|---|---|---|
+| pure redaction module（`redactHeaders` / 固定佔位字串 / 4 key 清單） | ✅ 已存在（`redaction.dart` + 測試） | 正規化納入本 flow，不需重寫 |
+| formatters redact 參數（secure default `true`） | ✅ 已存在（`network_formatters.dart` + 測試） | 正規化納入本 flow，不需重寫 |
+| `redactSensitiveData` core flag（預設 `true` + 文件承諾） | ✅ 已存在（`flutter_inspector.dart`） | 保留，不做反向改動 |
+| **UI 呼叫點讀取 flag** | 🔴 **缺口（主要工作）** | 把 `redactSensitiveData` 沿 `NetworkTab → NetworkDetailView → _onShare` 傳遞，讓三條分享呼叫點以 flag 值作為 `redact` 參數 |
+| flag 生效的驗證測試（opt-out 可被觀察） | 🔴 **缺口** | 補測試：`false` 時分享路徑輸出未遮罩、`true` 時遮罩（widget／整合層級，覆蓋三條分享路徑） |
+
+> 重點：既有改動已備好「能遮罩」的零件，但少了「把開關接上線」這一步。本功能的價值不在發明新機制，而在**讓既有的、已被文件承諾的開關真正可用**——把一個 dead field 變成 live field。
+
+---
+
+## 5. 規格出口條件
+
+本規格通過確認的標準：
+
+- US-1～US-4 的驗收條件被接受為「可測試、可驗收」。
+- 範圍邊界被確認，特別是：**只遮 header**、URL query／body／其他外洩面與 Resend 路徑明確排除、畫面顯示不遮。
+- 既有改動盤點與「UI 接線為主要缺口」的認定被確認。
+
+確認後進入 STAGE 0b（實作計畫），屆時才細化傳遞鏈的逐檔簽章異動、`NetworkDetailView` 新增參數的形狀、以及 TDD 任務拆解。

--- a/docs/plans/2026-06-27-sensitive-data-redaction.md
+++ b/docs/plans/2026-06-27-sensitive-data-redaction.md
@@ -1,0 +1,276 @@
+# 實作計畫：機敏資料遮罩（Sensitive Data Redaction）UI 接線
+
+- **日期**：2026-06-27
+- **階段**：STAGE 0b — 實作計畫（只寫 How）
+- **對應規格**：`docs/features/2026-06-27-sensitive-data-redaction.md`（source of truth）
+- **性質**：既有未 commit 改動「正規化」＋ UI 接線「缺口補完」。本計畫不重新設計遮罩機制，核心工作是把一個 dead field（`FlutterInspector.redactSensitiveData`）接成 live field。
+
+---
+
+## 1. 資料流 / 傳遞鏈設計
+
+### 1.1 現況（flag 是死的）
+
+```
+FlutterInspector.redactSensitiveData (true, 已文件化)
+        │
+        ✗ 斷點：沒有任何 widget 讀這個值
+        │
+NetworkTab (持有 widget.inspector)
+        │  network_tab.dart:188
+        ▼
+NetworkDetailView(entry: entry)          ← 建構子只有 entry，拿不到 flag
+        │
+        ▼
+_onShare → buildCurl(entry)              ← 沒傳 redact，靠 formatters 預設 true 才碰巧遮罩
+          buildPlainText(entry)          ← 同上
+```
+
+預設之所以還能遮罩，純粹是 formatters 參數預設 `true`，**與 flag 無關**。宿主設 `redactSensitiveData: false` 完全無效。
+
+### 1.2 目標（flag 真正生效）
+
+把 flag 值沿現成的 widget tree 一路傳到 4 個 build 呼叫點。**不需要 InheritedWidget，不需要全域 singleton**——`NetworkTab` 已持有 `widget.inspector`，`redactSensitiveData` 是其公開欄位。
+
+```
+FlutterInspector.redactSensitiveData
+        │
+NetworkTab._NetworkTabState
+        │  widget.inspector.redactSensitiveData
+        ▼
+NetworkDetailView(entry: entry, redactSensitiveData: widget.inspector.redactSensitiveData)
+        │  this.redactSensitiveData
+        ▼
+_onShare → buildCurl(entry, redact: redactSensitiveData)
+          buildPlainText(entry, redact: redactSensitiveData)   × 3 處（text / share / fallback）
+```
+
+### 1.3 逐檔簽章異動（before → after）
+
+#### A. `lib/src/ui/dashboard/tabs/network/network_detail_view.dart`
+
+**建構子**（新增一個有預設值的具名參數，維持向後相容）：
+
+```dart
+// before
+const NetworkDetailView({required this.entry, super.key});
+
+// after
+const NetworkDetailView({
+  required this.entry,
+  this.redactSensitiveData = true,
+  super.key,
+});
+```
+
+**欄位**（新增）：
+
+```dart
+// after（在 `final NetworkEntry entry;` 之後新增一行）
+final NetworkEntry entry;
+
+/// Whether share/export paths mask sensitive headers. Mirrors
+/// [FlutterInspector.redactSensitiveData]. Defaults to `true` (secure by
+/// default) so a NetworkDetailView built without this value still redacts.
+final bool redactSensitiveData;
+```
+
+**`_onShare` 內 4 個呼叫點**（把 flag 作為 `redact` 傳入）：
+
+```dart
+// before → after
+buildCurl(entry)                  → buildCurl(entry, redact: redactSensitiveData)        // line 227
+buildPlainText(entry)             → buildPlainText(entry, redact: redactSensitiveData)   // line 232
+shareText(buildPlainText(entry))  → shareText(buildPlainText(entry, redact: redactSensitiveData))  // line 238
+buildPlainText(entry)             → buildPlainText(entry, redact: redactSensitiveData)   // line 241 (share fail fallback)
+```
+
+> 注意：`_ResendAction._resend` 用的是 `buildReplayRequest(widget.entry)`（line 318），**不經過 buildCurl/buildPlainText、不套 redactHeaders**。Resend 路徑天然不受影響，本計畫不碰它（符合規格 §3 Resend out-of-scope）。
+
+#### B. `lib/src/ui/dashboard/tabs/network_tab.dart`
+
+**建立 NetworkDetailView 處**（line 188）：
+
+```dart
+// before
+MaterialPageRoute(builder: (_) => NetworkDetailView(entry: entry)),
+
+// after
+MaterialPageRoute(
+  builder: (_) => NetworkDetailView(
+    entry: entry,
+    redactSensitiveData: widget.inspector.redactSensitiveData,
+  ),
+),
+```
+
+`_NetworkTabState` 已透過 `widget.inspector` 存取 inspector（見 `network_tab.dart:13/57/118`），不需任何新欄位或依賴注入。
+
+#### C. 不需改動的檔案（僅正規化／納入 commit）
+
+- `lib/src/utils/redaction.dart`（新增、未追蹤）：簽章正確，不改。
+- `lib/src/utils/network_formatters.dart`（已修改）：`buildCurl` / `buildPlainText` / `_writeHeaders` 的 `{bool redact = true}` 已就位，不改。
+- `lib/src/core/flutter_inspector.dart`（已修改）：`redactSensitiveData = true` 欄位與文件註解已就位，不改。
+
+---
+
+## 2. 檔案異動清單
+
+| 檔案 | 類別 | 改什麼 | 為何改 |
+|---|---|---|---|
+| `lib/src/utils/redaction.dart` | 正規化（未追蹤→納入） | 不改內容，僅 `git add` | pure module 已完成且有測試覆蓋 |
+| `lib/src/utils/network_formatters.dart` | 正規化（已改→納入） | 不改內容 | redact 參數已就位且有測試 |
+| `lib/src/core/flutter_inspector.dart` | 正規化（已改→納入） | 不改內容 | flag 欄位＋文件已就位 |
+| `test/utils/redaction_test.dart` | 正規化（未追蹤→納入） | 不改內容 | 已覆蓋 redaction 全行為 |
+| `test/utils/network_formatters_test.dart` | 正規化（已改→納入） | 不改內容 | 已覆蓋 formatters redact true/false |
+| `test/core/flutter_inspector_test.dart` | 正規化（已改→納入） | 不改內容 | 已覆蓋 flag default/opt-out |
+| **`lib/src/ui/dashboard/tabs/network/network_detail_view.dart`** | **接線（新改動）** | 建構子加 `redactSensitiveData = true`、加同名欄位、`_onShare` 4 處傳 `redact:` | 讓 flag 能被分享呼叫點讀取（主要工作） |
+| **`lib/src/ui/dashboard/tabs/network_tab.dart`** | **接線（新改動）** | line 188 建立 NetworkDetailView 時傳 `widget.inspector.redactSensitiveData` | 把 flag 值注入詳情頁 |
+| **`test/ui/tabs/network_detail_view_test.dart`** | **接線（新測試）** | 新增 widget test：opt-out 路徑輸出未遮罩、預設路徑遮罩（覆蓋三條分享路徑） | 補 flag 生效驗證缺口（規格 US-2） |
+
+> 「正規化」六檔在最終 commit 一併納入，內容零改動；implementer 不需動筆，僅確認測試綠燈後一起 commit。真正的程式碼改動只有兩支 lib 檔 + 一支 test 檔。
+
+---
+
+## 3. 任務拆分（TDD）
+
+複雜度分級對照（供 STAGE 2 implementer 選 model）：
+
+- **機械性**：照既定簽章改字面，無設計判斷。
+- **整合**：跨檔接線、需理解既有測試慣例。
+- **設計判斷**：需要做取捨或設計決策。
+
+> 並行限制：T2 與 T3 都寫入 `network_detail_view.dart`，**不可並行**，必須序列。T4（測試）依賴 T2/T3 完成的簽章。T1（正規化驗證）與 T2 互不寫入同檔，可並行。
+
+### T1 — 正規化既有改動：確認 baseline 測試綠燈
+
+- **目標**：確認既有未 commit 改動（redaction / formatters / flag）的測試全綠，建立 baseline，不改任何程式。
+- **驗收條件**：
+  - `flutter test test/utils/redaction_test.dart test/utils/network_formatters_test.dart test/core/flutter_inspector_test.dart` 全綠。
+  - 不對上述 lib/test 檔做任何內容修改。
+- **觸及檔案（寫入 scope）**：無（唯讀驗證）。
+- **複雜度**：機械性。
+- **依賴**：無。可與 T2 並行。
+
+### T2 — `NetworkDetailView` 接受並傳遞 flag（含 TDD 測試先行）
+
+- **目標**：`NetworkDetailView` 新增 `redactSensitiveData`（預設 `true`）建構子參數與欄位，`_onShare` 4 個呼叫點以該值作 `redact`。
+- **TDD 順序**：
+  1. 先在 `network_detail_view_test.dart` 寫一個 failing widget test：建構 `NetworkDetailView(entry: <含 Authorization 的 entry>, redactSensitiveData: false)`，點 Copy as cURL，斷言 clipboard 內含原始 token（未遮罩）。此測試在改 code 前必失敗（目前無此參數，編譯不過 = red）。
+  2. 改 `network_detail_view.dart` 讓測試轉綠。
+- **驗收條件**：
+  - 建構子簽章為 `const NetworkDetailView({required this.entry, this.redactSensitiveData = true, super.key});`。
+  - `_onShare` 的 curl / text / share / fallback 4 處皆傳 `redact: redactSensitiveData`。
+  - 新增的 opt-out widget test 綠燈；既有 `network_detail_view_test.dart` 既有測試（renders all sections、copy as cURL、Resend 群組）全部維持綠燈。
+- **觸及檔案（寫入 scope）**：`lib/src/ui/dashboard/tabs/network/network_detail_view.dart`、`test/ui/tabs/network_detail_view_test.dart`。
+- **複雜度**：整合（需懂既有 widget test 的 clipboard mock 慣例與 PopupMenuButton 點擊流程）。
+- **依賴**：無。與 T1 並行；**必須在 T3 之前**（兩者同寫 detail_view，序列）。
+
+### T3 — `NetworkTab` 注入 flag 值
+
+- **目標**：`network_tab.dart:188` 建立 `NetworkDetailView` 時傳 `redactSensitiveData: widget.inspector.redactSensitiveData`。
+- **驗收條件**：
+  - line 188 的 builder 改為帶 `redactSensitiveData: widget.inspector.redactSensitiveData`。
+  - `flutter test test/ui/tabs/network_tab_test.dart` 綠燈（既有 `findsOneWidget` 導航測試不受影響）。
+- **觸及檔案（寫入 scope）**：`lib/src/ui/dashboard/tabs/network_tab.dart`。
+- **複雜度**：機械性。
+- **依賴**：依賴 T2（NetworkDetailView 新參數需先存在，否則編譯不過）。**不可與 T2 並行**（雖寫不同檔，但編譯相依）。
+
+### T4 — 預設遮罩路徑的端到端驗證測試
+
+- **目標**：補一個 widget test 證明預設（`redactSensitiveData` 省略 = `true`）下，三條分享路徑輸出皆遮罩，鎖住 US-1 行為。
+- **TDD 順序**：先寫測試（在 T2 改完簽章後，此測試應直接綠燈，作為 regression guard）；若不綠則回查接線。
+- **驗收條件**：
+  - 新測試：`NetworkDetailView(entry: <含 Authorization/Cookie 的 entry>)`（不帶 redactSensitiveData），分別觸發 Copy as cURL 與 Copy as text，斷言 clipboard 內容含 `••••`、不含原始 secret。
+  - 對 share 路徑：可斷言 Copy as text fallback 行為（避免依賴平台 share sheet），或以 `buildPlainText` 既有 unit 覆蓋為準（見 §4，share 與 text 共用同一格式化函式，不重複造輪子）。
+- **觸及檔案（寫入 scope）**：`test/ui/tabs/network_detail_view_test.dart`。
+- **複雜度**：整合。
+- **依賴**：依賴 T2（簽章與接線需就位）。與 T3 可並行（寫不同檔、且 T4 不依賴 NetworkTab）。
+
+### 任務依賴圖
+
+```
+T1 (唯讀驗證) ─┐
+               ├─ 可並行
+T2 (detail_view: 簽章+opt-out test) ─┬─→ T3 (network_tab 注入)   ┐
+                                     └─→ T4 (預設遮罩 regression) ┴─ T3/T4 可並行
+```
+
+序列關鍵路徑：**T2 → T3**（同碼相依）。T1 全程可獨立並行；T4 可與 T3 並行。
+
+---
+
+## 4. 測試策略
+
+### 4.1 已覆蓋、不重寫
+
+- **redaction.dart**：`redaction_test.dart` 已覆蓋大小寫、多值、非敏感不動、不 mutate、保留 key 大小寫。→ 不動。
+- **formatters 的 redact 開關**：`network_formatters_test.dart` 已覆蓋 `buildCurl` / `buildPlainText` 在 `redact: true`（預設遮）與 `redact: false`（不遮）兩條。→ 不動。
+- **flag 欄位本身**：`flutter_inspector_test.dart` 已覆蓋 default true 與 explicit false。→ 不動。
+
+這三層已證明「能遮罩」與「開關參數有效」。本功能的測試缺口**只在 UI 接線**：flag 是否真的被讀取、opt-out 是否可觀察。
+
+### 4.2 新缺口的測試層級建議
+
+採 **widget test**，理由與專案慣例對齊：
+
+- 既有 `network_detail_view_test.dart` 已用 widget test + `SystemChannels.platform` 的 `Clipboard.setData` mock 攔截剪貼簿輸出（line 82-105），這正是觀察「分享輸出內容」最直接的手段。沿用同一 pattern 即可，不需新基礎建設。
+- `_onShare` 是 `NetworkDetailView` 的私有方法，**不建議**為了測試把它抽成 top-level 函式——那會為了測試破壞封裝，且 widget test 已能透過點擊 PopupMenuItem + clipboard mock 完整觀察其輸出，沒有抽函式的必要（YAGNI）。
+
+具體新增測試（都放 `test/ui/tabs/network_detail_view_test.dart`）：
+
+1. **opt-out 可觀察**（US-2，屬 T2）：`redactSensitiveData: false` + Copy as cURL → clipboard 含原始 `Bearer secret-token`。
+2. **預設遮罩 cURL**（US-1，屬 T4）：省略參數 + Copy as cURL → clipboard 含 `Authorization: ••••`、不含 token。
+3. **預設遮罩 text**（US-1，屬 T4）：省略參數 + Copy as text → clipboard 含 `••••`、不含 secret。
+
+> share 路徑（`_ShareAction.share`）呼叫 `shareText`（平台 channel），在 widget test 難以穩定攔截系統 share sheet。它與 Copy as text 共用 `buildPlainText(entry, redact: redactSensitiveData)`，redact 行為已由 formatters unit test + 上述 text widget test 雙重覆蓋；**不需**為 share 再造平台 mock（避免脆弱測試）。share fallback（line 241）走的也是同一條 `buildPlainText`，行為等價。
+
+### 4.3 回歸保護
+
+- 既有 `network_detail_view_test.dart` 的 `copy as cURL writes to clipboard`、`renders all sections`、整個 `Resend action` group 必須維持綠燈——驗證接線未破壞既有行為（US-4）。
+- 新參數有預設值 `true`，既有測試呼叫 `NetworkDetailView(entry: ...)` 不需修改即可編譯（向後相容，見 §5）。
+
+---
+
+## 5. 風險與破壞性分析
+
+### 5.1 既有呼叫端會不會被破壞？
+
+`NetworkDetailView` 目前有 5 個呼叫端：
+
+- `network_tab.dart:188`（lib，T3 會更新）。
+- `test/ui/tabs/network_detail_view_test.dart` 共 4 處（line 55、71、95，及 `pumpView` 內）。
+
+**對策：新參數 `redactSensitiveData` 給預設值 `true`**。所有既有 `NetworkDetailView(entry: ...)` 呼叫無需修改即可繼續編譯與通過——零破壞。這同時維持 secure-by-default：即使某呼叫端忘了傳 flag，也是「遮罩」這個安全側。
+
+### 5.2 secure-by-default 是否維持？
+
+維持。三道預設都站在「遮罩」一側：
+
+- `FlutterInspector.redactSensitiveData = true`（core 預設）。
+- `NetworkDetailView.redactSensitiveData = true`（新建構子預設）。
+- `buildCurl/buildPlainText/_writeHeaders` 的 `redact = true`（formatters 預設）。
+
+唯一能關閉的途徑是宿主顯式 `FlutterInspector(redactSensitiveData: false)`，符合規格「opt-out 必須是明確選擇」。
+
+### 5.3 Resend 路徑會不會被誤遮？
+
+不會。`_ResendAction._resend`（line 308-349）用 `buildReplayRequest(widget.entry)` 取得 `req.headers`（原始 header），直接送 `dio.request`，**完全不經過 `redactHeaders` / `buildCurl` / `buildPlainText`**。本計畫不碰 `_ResendAction`，Resend 永遠用真實 header（否則重送會帶 `••••` 必然失敗）。符合規格 §3 Resend out-of-scope 與 US-4 驗收條件。
+
+### 5.4 範圍邊界守則（不擴張）
+
+- **只遮 4 個 header key**，URL query / request body / response body 一律照原樣輸出——本計畫不新增任何 body/query 遮罩邏輯。
+- 畫面顯示（`KeyValueTable`）不動，螢幕永遠顯示真實值（US-3）。`NetworkDetailView.build` 內的 headers section（line 54-70）不在改動範圍。
+- 不開放自訂敏感 key 清單。
+
+### 5.5 殘餘風險
+
+- **低**：share 路徑無直接 widget 斷言（靠共用 `buildPlainText` 的間接覆蓋）。可接受——避免引入脆弱的平台 channel mock，且 formatters unit test 已直接驗證 `buildPlainText` 的 redact 行為。
+- **低**：若未來有人新增第三條走 `buildReplayRequest` 以外的分享路徑而忘了傳 `redact`，formatters 預設 `true` 仍會兜底遮罩，不會洩漏。
+
+---
+
+## 6. 執行方式選項
+
+- **subagent-driven（建議）**：T1 + T2 第一波並行（T1 唯讀、T2 寫 detail_view，不衝突）；T2 完成後 T3 + T4 第二波並行（寫不同檔）。關鍵序列僅 T2→T3。整體 2 波即可收斂。
+- **parallel session**：因 T2/T3/T4 都圍繞同一條接線且 T3 編譯相依 T2，平行 session 收益有限，反而增加 detail_view 檔的合併衝突風險。除非要把「正規化納入 commit（T1 範疇）」與「接線（T2-T4）」拆給兩個人，否則單 session 序列執行更穩。

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -32,10 +32,12 @@ class FlutterInspector {
     this.showNetworkNotification = false,
     this.navigatorKey,
     this.captureUncaughtErrors = false,
+    this.redactSensitiveData = true,
     int bufferSize = 500,
     NetworkNotifier? notifier,
     List<DatabaseBrowserSource>? databaseSources,
-  }) : _registry = InspectorRegistry(bufferSize: bufferSize) {
+  }) {
+    _registry = InspectorRegistry(bufferSize: bufferSize);
     if (captureUncaughtErrors) setupErrorHandlers();
     _navigatorObserver = FlutterInspectorNavigatorObserver(this);
     _operationLogSource = OperationLogSource(_registry.database);
@@ -107,13 +109,20 @@ class FlutterInspector {
   ///   are kept solely to chain to, not to restore.
   final bool captureUncaughtErrors;
 
+  /// Whether to mask sensitive headers (e.g. `Authorization`, `Cookie`,
+  /// `Set-Cookie`, `X-Api-Key`) in all share/export paths (cURL, plain text).
+  ///
+  /// Defaults to `true` so secrets never leak to the clipboard, a share sheet,
+  /// or a screenshot unless the host explicitly opts out.
+  final bool redactSensitiveData;
+
   FlutterExceptionHandler? _oldFlutterErrorHandler;
   bool Function(Object, StackTrace)? _oldPlatformDispatcherOnError;
   bool _uncaughtErrorHandlersAttached = false;
 
   NetworkNotifier? _notifier;
 
-  final InspectorRegistry _registry;
+  late final InspectorRegistry _registry;
   late final FlutterInspectorNavigatorObserver _navigatorObserver;
   late final OperationLogSource _operationLogSource;
   final List<DatabaseBrowserSource> _customDatabaseSources = [];
@@ -263,10 +272,7 @@ class FlutterInspector {
     };
   }
 
-  void _logFlutterError(
-    FlutterErrorDetails details, {
-    required String source,
-  }) {
+  void _logFlutterError(FlutterErrorDetails details, {required String source}) {
     final data = <String, dynamic>{
       'source': source,
       'exceptionType': details.exception.runtimeType.toString(),

--- a/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
@@ -13,9 +13,18 @@ enum _ShareAction { curl, text, share }
 /// A full-screen, structured view of a single [NetworkEntry], showing request
 /// and response sections plus sharing (cURL / plain text / system share).
 class NetworkDetailView extends StatelessWidget {
-  const NetworkDetailView({required this.entry, super.key});
+  const NetworkDetailView({
+    required this.entry,
+    this.redactSensitiveData = true,
+    super.key,
+  });
 
   final NetworkEntry entry;
+
+  /// Whether share/export paths mask sensitive headers. Mirrors
+  /// [FlutterInspector.redactSensitiveData]. Defaults to `true` (secure by
+  /// default) so a NetworkDetailView built without this value still redacts.
+  final bool redactSensitiveData;
 
   @override
   Widget build(BuildContext context) {
@@ -224,21 +233,31 @@ class NetworkDetailView extends StatelessWidget {
     final messenger = ScaffoldMessenger.of(context);
     switch (action) {
       case _ShareAction.curl:
-        await Clipboard.setData(ClipboardData(text: buildCurl(entry)));
+        await Clipboard.setData(
+          ClipboardData(text: buildCurl(entry, redact: redactSensitiveData)),
+        );
         messenger.showSnackBar(
           const SnackBar(content: Text('cURL copied to clipboard')),
         );
       case _ShareAction.text:
-        await Clipboard.setData(ClipboardData(text: buildPlainText(entry)));
+        await Clipboard.setData(
+          ClipboardData(
+            text: buildPlainText(entry, redact: redactSensitiveData),
+          ),
+        );
         messenger.showSnackBar(
           const SnackBar(content: Text('Details copied to clipboard')),
         );
       case _ShareAction.share:
         try {
-          await shareText(buildPlainText(entry));
+          await shareText(buildPlainText(entry, redact: redactSensitiveData));
         } catch (_) {
           // Fallback to clipboard when the platform has no share sheet.
-          await Clipboard.setData(ClipboardData(text: buildPlainText(entry)));
+          await Clipboard.setData(
+            ClipboardData(
+              text: buildPlainText(entry, redact: redactSensitiveData),
+            ),
+          );
           messenger.showSnackBar(
             const SnackBar(
               content: Text('Share unavailable — copied to clipboard'),

--- a/lib/src/ui/dashboard/tabs/network_tab.dart
+++ b/lib/src/ui/dashboard/tabs/network_tab.dart
@@ -185,7 +185,12 @@ class _NetworkTabState extends State<NetworkTab> {
       ),
       trailing: const Icon(Icons.chevron_right, size: 18),
       onTap: () => Navigator.of(context).push(
-        MaterialPageRoute(builder: (_) => NetworkDetailView(entry: entry)),
+        MaterialPageRoute(
+          builder: (_) => NetworkDetailView(
+            entry: entry,
+            redactSensitiveData: widget.inspector.redactSensitiveData,
+          ),
+        ),
       ),
     );
   }

--- a/lib/src/utils/network_formatters.dart
+++ b/lib/src/utils/network_formatters.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import '../models/network_entry.dart';
+import 'redaction.dart';
 
 /// Pure formatting helpers for the Network inspector. No Flutter dependencies,
 /// so everything here is unit-testable in isolation.
@@ -68,12 +69,17 @@ String prettyJson(String? body) {
 }
 
 /// Builds an executable `curl` command reproducing [entry]'s request.
-String buildCurl(NetworkEntry entry) {
+///
+/// When [redact] is true (the secure default), sensitive request headers
+/// (see [redactHeaders]) are masked before serialisation.
+String buildCurl(NetworkEntry entry, {bool redact = true}) {
   final req = buildReplayRequest(entry);
   final buffer = StringBuffer('curl');
   buffer.write(" -X ${req.method.toUpperCase()}");
 
-  final headers = req.headers;
+  final headers = redact && req.headers != null
+      ? redactHeaders(req.headers!)
+      : req.headers;
   if (headers != null) {
     for (final h in headers.entries) {
       final value = h.value?.toString().replaceAll("'", r"'\''") ?? '';
@@ -94,7 +100,10 @@ String buildCurl(NetworkEntry entry) {
 
 /// Builds a full plain-text export of [entry] covering general info, request,
 /// response, and error sections.
-String buildPlainText(NetworkEntry entry) {
+///
+/// When [redact] is true (the secure default), sensitive request/response
+/// headers (see [redactHeaders]) are masked before serialisation.
+String buildPlainText(NetworkEntry entry, {bool redact = true}) {
   final b = StringBuffer()
     ..writeln('=== General ===')
     ..writeln('Method: ${entry.method}')
@@ -112,7 +121,7 @@ String buildPlainText(NetworkEntry entry) {
   }
 
   b.writeln('\n=== Request Headers ===');
-  _writeHeaders(b, entry.requestHeaders);
+  _writeHeaders(b, entry.requestHeaders, redact: redact);
   if (entry.requestBody != null && entry.requestBody!.isNotEmpty) {
     b
       ..writeln('\n=== Request Body ===')
@@ -122,7 +131,7 @@ String buildPlainText(NetworkEntry entry) {
   }
 
   b.writeln('\n=== Response Headers ===');
-  _writeHeaders(b, entry.responseHeaders);
+  _writeHeaders(b, entry.responseHeaders, redact: redact);
   if (entry.responseBody != null && entry.responseBody!.isNotEmpty) {
     b
       ..writeln('\n=== Response Body ===')
@@ -142,10 +151,15 @@ String buildPlainText(NetworkEntry entry) {
   return b.toString().trimRight();
 }
 
-void _writeHeaders(StringBuffer b, Map<String, dynamic>? headers) {
+void _writeHeaders(
+  StringBuffer b,
+  Map<String, dynamic>? headers, {
+  bool redact = true,
+}) {
   if (headers == null || headers.isEmpty) {
     b.writeln('(none)');
     return;
   }
-  headers.forEach((k, v) => b.writeln('$k: $v'));
+  final shown = redact ? redactHeaders(headers) : headers;
+  shown.forEach((k, v) => b.writeln('$k: $v'));
 }

--- a/lib/src/utils/redaction.dart
+++ b/lib/src/utils/redaction.dart
@@ -1,0 +1,27 @@
+// Pure redaction helpers for sensitive network data. No Flutter dependencies,
+// so everything here is unit-testable in isolation.
+
+/// Placeholder substituted for a sensitive header value. A fixed string so it
+/// leaks neither the value nor its length.
+const String kRedactedValue = '••••';
+
+/// Header keys whose values are masked, compared case-insensitively.
+const Set<String> kSensitiveHeaderKeys = {
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+};
+
+/// Returns a copy of [headers] with the values of any sensitive keys
+/// (see [kSensitiveHeaderKeys], matched case-insensitively) replaced by
+/// [kRedactedValue]. Non-sensitive entries and the original key casing are
+/// preserved. The input map is never mutated.
+Map<String, dynamic> redactHeaders(Map<String, dynamic> headers) {
+  return headers.map((key, value) {
+    if (kSensitiveHeaderKeys.contains(key.toLowerCase())) {
+      return MapEntry(key, kRedactedValue);
+    }
+    return MapEntry(key, value);
+  });
+}

--- a/test/core/flutter_inspector_test.dart
+++ b/test/core/flutter_inspector_test.dart
@@ -51,6 +51,16 @@ void main() {
       final observer = inspector.navigatorObserver;
       expect(observer, isNotNull);
     });
+
+    test('redactSensitiveData defaults to true (secure by default)', () {
+      final inspector = FlutterInspector();
+      expect(inspector.redactSensitiveData, isTrue);
+    });
+
+    test('redactSensitiveData can be disabled explicitly', () {
+      final inspector = FlutterInspector(redactSensitiveData: false);
+      expect(inspector.redactSensitiveData, isFalse);
+    });
   });
 
   group('Database Browser Sources API', () {

--- a/test/ui/tabs/network_detail_view_test.dart
+++ b/test/ui/tabs/network_detail_view_test.dart
@@ -103,6 +103,158 @@ void main() {
       expect(clipboardText, isNotNull);
       expect(clipboardText!.startsWith('curl -X POST'), isTrue);
     });
+
+    testWidgets(
+        'opt-out: redactSensitiveData false leaves Authorization unmasked in cURL',
+        (tester) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+
+      final entry = NetworkEntry(
+        method: 'POST',
+        url: 'https://api.test/users?page=2',
+        statusCode: 201,
+        duration: const Duration(milliseconds: 120),
+        requestHeaders: {
+          'Authorization': 'Bearer secret-token-123',
+          'Content-Type': 'application/json',
+        },
+        requestBody: '{"name":"x"}',
+        responseHeaders: {'content-type': 'application/json'},
+        responseBody: '{"id":1}',
+        isComplete: true,
+        timestamp: t,
+      );
+
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NetworkDetailView(entry: entry, redactSensitiveData: false),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.share));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Copy as cURL'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, isNotNull);
+      expect(clipboardText, contains('secret-token-123'));
+      expect(clipboardText, isNot(contains('••••')));
+    });
+
+    testWidgets(
+        'default: redactSensitiveData omitted masks Authorization in cURL',
+        (tester) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+
+      final entry = NetworkEntry(
+        method: 'POST',
+        url: 'https://api.test/users?page=2',
+        statusCode: 201,
+        duration: const Duration(milliseconds: 120),
+        requestHeaders: {
+          'Authorization': 'Bearer secret-token-123',
+          'Content-Type': 'application/json',
+        },
+        requestBody: '{"name":"x"}',
+        responseHeaders: {'content-type': 'application/json'},
+        responseBody: '{"id":1}',
+        isComplete: true,
+        timestamp: t,
+      );
+
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(home: NetworkDetailView(entry: entry)),
+      );
+
+      await tester.tap(find.byIcon(Icons.share));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Copy as cURL'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, isNotNull);
+      expect(clipboardText, contains('••••'));
+      expect(clipboardText, isNot(contains('secret-token-123')));
+    });
+
+    testWidgets(
+        'default: redactSensitiveData omitted masks Authorization and Cookie '
+        'in text',
+        (tester) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+
+      final entry = NetworkEntry(
+        method: 'POST',
+        url: 'https://api.test/users?page=2',
+        statusCode: 201,
+        duration: const Duration(milliseconds: 120),
+        requestHeaders: {
+          'Authorization': 'Bearer secret-token-123',
+          'Cookie': 'session=abc-secret',
+          'Content-Type': 'application/json',
+        },
+        requestBody: '{"name":"x"}',
+        responseHeaders: {'content-type': 'application/json'},
+        responseBody: '{"id":1}',
+        isComplete: true,
+        timestamp: t,
+      );
+
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(home: NetworkDetailView(entry: entry)),
+      );
+
+      await tester.tap(find.byIcon(Icons.share));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Copy as text'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, isNotNull);
+      expect(clipboardText, contains('••••'));
+      expect(clipboardText, isNot(contains('secret-token-123')));
+      expect(clipboardText, isNot(contains('session=abc-secret')));
+    });
   });
 
   group('statusColorFor', () {

--- a/test/utils/network_formatters_test.dart
+++ b/test/utils/network_formatters_test.dart
@@ -87,6 +87,62 @@ void main() {
     });
   });
 
+  group('buildCurl redaction', () {
+    test('masks sensitive request headers by default', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/items',
+        requestHeaders: {
+          'Authorization': 'Bearer secret-token',
+          'Accept': 'application/json',
+        },
+        timestamp: fixedTime,
+      );
+      final curl = buildCurl(entry);
+      expect(curl.contains('secret-token'), isFalse);
+      expect(curl.contains("-H 'Authorization: ••••'"), isTrue);
+      expect(curl.contains("-H 'Accept: application/json'"), isTrue);
+    });
+
+    test('keeps raw sensitive headers when redact is disabled', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/items',
+        requestHeaders: {'Authorization': 'Bearer secret-token'},
+        timestamp: fixedTime,
+      );
+      final curl = buildCurl(entry, redact: false);
+      expect(curl.contains("-H 'Authorization: Bearer secret-token'"), isTrue);
+    });
+  });
+
+  group('buildPlainText redaction', () {
+    test('masks sensitive request and response headers by default', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/items',
+        requestHeaders: {'Cookie': 'session=abc'},
+        responseHeaders: {'Set-Cookie': 'session=abc; HttpOnly'},
+        timestamp: fixedTime,
+      );
+      final text = buildPlainText(entry);
+      expect(text.contains('session=abc'), isFalse);
+      expect(text.contains('Cookie: ••••'), isTrue);
+      expect(text.contains('Set-Cookie: ••••'), isTrue);
+    });
+
+    test('keeps raw sensitive headers when redact is disabled', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/items',
+        requestHeaders: {'Cookie': 'session=abc'},
+        timestamp: fixedTime,
+      );
+      final text = buildPlainText(entry, redact: false);
+      expect(text.contains('Cookie: session=abc'), isTrue);
+    });
+  });
+
   group('buildPlainText', () {
     test('includes general, request, response and error sections', () {
       final entry = NetworkEntry(

--- a/test/utils/redaction_test.dart
+++ b/test/utils/redaction_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_inspector_kit/src/utils/redaction.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('redactHeaders', () {
+    test('masks Authorization regardless of case', () {
+      expect(
+        redactHeaders({'Authorization': 'Bearer secret'}),
+        {'Authorization': '••••'},
+      );
+      expect(
+        redactHeaders({'authorization': 'Bearer secret'}),
+        {'authorization': '••••'},
+      );
+      expect(
+        redactHeaders({'AUTHORIZATION': 'Bearer secret'}),
+        {'AUTHORIZATION': '••••'},
+      );
+    });
+
+    test('masks cookie, set-cookie and x-api-key', () {
+      expect(
+        redactHeaders({
+          'Cookie': 'session=abc',
+          'Set-Cookie': 'session=abc; HttpOnly',
+          'X-Api-Key': 'k-123',
+        }),
+        {
+          'Cookie': '••••',
+          'Set-Cookie': '••••',
+          'X-Api-Key': '••••',
+        },
+      );
+    });
+
+    test('leaves non-sensitive headers untouched', () {
+      expect(
+        redactHeaders({
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'X-Request-Id': 'r-1',
+        }),
+        {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'X-Request-Id': 'r-1',
+        },
+      );
+    });
+
+    test('masks the value even when it is a list (multi-value header)', () {
+      expect(
+        redactHeaders({
+          'Set-Cookie': ['a=1', 'b=2'],
+          'Accept': ['application/json', 'text/plain'],
+        }),
+        {
+          'Set-Cookie': '••••',
+          'Accept': ['application/json', 'text/plain'],
+        },
+      );
+    });
+
+    test('preserves the original key casing of redacted entries', () {
+      final result = redactHeaders({'CooKie': 'session=abc'});
+      expect(result.keys, ['CooKie']);
+      expect(result['CooKie'], '••••');
+    });
+
+    test('does not mutate the input map', () {
+      final input = {'Authorization': 'Bearer secret'};
+      redactHeaders(input);
+      expect(input, {'Authorization': 'Bearer secret'});
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- `FlutterInspector.redactSensitiveData` 原本是 dead field——文件承諾可 opt-out 機敏資料遮罩，實際上從未接到任何輸出路徑，等同無效。此 PR 完整接線，讓開關真正生效。
- 新增純函式 redaction module，對 4 個固定 header key（`Authorization`、`Cookie`、`Set-Cookie`、`X-Api-Key`）以定長 placeholder `••••` 遮罩，連原值長度都不洩漏。
- Secure by default：`redactSensitiveData` 預設 `true`，要看到原始值必須宿主顯式 opt-out；既有整合零改動。

## 修正的問題

Issue #38：宿主設 `FlutterInspector(redactSensitiveData: false)` 對 share/export 輸出完全無效——cURL snippet、純文字匯出、系統分享都照樣輸出明文 header。預設遮罩之所以還能生效，純粹靠 `network_formatters` 的參數預設 `true`，與這個 flag 毫無關聯。

## 修正方式

**Commit 1 — redaction primitives**（`ae37f5c`）

- 新增 `lib/src/utils/redaction.dart`：`redactHeaders()` 純函式，回傳遮罩後副本、不 mutate 原 map、只處理 header（不碰 URL/body）。
- `buildCurl` / `buildPlainText`（`network_formatters.dart`）加入 `redact` 參數（預設 `true`），遮罩走 `redactHeaders()`。
- `FlutterInspector` 的 `redactSensitiveData` flag 補上文件註解。
- 既有測試正規化納入：`redaction_test.dart`、`network_formatters_test.dart`、`flutter_inspector_test.dart`。

**Commit 2 — UI 接線**（`dcc33f2`）

- `NetworkDetailView` 建構子新增 `redactSensitiveData`（預設 `true`），傳入 `_onShare` 4 個 share/export 呼叫點的 `redact` 參數。
- `NetworkTab` 建構 `NetworkDetailView` 時注入 `widget.inspector.redactSensitiveData`，完成端到端串接（沿現成 widget tree，不需 InheritedWidget / singleton）。
- 新增 widget tests：驗證 opt-out 可觀察（設 `false` → 輸出含原始 token）、預設路徑仍遮罩（含 cURL 與純文字兩條）。
- Resend 路徑（`buildReplayRequest`）刻意排除——重送需要真實 header，行為不變。

## 範圍邊界（Out of scope）

| 項目 | 原因 |
|------|------|
| URL query string 內的 token | 不在 #38 範圍 |
| Request / response body 敏感欄位 | 不在 #38 範圍 |
| Resend 路徑 | 需要真實 header 才能重送成功，設計決策 |
| 畫面顯示層（詳情頁 KeyValueTable） | 開發者需看真實值，遮罩只在分享/匯出路徑 |
| 可設定的自訂敏感 key 清單 | 維持固定 4 key |

## 驗證

- `flutter analyze`（10 個改動檔）：0 issues
- 相關測試 52/52 綠（已避開既有 magical_tap_test timeout），含 opt-out 可觀察性測試
- 本 PR 新增 / 擴充測試共 +294 行，覆蓋三個層次：純函式邊界（大小寫、不 mutate、多值）、formatter redact flag（true/false）、widget-level opt-out 與預設遮罩

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
