### PR TITLE
feat(console): merge all inspector buffers into a cross-layer timeline (#40)

### DIFF
--- a/docs/features/2026-06-26-console-merged-timeline.md
+++ b/docs/features/2026-06-26-console-merged-timeline.md
@@ -1,0 +1,149 @@
+# 功能規格：Console 升級為跨層混合時序軸（Cross-Layer Merged Timeline）
+
+- **日期**：2026-06-26
+- **狀態**：STAGE 0a — 待確認（設計已定稿，無待拍板的開放問題）
+- **來源**：`docs/brainstorm/2026-06-25-features-brainstorm.md` 的 #2（跨 Inspector 時序關聯，現況「⬜ 未實作，現僅有 nav/network 鏡射到 console log 的廉價替代」）與 #5（ConsoleTab 排查化）
+- **類型**：既有功能升級（Console tab 的呈現模型重構 + 移除複製式鏡射）
+
+---
+
+## 1. 功能概述（What & Why）
+
+### 一句話本質
+
+Console 不再靠「把事件複製成字串塞進 log buffer」來假裝呈現綜合情境，改成**在渲染當下讀取四個 buffer（log / network / nav / db）、按 `timestamp` merge-sort、引用原 entry 顯示**。預設顯示 All（四種混合）。
+
+### 為什麼要做（Why，已查證的現況事實）
+
+現況的 Console 其實已經在「假裝」做混合軸，但用的是劣化版做法——把其他層的事件**複製成字串**塞進 log buffer：
+
+- `lib/src/interceptors/dio_interceptor.dart`：每筆 network 請求在 `onResponse`、`onError` 各額外塞一條 `LogLevel.debug` 字串 log 進 console buffer（已核對：`onResponse` 與 `onError` 各一處 `_inspector.log(...)`）。
+- `lib/src/observers/navigator_observer.dart`：每次 push / pop / replace / remove 都額外塞一條 `LogLevel.warning` 字串 log 進 console buffer（已核對：`_record()` 內一處 `_inspector.log(..., level: LogLevel.warning)`，且 class doc 明白寫著這是刻意「mirroring the interceptor」的設計）。
+- database 操作則**完全沒有鏡射**（已核對：`FlutterInspector.database()` 只寫 `_registry.database`，無任何 `log()` 呼叫），所以「綜合情境」一直缺 db 那一塊。
+
+這個複製式做法有三個必須解決的問題：
+
+1. **第二份真相**：複製的是字串快照。network entry 後續會由 pending 更新為 completed（`logNetwork(entry, replaces: pending)`），但 console 那份字串快照不會跟著更新，導致兩份對不上；而且點進去也看不到完整結構（network 的 headers / body、nav 的 arguments、db 的 rows）。
+2. **偽造 level**：nav 事件用 `LogLevel.warning` 純粹是為了在 Console 有顏色，污染了真實的 level 語意。使用者想撈真正的 warning 時，會撈到一堆 navigation 雜訊。
+3. **吃 buffer 配額**：四個 inspector 各自獨立、各 500 格（已核對 `InspectorRegistry`：四個 inspector 都以同一 `bufferSize` 建立），但複製式做法把 network + nav 的字串灌進 log buffer，把真正的 error log 擠出 500 格的視窗，反而看不到完整情境。
+
+### 設計核心（已定稿）
+
+> 混合只發生在「渲染讀取」當下，不發生在「寫入」當下。Console 不再擁有第二份資料，而是**引用四個既有 buffer 的原始 entry**，按 `timestamp` 排序後攤在同一條軸上。
+
+這同時對齊了 brainstorm 的品味守則：「只是指標包裝（指向既有 entry），不複製資料、不引入第二份真相。」
+
+四個 model 都已具備排序所需的 `timestamp` 欄位（已核對：`LogEntry` / `NetworkEntry` / `NavigatorEntry` / `DatabaseEntry` 皆有 `final DateTime timestamp`），因此 merge-sort 的排序鍵天然存在，無需新增欄位。
+
+---
+
+## 2. 使用者故事與驗收條件
+
+> 以排查場景為主：開發者 / QA 如何用這條時序軸定位「跨層」問題。
+
+### US-1：開發者用一條軸看清「故障前後到底發生了什麼」
+
+> 身為開發者，當某個操作出錯時，我希望在同一個 Console tab 裡，按時間順序看到「使用者點了什麼（nav）→ 發了什麼 API（network）→ 印了什麼 log → 做了什麼 db 操作」，而不必在四個孤立的 tab 之間用肉眼對時間戳。
+
+**驗收條件：**
+
+- [ ] Console tab 預設顯示 All：同時呈現 log / network / nav / db 四種來源的事件。
+- [ ] 所有來源的事件以單一時間順序（依各 entry 的 `timestamp`）交錯排列在同一個清單中，使用者能直接讀出跨層事件的先後關係。
+- [ ] 每一列能被辨識出它的來源類別（log / network / nav / db），使用者一眼分得出這列是哪一層的事件。
+
+### US-2：開發者點任一事件都能看到「完整且最新」的詳情
+
+> 身為開發者，當我在時序軸上看到一筆 network 請求時，我希望點進去看到的是完整的 headers / body / 狀態，而且是它最新的狀態（pending 已更新為 completed），不是一張過時的字串快照。
+
+**驗收條件：**
+
+- [ ] 時序軸上的每一列**引用原始 entry**，而非字串快照；點擊可進入該來源既有的詳情呈現（network 看 headers / body、nav 看 arguments、db 看 rows、log 看 stackTrace / data）。
+- [ ] 當某筆 network entry 由 pending 更新為 completed 後，下一次渲染時序軸時，該列反映的是更新後的最新狀態（不存在「軸上一份、詳情頁另一份」的對不上）。
+
+### US-3：QA 在不被雜訊干擾的情況下只看某一層
+
+> 身為 QA，當我只想專注看 API 流量（或只看 navigation、只看 error log）時，我希望能一鍵切換來源，把其他層暫時收起來，而不是被混合視圖淹沒。
+
+**驗收條件：**
+
+- [ ] Console tab 頂部提供 source filter chip：`[All] [Log] [Network] [Nav] [DB]`，預設選中 `All`。
+- [ ] 切換到任一單一來源時，時序軸只顯示該來源的事件；切回 `All` 時恢復四種混合。
+- [ ] filter 一併滿足 Console 原本缺的「errors-only / 過濾」需求：切到 `Log` 時，呈現的就是純粹的 console log 視圖（不再混入 network / nav 的鏡射雜訊）。
+
+### US-4：開發者撈「真正的 warning / debug」時不再撈到鏡射雜訊
+
+> 身為開發者，當我想找真正的 `LogLevel.warning` 或 `LogLevel.debug` 訊息時，我希望結果只有我自己（或框架）真正記下的 log，而不是被 navigation（偽造的 warning）和 network（偽造的 debug）鏡射訊息污染。
+
+**驗收條件：**
+
+- [ ] interceptor 不再為 network 請求額外寫入 `LogLevel.debug` 的鏡射字串 log。
+- [ ] navigator observer 不再為 navigation 事件額外寫入 `LogLevel.warning` 的鏡射字串 log。
+- [ ] 移除鏡射後，log buffer 內 `debug` / `warning` 等級的內容只反映真實的 log 來源，navigation 與 network 事件改由時序軸從各自 buffer 直接呈現。
+
+### US-5：既有使用者不因升級而失去原本的 Console 觀感
+
+> 身為既有的套件使用者，我希望升級後既有接線與既有「看 console log」的行為仍可用，必要時能還原成升級前的觀感。
+
+**驗收條件：**
+
+- [ ] 既有 `FlutterInspector.logEntries` getter 與其語意保留可用（不破壞既有依賴它的程式碼）。
+- [ ] 將 source filter 切到 `Log` only 時，Console 還原為「只看 log buffer」的舊觀感（等同升級前去掉鏡射雜訊後的 console）。
+- [ ] 既有四個 tab（Network / Navigator / Database）的各自呈現不受本功能影響。
+
+---
+
+## 3. 範圍邊界（Scope）
+
+### In-Scope
+
+- Console tab 改為「渲染當下讀取四個 buffer → 依 `timestamp` merge-sort → 引用原 entry」的混合時序軸，預設 All。
+- 每一列引用原始 entry，點擊進入該來源既有的詳情呈現（不複製資料、不產生第二份真相）。
+- 頂部新增 source filter chip `[All] [Log] [Network] [Nav] [DB]`，預設 All；filter 順帶解決 Console 原本缺的過濾 / errors-only 需求。
+- 移除 `dio_interceptor.dart` 中 network 的複製式 `LogLevel.debug` log（`onResponse` / `onError` 兩處）。
+- 移除 `navigator_observer.dart` 中 nav 的複製式 `LogLevel.warning` log（`_record()` 一處）。
+- 保留 `logEntries` getter 與舊 console 行為（filter 切 `Log` only 即還原）。
+
+### Out-of-Scope（明確排除）
+
+- **敏感資料遮罩**：已切成獨立後續工作，不在本功能範圍。
+- **buffer 合併成單一資料源**：四個 buffer 維持各自獨立（各 500 格），混合只發生在渲染讀取當下——這正是解決「配額互吃」的關鍵設計，不可改為合併。
+- **RingBuffer 效能優化**：500 格非真問題，不在本次處理。
+- **獨立的 Timeline tab**：brainstorm #2 做法 B 曾構想新增獨立 Timeline 視圖；本功能直接把混合時序軸做進 Console，已取代「獨立 Timeline tab」的需求，故不另開 tab。
+
+---
+
+## 4. 向後相容性聲明
+
+本功能定位為「既有 Console 的升級」，必須維持向後相容：
+
+- **公開 API 保留**：`FlutterInspector.logEntries`（讀 log buffer）與 `clearLogs()` 等既有 getter / 方法語意不變，既有依賴它們的宿主程式碼不受影響。
+- **舊觀感可還原**：source filter 切到 `Log` only 即還原為「只看 log buffer」的升級前觀感（差別僅在於不再有 network / nav 的鏡射雜訊——而那本來就是要修掉的劣化）。
+- **行為改變的範圍受控且為正向**：移除鏡射後，唯一「行為改變」是 Console 預設不再混入偽造 level 的 network / debug 與 nav / warning 字串 log；這些資訊改由時序軸從各自 buffer 直接、且以正確語意呈現，資訊不減反增，且 level 語意被修正。
+- **其他 tab 不受影響**：Network / Navigator / Database 三個 tab 的既有呈現與資料來源完全不動。
+
+---
+
+## 5. 與現況的查證對照（規格依據）
+
+| 規格描述 | 現況事實（已逐檔核對） | 一致性 |
+|---|---|---|
+| interceptor 複製式 `debug` log（兩處） | `dio_interceptor.dart` `onResponse` 與 `onError` 各一處 `_inspector.log(..., level: LogLevel.debug)` | ✅ 一致 |
+| observer 複製式 `warning` log（一處） | `navigator_observer.dart` `_record()` 一處 `_inspector.log(..., level: LogLevel.warning)`，class doc 明載刻意鏡射 | ✅ 一致 |
+| db 完全沒鏡射 | `FlutterInspector.database()` 只寫 `_registry.database`，無 `log()` 呼叫 | ✅ 一致 |
+| 四個 buffer 各自獨立、各 500 格 | `InspectorRegistry` 四個 inspector 以同一 `bufferSize`（預設 500）各自建立，無合併 | ✅ 一致 |
+| 四個 model 皆有排序鍵 `timestamp` | `LogEntry` / `NetworkEntry` / `NavigatorEntry` / `DatabaseEntry` 皆有 `final DateTime timestamp` | ✅ 一致 |
+| 向後相容基礎存在 | `FlutterInspector.logEntries` getter 存在（讀 `_registry.log.entries`），Console tab 現直接渲染它 | ✅ 一致 |
+
+> 查證結論：規格描述與現況**完全一致**，未發現任何不符。
+
+---
+
+## 6. 規格出口條件
+
+本規格通過確認的標準：
+
+- US-1 ～ US-5 的驗收條件被接受為「可測試、可驗收」。
+- 範圍邊界（特別是「不合併 buffer、不複製資料、移除鏡射、預設 All」這四項定稿決策）被確認。
+- 向後相容性聲明（`logEntries` getter 保留、filter 切 Log only 還原舊觀感）被確認。
+
+確認後進入 STAGE 0b（實作計畫），屆時才細化：時序軸列的資料表示（指標包裝的形狀）、四 buffer merge-sort 的讀取與排序邏輯、filter chip 的 UI 與狀態管理、各來源列的詳情跳轉接線，以及對應的 TDD 任務拆解與逐檔異動清單。

--- a/docs/plans/2026-06-26-console-merged-timeline.md
+++ b/docs/plans/2026-06-26-console-merged-timeline.md
@@ -1,0 +1,340 @@
+# 實作計畫：Console 升級為跨層混合時序軸
+
+- **日期**：2026-06-26
+- **對應規格**：`docs/features/2026-06-26-console-merged-timeline.md`
+- **狀態**：STAGE 0b — 實作計畫（設計決策已定稿，本文件僅描述 How）
+- **語言**：本文件繁體中文；程式碼、識別字、指令保留原文
+
+---
+
+## 0. 設計快照（落地依據，不再議）
+
+| 項目 | 決策 |
+|---|---|
+| 排序契約 | 新增 `abstract interface class TimestampedEntry`（只 `timestamp` getter），四個 model `implements` 它 |
+| 顯示格式 | `displayTime` 以 **extension** 提供，格式 `HH:mm:ss.mmm`（如 `14:30:01.123`） |
+| merge 歸屬 | `InspectorRegistry.mergedTimeline({Set<TimelineSource> sources})`，回傳 `List<TimestampedEntry>`，依 `timestamp` **降冪**（newest-first，對齊 `RingBuffer.items`） |
+| 過濾時機 | 在「收集階段」用 `if` 依 `sources` 過濾，**不**在排序階段過濾 |
+| 對外 API | `FlutterInspector` 開薄 getter/方法轉發給 `registry.mergedTimeline`；`console_tab` 不直接碰 `registry` |
+| filter UI | 頂部 chip `[All][Log][Network][Nav][DB]`，預設 All；State 持有 `Set<TimelineSource>` 或等價 |
+| 列分派 | `console_tab` row builder 用 `switch` / `is` 判型分派四種視覺 |
+| 點擊跳轉 | network→`NetworkDetailView`（**須比照 network_tab 傳 `redactSensitiveData: widget.inspector.redactSensitiveData`**，見 §1.6）、log→`LogDetailView`（無需 redaction 參數）；nav/db 不可點（不顯 chevron、不補 detail view） |
+| 移除鏡射 | `dio_interceptor` 兩處 `_inspector.log(debug)`、`navigator_observer` 一處 `_inspector.log(warning)` 全刪，並同步 doc |
+
+---
+
+## 1. 資料結構設計
+
+### 1.1 `TimestampedEntry`（新檔 `lib/src/models/timestamped_entry.dart`）
+
+```dart
+/// 統一的排序契約：所有可進時序軸的 entry 都暴露一個 [timestamp]。
+///
+/// 用 abstract interface class（只能 implements、不能 extends），把它鎖死為窄契約：
+/// 它存在的唯一理由是讓 [mergedTimeline] 能用單一型別索取排序鍵，
+/// extension（[displayTime]）才得以掛在這個契約上。
+abstract interface class TimestampedEntry {
+  /// 事件發生時間，作為時序軸排序鍵。
+  DateTime get timestamp;
+}
+
+/// [TimestampedEntry] 的衍生顯示。
+///
+/// [displayTime] 是 derived（不是 raw data），四種 model 格式統一、不依賴具體型別，
+/// 因此用 extension 提供一份共用實作，避免四個 model 各抄一份（DRY）。
+/// 格式為 `HH:mm:ss.mmm`（如 `14:30:01.123`），刻意不沿用 toIso8601String（帶日期+微秒太冗長）。
+extension TimestampedEntryDisplay on TimestampedEntry {
+  String get displayTime {
+    final h = timestamp.hour.toString().padLeft(2, '0');
+    final m = timestamp.minute.toString().padLeft(2, '0');
+    final s = timestamp.second.toString().padLeft(2, '0');
+    final ms = timestamp.millisecond.toString().padLeft(3, '0');
+    return '$h:$m:$s.$ms';
+  }
+}
+```
+
+判準（已定稿，僅記錄落地理由）：
+- `timestamp` 是 raw data → 必須進介面當契約。extension 無法穿進具體型別取 field，唯一能統一索取的方式是介面。
+- `displayTime` 是 derived、格式統一 → 進 extension。若進介面會逼四個 model 各抄一份相同代碼（DRY 違規）。
+- 用 `abstract interface class` 鎖死它只當窄契約（只 implements 不 extends）。
+
+### 1.2 `TimelineSource`（同檔 `lib/src/models/timestamped_entry.dart`，與契約並置）
+
+```dart
+/// 時序軸的來源類別，用於 [mergedTimeline] 過濾與 console_tab filter chip。
+enum TimelineSource { log, network, nav, db }
+```
+
+> 歸屬決策：放在 `timestamped_entry.dart` 同檔（兩者都是時序軸的基礎型別、無循環依賴疑慮），避免新增碎檔。`InspectorRegistry` 與 `console_tab` 各自 import 此檔。
+
+### 1.3 四個 model 加 `implements TimestampedEntry`
+
+四個 model 本來就有 `final DateTime timestamp`，加 `implements TimestampedEntry` 後在 `timestamp` 欄位上加 `@override`，**零行為改動**（欄位定義、建構子、`copyWith`、`==`、`hashCode` 全不動）：
+
+- `lib/src/models/log_entry.dart`：`class LogEntry implements TimestampedEntry`
+- `lib/src/models/network_entry.dart`：`class NetworkEntry implements TimestampedEntry`
+- `lib/src/models/navigator_entry.dart`：`class NavigatorEntry implements TimestampedEntry`
+- `lib/src/models/database_entry.dart`：`class DatabaseEntry implements TimestampedEntry`
+
+每檔需 `import 'timestamped_entry.dart';`，並在 `final DateTime timestamp;` 上方加 `@override`。
+
+### 1.4 `InspectorRegistry.mergedTimeline`
+
+```dart
+/// 在渲染讀取當下，把四個 buffer 依 [sources] 過濾、合併、依 timestamp 降冪排序。
+///
+/// 過濾發生在收集階段（用 if 決定要不要讀某個 buffer），不在排序階段。
+/// 降冪（newest-first）對齊 RingBuffer.items 慣例。
+/// 預設 sources 為全選（All）。
+List<TimestampedEntry> mergedTimeline({
+  Set<TimelineSource> sources = const {
+    TimelineSource.log,
+    TimelineSource.network,
+    TimelineSource.nav,
+    TimelineSource.db,
+  },
+}) {
+  final merged = <TimestampedEntry>[];
+  if (sources.contains(TimelineSource.log)) merged.addAll(log.entries);
+  if (sources.contains(TimelineSource.network)) merged.addAll(network.entries);
+  if (sources.contains(TimelineSource.nav)) merged.addAll(navigator.entries);
+  if (sources.contains(TimelineSource.db)) merged.addAll(database.entries);
+  merged.sort((a, b) => b.timestamp.compareTo(a.timestamp)); // 降冪
+  return merged;
+}
+```
+
+資料流：四個 buffer（各自 newest-first 的 snapshot）→ 依 sources 收集 → 合併成單一 list → 整體 `sort` 降冪。不複製資料、不引入第二份真相（list 內裝的是原始 entry 指標）。
+
+### 1.5 `FlutterInspector` 薄轉發
+
+```dart
+/// 跨層混合時序軸：依 [sources] 讀四個 buffer，合併後依 timestamp 降冪排序。
+/// 預設回傳全部來源（All）。
+List<TimestampedEntry> mergedTimeline({Set<TimelineSource> sources = const {
+  TimelineSource.log, TimelineSource.network, TimelineSource.nav, TimelineSource.db,
+}}) => _registry.mergedTimeline(sources: sources);
+```
+
+維持對外 API 乾淨：`registry` 是 `@visibleForTesting` 才暴露的，`console_tab` 透過此薄方法取得時序軸，不直接伸手進 registry。`logEntries` / `clearLogs` 等既有 API 全部保留（向後相容）。
+
+> **插入位置（已對齊當前 main）**：薄轉發 `mergedTimeline` 插在 `flutter_inspector.dart` 的 `logEntries` getter（行 138）附近、與 `networkEntries` / `navigatorEntries` / `databaseEntries` 等 buffer 存取 getter 並置。`_registry` 在 redaction（PR #39）後已改為 `late final InspectorRegistry _registry;`（行 125，建構子 body 內賦值）——**不影響薄轉發**：轉發是讀取端，執行時 `_registry` 早已賦值完成，語意無差異。
+
+### 1.6 redaction × timeline 接線契約（redaction merge 後新增的必要接線）
+
+本計畫定稿於 redaction（PR #39）之前。redaction merge 後，`NetworkDetailView` 多了 `redactSensitiveData` 建構參數（`network_detail_view.dart:16-27`，預設 `true`，doc 明載「Mirrors `FlutterInspector.redactSensitiveData`」），而 `network_tab.dart:189-192` 的跳轉**已傳**此值：
+
+```dart
+builder: (_) => NetworkDetailView(
+  entry: entry,
+  redactSensitiveData: widget.inspector.redactSensitiveData,
+),
+```
+
+**契約**：T9 改寫 console_tab 時，network 列跳轉 **必須比照傳同一個值**。
+- 若不傳：因預設 `true` 不會洩密，但會造成 host 設 `redactSensitiveData: false` 時「Network tab 不遮、Console timeline 遮」的行為分歧——違反「引用同一原 entry、行為應一致」的設計精神（Never break userspace 等級的一致性問題）。
+- log 列跳 `LogDetailView` **不需** redaction 參數（redaction 未碰 `log_detail_view.dart`，該 view 無此參數）。
+
+---
+
+## 2. 逐檔異動清單
+
+| 檔案 | 動作 | 類型 |
+|---|---|---|
+| `lib/src/models/timestamped_entry.dart` | 新增（契約 + extension + enum） | 設計判斷 |
+| `lib/src/models/log_entry.dart` | `implements` + `@override` | 機械性 |
+| `lib/src/models/network_entry.dart` | `implements` + `@override` | 機械性 |
+| `lib/src/models/navigator_entry.dart` | `implements` + `@override` | 機械性 |
+| `lib/src/models/database_entry.dart` | `implements` + `@override` | 機械性 |
+| `lib/src/core/inspector_registry.dart` | 新增 `mergedTimeline` | 整合 |
+| `lib/src/core/flutter_inspector.dart` | 新增薄 `mergedTimeline` 轉發 | 機械性 |
+| `lib/src/ui/dashboard/tabs/console_tab.dart` | 改寫（filter chip + 判型分派 + 跳轉） | 設計判斷 |
+| `lib/src/interceptors/dio_interceptor.dart` | 刪 `onResponse`/`onError` 兩處鏡射 log | 機械性 |
+| `lib/src/observers/navigator_observer.dart` | 刪 `_record` 鏡射 log + 改 class/method doc | 機械性 |
+
+共享檔 owner 標註：
+- `lib/src/core/flutter_inspector.dart` 由 **T6（registry 轉發任務）唯一 owner**。其他任務不得改它。
+- `lib/src/models/timestamped_entry.dart` 由 **T1 唯一 owner**，建立後其餘任務只 import 不改。
+
+---
+
+## 3. 任務拆分（TDD-first，依相依順序）
+
+> 每個任務標註：觸及檔案、複雜度、可否並行。複雜度三級：機械性 / 整合 / 設計判斷。
+
+### T1 — 建立 `TimestampedEntry` 契約 + extension + enum
+- **觸及**：`lib/src/models/timestamped_entry.dart`（新）、`test/models/timestamped_entry_test.dart`（新）
+- **複雜度**：設計判斷
+- **並行**：無相依（最先做），但下游 T2–T6 全部依賴它 → **必須最先完成**
+- **TDD**：
+  - 先寫 `test/models/timestamped_entry_test.dart`：用一個 test-local 的 `_Fixture implements TimestampedEntry`（只給 `timestamp`），驗證 `displayTime`：
+    - `DateTime(2026, 6, 26, 14, 30, 1, 123).displayTime == '14:30:01.123'`
+    - 個位數補零：`DateTime(2026, 1, 1, 9, 5, 3, 7).displayTime == '09:05:03.007'`
+    - 毫秒三位補零：millisecond `0` → `.000`
+  - 後寫實作（§1.1 + §1.2）通過。
+- **驗收**：`flutter test test/models/timestamped_entry_test.dart` 綠。
+
+### T2 — `LogEntry implements TimestampedEntry`
+- **觸及**：`lib/src/models/log_entry.dart`、`test/models/log_entry_test.dart`（追加）
+- **複雜度**：機械性
+- **並行**：依賴 T1；與 T3/T4/T5 **路徑不重疊，可並行**
+- **TDD**：
+  - 追加 test：`LogEntry(...) is TimestampedEntry` 為 true；`entry.displayTime` 等於對應格式（沿用既有 `fixedTime` 風格）。
+  - 改 `log_entry.dart`：`import 'timestamped_entry.dart';`、`class LogEntry implements TimestampedEntry`、`timestamp` 上加 `@override`。
+- **驗收**：`flutter test test/models/log_entry_test.dart` 綠。
+
+### T3 — `NetworkEntry implements TimestampedEntry`
+- **觸及**：`lib/src/models/network_entry.dart`、`test/models/network_entry_test.dart`（追加）
+- **複雜度**：機械性
+- **並行**：依賴 T1；與 T2/T4/T5 並行
+- **TDD**：追加 `is TimestampedEntry` + `displayTime` 斷言；改 model 加 `implements` + `@override`。
+- **驗收**：`flutter test test/models/network_entry_test.dart` 綠。
+
+### T4 — `NavigatorEntry implements TimestampedEntry`
+- **觸及**：`lib/src/models/navigator_entry.dart`、`test/models/navigator_entry_test.dart`（新增或追加；目前 `test/models/` 無 navigator_entry_test → **新建**）
+- **複雜度**：機械性
+- **並行**：依賴 T1；與 T2/T3/T5 並行
+- **TDD**：新建 `test/models/navigator_entry_test.dart`，最小斷言 `is TimestampedEntry` + `displayTime`；改 model 加 `implements` + `@override`。
+- **驗收**：`flutter test test/models/navigator_entry_test.dart` 綠。
+
+### T5 — `DatabaseEntry implements TimestampedEntry`
+- **觸及**：`lib/src/models/database_entry.dart`、`test/models/database_entry_test.dart`（新建；目前 `test/models/` 無此檔）
+- **複雜度**：機械性
+- **並行**：依賴 T1；與 T2/T3/T4 並行
+- **TDD**：新建測試，最小斷言 `is TimestampedEntry` + `displayTime`；改 model 加 `implements` + `@override`。
+- **驗收**：`flutter test test/models/database_entry_test.dart` 綠。
+
+### T6 — `mergedTimeline`（registry + inspector 薄轉發）
+- **觸及**：`lib/src/core/inspector_registry.dart`、`lib/src/core/flutter_inspector.dart`、`test/core/inspector_registry_merged_timeline_test.dart`（新建）
+- **複雜度**：整合
+- **並行**：依賴 **T2–T5 全部完成**（merge 需四個 model 已是 `TimestampedEntry`）。**唯一 owner of `flutter_inspector.dart`**，與後續 console 改寫序列化（T9 依賴 T6）
+- **TDD**（先寫 test）：
+  - 用固定 timestamp 各塞 log/network/nav/db 一筆（時間錯開），斷言：
+    - 預設（不傳 sources）回傳 4 筆，且依 timestamp **降冪**（`result[0].timestamp` 最新）。
+    - 傳 `{TimelineSource.network}` 只回 network 那筆。
+    - 傳 `{TimelineSource.log, TimelineSource.nav}` 回兩筆，仍降冪。
+    - 空 buffer → 回空 list。
+  - 經由 `FlutterInspector.mergedTimeline(...)` 與 `registry.mergedTimeline(...)` 都驗一次，確認薄轉發等價。
+  - 後寫實作（§1.4 + §1.5）。
+- **驗收**：新測試綠 + `flutter test test/core/` 全綠（確認沒破壞既有 core 測試）。
+
+### T7 — 移除 dio_interceptor 鏡射 log
+- **觸及**：`lib/src/interceptors/dio_interceptor.dart`、`test/interceptors/dio_interceptor_test.dart`（追加守門測試）
+- **複雜度**：機械性
+- **並行**：**完全獨立**（不依賴 T1–T6，路徑不與任何任務重疊）→ 可在第一批就並行
+- **TDD**：
+  - 追加守門 test：`onResponse` 後 `inspector.logEntries`（即 `registry.log.entries`）為 **empty**（網路完成不再產生 debug 鏡射）；`onError` 後同樣 empty。
+  - 改 `dio_interceptor.dart`：刪 `onResponse` 的 `_inspector.log(...)`（行 76–79）與 `onError` 的 `_inspector.log(...)`（行 111–114）；移除不再需要的 `import '.../log_level.dart';`。
+- **驗收**：`flutter test test/interceptors/dio_interceptor_test.dart` 綠（既有測試不依賴鏡射，全數仍通過）。
+
+### T8 — 移除 navigator_observer 鏡射 log + 同步 doc
+- **觸及**：`lib/src/observers/navigator_observer.dart`、`test/observers/navigator_observer_test.dart`（**改既有測試**，見 §5）
+- **複雜度**：機械性
+- **並行**：**完全獨立**（不依賴 T1–T6）→ 可在第一批就並行；與 T7 路徑不重疊，兩者可同批
+- **TDD**：
+  - 改既有測試（見 §5）：刪 `mirrors a navigation event to the console log at warning level`，改寫 `does not log for the inspector dashboard route` 為「`_record` 不再寫任何 log」的守門測試（push 一般 route 後 `inspector.logEntries` 為 empty）。
+  - 改 `navigator_observer.dart`：刪 `_record` 內 `_inspector.log(..., level: LogLevel.warning)`（行 64–67）；class doc（行 8–12）移除「mirroring the interceptor / written to the console log at warning level」描述、`_record` doc（行 51–52）移除「mirrors it to the console log」描述；移除不再需要的 `import '.../log_level.dart';`。
+- **驗收**：`flutter test test/observers/navigator_observer_test.dart` 綠。
+
+### T9 — 改寫 `console_tab`（filter chip + 判型分派 + 跳轉）
+- **觸及**：`lib/src/ui/dashboard/tabs/console_tab.dart`、`test/ui/tabs/console_tab_test.dart`（**大幅改寫**，見 §5）
+- **複雜度**：設計判斷
+- **並行**：依賴 **T6（mergedTimeline）+ T1（TimestampedEntry/displayTime）+ T2–T5（判型用的 `is LogEntry` 等）全部就位** → **最後做、序列**
+- **TDD**（先寫 widget test，見 §5 清單）：
+  - State 持有 `Set<TimelineSource> _selected`，初值四種全選（All）。
+  - filter chip row：`[All][Log][Network][Nav][DB]`，All 切回全選；單一來源切成只含該源。
+  - row builder：`final entries = widget.inspector.mergedTimeline(sources: _selected);` 後對每筆 `switch`/`is` 分派：
+    - `LogEntry` → level 色 + message，subtitle 顯 `displayTime`，可點（沿用既有 canTap：有 stackTrace/data 才可點）→ `LogDetailView`。
+    - `NetworkEntry` → `method + statusCode + url`，subtitle `displayTime`，可點 → `NetworkDetailView(entry: e, redactSensitiveData: widget.inspector.redactSensitiveData)`。**必須傳 `redactSensitiveData`**，與 `network_tab.dart:189-192` 的跳轉一致——否則 host 設 `redactSensitiveData: false` 時，同一筆 entry 從 Network tab 點進去不遮、從 Console timeline 點進去卻遮，行為不一致（見 §1.6）。console_tab 需 `import '../network/network_detail_view.dart';`。
+    - `NavigatorEntry` → `action + routeName`（沿用 `displayName`），subtitle `displayTime`，**不可點**（trailing 無 chevron）。
+    - `DatabaseEntry` → `operation + tableName`，subtitle `displayTime`，**不可點**。
+  - 保留 refresh / clear 按鈕；clear 行為維持呼叫 `clearLogs()`（規格 US-5：clear 仍清 log buffer；其他 buffer 各自 tab 清，本功能不擴張 clear 語意）。
+- **驗收**：`flutter test test/ui/tabs/console_tab_test.dart` 綠 + 跑整套 `flutter test`（排除已知 10 分鐘 timeout 的 magical_tap_test）。
+
+---
+
+## 4. 並行批次規劃
+
+| 批次 | 任務 | 並行性 | 相依說明 |
+|---|---|---|---|
+| **Batch 0** | T1、T7、T8 | 三者並行 | T1 是契約根；T7/T8 是移除鏡射，路徑與 T1 及彼此皆不重疊，無需等 T1 |
+| **Batch 1** | T2、T3、T4、T5 | 四者並行 | 全部依賴 T1 完成；四個 model 路徑互不重疊 |
+| **Batch 2** | T6 | 單一序列 | 依賴 T2–T5 全部完成（merge 需四 model 已是 `TimestampedEntry`）；唯一 owner of `flutter_inspector.dart` |
+| **Batch 3** | T9 | 單一序列 | 依賴 T6 + T1–T5 全部就位 |
+
+> 序列鏈關鍵路徑：`T1 → (T2..T5) → T6 → T9`。T7/T8 可塞進關鍵路徑的任何空檔（Batch 0 即可完成）。
+> 預估並行收益：Batch 1 四 model 並行（vs 序列）約省 3/4 時間；T7/T8 與 T1 同批不佔關鍵路徑。
+
+---
+
+## 5. 需調整的既有測試清單
+
+> 「移除鏡射」與「console 由 logEntries 改 mergedTimeline」會使部分既有測試的前提失效。逐項列出改什麼、為何改。
+
+### 5.1 `test/observers/navigator_observer_test.dart`（T8 owner）
+
+| 既有測試 | 動作 | 原因 |
+|---|---|---|
+| `mirrors a navigation event to the console log at warning level`（行 127–139） | **刪除** | 斷言 `inspector.logEntries.length == 1` 且 `log.level == warning` — 鏡射移除後此行為消失，斷言永遠失敗 |
+| `does not log for the inspector dashboard route`（行 141–149） | **改寫為守門測試** | 原意是「dashboard route 不鏡射」；鏡射移除後改為驗「任何 route 都不再寫 log」：push 一般 route 後 `expect(inspector.logEntries, isEmpty)`，鎖死「不再有鏡射」 |
+| 其餘 navigator buffer 測試（行 18–125） | **不動** | 它們驗的是 `navigatorInspector.entries`，與鏡射無關 |
+
+### 5.2 `test/interceptors/dio_interceptor_test.dart`（T7 owner）
+
+| 既有測試 | 動作 | 原因 |
+|---|---|---|
+| 全部既有測試（行 16–254） | **不動，全數通過** | 它們只斷言 `registry.network.entries`，**從不**斷言 debug 鏡射 log 存在 → 移除鏡射不影響它們 |
+| （新增）`onResponse / onError 不再寫 debug 鏡射 log` | **追加守門測試** | 鎖死「移除鏡射」這個行為改變，防止未來回歸 |
+
+### 5.3 `test/ui/tabs/console_tab_test.dart`（T9 owner，大幅改寫）
+
+現有 5 個測試全部以「`inspector.log(...)` → Console 直接顯示 log」為前提，改寫後 Console 改讀 `mergedTimeline`。逐項：
+
+| 既有測試 | 動作 | 改寫重點 |
+|---|---|---|
+| `displays logs and supports clearing`（行 10–29） | **保留+微調** | log-only 仍會顯示（mergedTimeline 含 log）；clear 仍清 log。斷言可沿用，但需確認在 All filter 下兩筆 log 仍出現 |
+| `tapping error log with stackTrace opens LogDetailView`（行 31–53） | **保留** | log 列仍可點進 `LogDetailView`，判型分派後行為不變 |
+| `tapping error log with data opens LogDetailView`（行 55–77） | **保留** | 同上 |
+| `shows a chevron only on expandable rows`（行 79–105） | **保留+擴充** | log 列 canTap 規則不變；可擴充驗 nav/db 列不顯 chevron |
+| `tapping pure info log without stackTrace or data does not navigate`（行 107–128） | **保留** | 不可點 log 列行為不變 |
+| （新增）`filter chip 切 Network 只顯 network 列` | **新增** | 驗 US-3：塞 log + network，切 Network filter 後只剩 network 列 |
+| （新增）`All filter 下四種來源混合並依時間排序` | **新增** | 驗 US-1：塞四種來源、時間錯開，斷言混合呈現且 newest-first |
+| （新增）`network 列可點進 NetworkDetailView` | **新增** | 驗 US-2 跳轉 |
+| （新增）`network 列跳轉正確轉傳 redactSensitiveData` | **新增** | 驗 §1.6 契約：建構 `FlutterInspector(redactSensitiveData: false)`，點 network 列後斷言進入的 `NetworkDetailView.redactSensitiveData == false`（防止 timeline 與 Network tab 行為分歧） |
+| （新增）`nav / db 列不可點（無 chevron）` | **新增** | 驗設計決策（nav/db 暫不可點） |
+| （新增）`每列顯示 displayTime（HH:mm:ss.mmm）` | **新增** | 驗格式落地 |
+
+> 注意：改寫 console_tab_test 時需 import `network_entry.dart` / `navigator_action.dart` / `database_operation.dart` 等，以便構造混合來源資料（透過 `inspector.logNetwork(...)`、`inspector.navigatorObserver.didPush(...)`、`inspector.database(...)` 餵入各 buffer）。
+
+### 5.4 其他既有測試 — 確認不受影響
+
+- `test/core/flutter_inspector_test.dart`：只斷言各 inspector buffer 計數，**不依賴鏡射**，不動。
+- `test/core/error_capture_test.dart`：用 `logEntries.where(level == error)`，error log 來源不變，不動。
+- Network / Navigator / Database 各 tab 測試：本功能不動這三個 tab，不受影響。
+
+---
+
+## 6. 風險與品味守則
+
+- **Never break userspace**：`logEntries` / `clearLogs` / `networkEntries` 等公開 API 全保留語意；唯一行為改變是「Console 預設不再混入偽 level 鏡射 log」，且該資訊改由時序軸以正確語意呈現（資訊不減反增）。
+- **不引入第二份真相**：`mergedTimeline` 回傳的是原始 entry 指標的合併 list，無複製、無快照；network entry pending→completed 後下次渲染自動反映最新（因為讀的是同一 buffer）。
+- **消滅特殊情況**：過濾在收集階段用 `if` 決定要不要讀某 buffer，排序階段一視同仁降冪 — 不在排序裡再塞 source 判斷。
+- **窄契約**：`TimestampedEntry` 只有 `timestamp`，`abstract interface class` 鎖死不被誤用為基底類別。
+
+---
+
+## 7. 執行方式選擇（供 orchestrator 選用）
+
+### 方式 A：subagent-driven（推薦）
+- **Batch 0**：開 3 個 subagent 並行跑 T1 / T7 / T8（路徑零重疊）。
+- **Batch 1**：T1 完成後，開 4 個 subagent 並行跑 T2 / T3 / T4 / T5。
+- **Batch 2 / 3**：T6、T9 各由單一 agent 序列完成（T6 是 `flutter_inspector.dart` 唯一 owner，T9 依賴全部）。
+- 優點：最大化並行（關鍵路徑只有 T1→model→T6→T9）；缺點：需 orchestrator 控管 batch barrier。
+
+### 方式 B：parallel session（人工分工）
+- Session 1（契約線）：T1 →（協調 T2–T5）→ T6 → T9，握住 `flutter_inspector.dart` owner 權。
+- Session 2（清理線）：T7 + T8 並行做完（與 Session 1 路徑零重疊），先行合入。
+- 優點：人為邊界清晰、衝突面小；缺點：T2–T5 的四路並行收益不如方式 A 充分。
+
+兩方式皆遵守同一相依鏈與 owner 規範，差別僅在並行調度顆粒度。

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -10,6 +10,7 @@ import '../sources/operation_log_source.dart';
 import '../models/log_level.dart';
 import '../models/navigator_entry.dart';
 import '../models/network_entry.dart';
+import '../models/timestamped_entry.dart';
 import '../notifications/network_notifier.dart';
 import '../observers/navigator_observer.dart';
 import '../ui/dashboard/dashboard_modal.dart';
@@ -160,6 +161,18 @@ class FlutterInspector {
 
   /// Clears all database logs.
   void clearDatabase() => _registry.database.clear();
+
+  /// Cross-layer merged timeline: reads the four buffers filtered by [sources],
+  /// merged and sorted by timestamp descending (newest first). Defaults to all
+  /// sources. Thin forward to [InspectorRegistry.mergedTimeline].
+  List<TimestampedEntry> mergedTimeline({
+    Set<TimelineSource> sources = const {
+      TimelineSource.log,
+      TimelineSource.network,
+      TimelineSource.nav,
+      TimelineSource.db,
+    },
+  }) => _registry.mergedTimeline(sources: sources);
 
   /// Retrieves the registered database browser sources.
   List<DatabaseBrowserSource> get databaseSources =>

--- a/lib/src/core/inspector_registry.dart
+++ b/lib/src/core/inspector_registry.dart
@@ -2,6 +2,7 @@ import '../inspectors/database_inspector.dart';
 import '../inspectors/log_inspector.dart';
 import '../inspectors/navigator_inspector.dart';
 import '../inspectors/network_inspector.dart';
+import '../models/timestamped_entry.dart';
 
 /// Internal registry holding instances of the four fixed inspectors.
 class InspectorRegistry {
@@ -23,4 +24,33 @@ class InspectorRegistry {
 
   /// Inspector for database operations.
   final DatabaseInspector database;
+
+  /// Merges the four buffers into a single timeline, filtered by [sources] and
+  /// sorted by [TimestampedEntry.timestamp] descending (newest first).
+  ///
+  /// Filtering happens at the collection stage (an `if` decides whether a buffer
+  /// is read at all), not during sorting. Descending order matches the
+  /// newest-first convention of [RingBuffer.items]. Defaults to all sources.
+  ///
+  /// Returns the original entry pointers (no copy, no second source of truth):
+  /// a network entry that later transitions pending -> completed is reflected on
+  /// the next read, because the same buffer is read each time.
+  List<TimestampedEntry> mergedTimeline({
+    Set<TimelineSource> sources = const {
+      TimelineSource.log,
+      TimelineSource.network,
+      TimelineSource.nav,
+      TimelineSource.db,
+    },
+  }) {
+    final merged = <TimestampedEntry>[];
+    if (sources.contains(TimelineSource.log)) merged.addAll(log.entries);
+    if (sources.contains(TimelineSource.network)) {
+      merged.addAll(network.entries);
+    }
+    if (sources.contains(TimelineSource.nav)) merged.addAll(navigator.entries);
+    if (sources.contains(TimelineSource.db)) merged.addAll(database.entries);
+    merged.sort((a, b) => b.timestamp.compareTo(a.timestamp)); // descending
+    return merged;
+  }
 }

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
-import 'package:flutter_inspector_kit/src/models/log_level.dart';
 
 import '../core/flutter_inspector.dart';
 import '../models/network_entry.dart';
@@ -73,10 +72,6 @@ class FlutterInspectorDioInterceptor extends Interceptor {
       isReplay: response.requestOptions.extra['_inspector_is_replay'] == true,
     );
     _inspector.logNetwork(entry, replaces: pending);
-    _inspector.log(
-      "entry.url: ${entry.url}\nMethod: ${entry.method}\nStatus: ${entry.statusCode}",
-      level: LogLevel.debug,
-    );
     handler.next(response);
   }
 
@@ -108,10 +103,6 @@ class FlutterInspectorDioInterceptor extends Interceptor {
       isReplay: err.requestOptions.extra['_inspector_is_replay'] == true,
     );
     _inspector.logNetwork(entry, replaces: pending);
-    _inspector.log(
-      "entry.url: ${entry.url}\nMethod: ${entry.method}\nStatus: ${entry.statusCode}",
-      level: LogLevel.debug,
-    );
     handler.next(err);
   }
 }

--- a/lib/src/models/database_entry.dart
+++ b/lib/src/models/database_entry.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/foundation.dart';
 
 import 'database_operation.dart';
+import 'timestamped_entry.dart';
 
 /// An immutable record of a database operation, displayed in the Database tab.
 @immutable
-class DatabaseEntry {
+class DatabaseEntry implements TimestampedEntry {
   /// Creates a database entry. [timestamp] defaults to the moment of creation.
   DatabaseEntry({
     required this.operation,
@@ -15,6 +16,7 @@ class DatabaseEntry {
   }) : timestamp = timestamp ?? DateTime.now();
 
   /// When the operation was recorded.
+  @override
   final DateTime timestamp;
 
   /// The kind of operation.

--- a/lib/src/models/log_entry.dart
+++ b/lib/src/models/log_entry.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/foundation.dart';
 
 import 'log_level.dart';
+import 'timestamped_entry.dart';
 
 /// An immutable record of a single console log, displayed in the Console tab.
 @immutable
-class LogEntry {
+class LogEntry implements TimestampedEntry {
   /// Creates a log entry. [timestamp] defaults to the moment of creation.
   LogEntry({
     required this.message,
@@ -15,6 +16,7 @@ class LogEntry {
   }) : timestamp = timestamp ?? DateTime.now();
 
   /// When the log was recorded.
+  @override
   final DateTime timestamp;
 
   /// Severity of the log.

--- a/lib/src/models/navigator_entry.dart
+++ b/lib/src/models/navigator_entry.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/foundation.dart';
 
 import 'navigator_action.dart';
+import 'timestamped_entry.dart';
 
 /// An immutable record of a navigation event, displayed in the Navigator tab.
 @immutable
-class NavigatorEntry {
+class NavigatorEntry implements TimestampedEntry {
   /// Creates a navigator entry. [timestamp] defaults to the moment of creation.
   NavigatorEntry({
     required this.action,
@@ -15,6 +16,7 @@ class NavigatorEntry {
   }) : timestamp = timestamp ?? DateTime.now();
 
   /// When the navigation event occurred.
+  @override
   final DateTime timestamp;
 
   /// The kind of navigation event.

--- a/lib/src/models/network_entry.dart
+++ b/lib/src/models/network_entry.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
+import 'timestamped_entry.dart';
+
 /// Maximum number of bytes (characters) retained for a request/response body
 /// before truncation. Bodies larger than this are cut and marked.
 const int kNetworkBodyMaxLength = 10 * 1024;
@@ -17,7 +19,7 @@ const String kTruncatedMarker = '...[truncated]';
 /// known, and is later replaced by a completed entry once the response or error
 /// arrives.
 @immutable
-class NetworkEntry {
+class NetworkEntry implements TimestampedEntry {
   /// Creates a network entry. [timestamp] defaults to the moment of creation.
   NetworkEntry({
     required this.method,
@@ -37,6 +39,7 @@ class NetworkEntry {
        timestamp = timestamp ?? DateTime.now();
 
   /// When the request started.
+  @override
   final DateTime timestamp;
 
   /// HTTP method, e.g. `GET`, `POST`.

--- a/lib/src/models/timestamped_entry.dart
+++ b/lib/src/models/timestamped_entry.dart
@@ -1,0 +1,27 @@
+/// 統一的排序契約：所有可進時序軸的 entry 都暴露一個 [timestamp]。
+///
+/// 用 abstract interface class（只能 implements、不能 extends），把它鎖死為窄契約：
+/// 它存在的唯一理由是讓 [mergedTimeline] 能用單一型別索取排序鍵，
+/// extension（[displayTime]）才得以掛在這個契約上。
+abstract interface class TimestampedEntry {
+  /// 事件發生時間，作為時序軸排序鍵。
+  DateTime get timestamp;
+}
+
+/// [TimestampedEntry] 的衍生顯示。
+///
+/// [displayTime] 是 derived（不是 raw data），四種 model 格式統一、不依賴具體型別，
+/// 因此用 extension 提供一份共用實作，避免四個 model 各抄一份（DRY）。
+/// 格式為 `HH:mm:ss.mmm`（如 `14:30:01.123`），刻意不沿用 toIso8601String（帶日期+微秒太冗長）。
+extension TimestampedEntryDisplay on TimestampedEntry {
+  String get displayTime {
+    final h = timestamp.hour.toString().padLeft(2, '0');
+    final m = timestamp.minute.toString().padLeft(2, '0');
+    final s = timestamp.second.toString().padLeft(2, '0');
+    final ms = timestamp.millisecond.toString().padLeft(3, '0');
+    return '$h:$m:$s.$ms';
+  }
+}
+
+/// 時序軸的來源類別，用於 [mergedTimeline] 過濾與 console_tab filter chip。
+enum TimelineSource { log, network, nav, db }

--- a/lib/src/observers/navigator_observer.dart
+++ b/lib/src/observers/navigator_observer.dart
@@ -1,15 +1,13 @@
 import 'package:flutter/widgets.dart';
 
 import '../core/flutter_inspector.dart';
-import '../models/log_level.dart';
 import '../models/navigator_action.dart';
 import '../models/navigator_entry.dart';
 
 /// An observer that records navigation events into the inspector.
 ///
-/// Each navigation event is buffered into the navigator inspector and, mirroring
-/// [FlutterInspectorDioInterceptor], also written to the console log at
-/// [LogLevel.warning] so route changes are visible in the Console tab.
+/// Each navigation event is buffered into the navigator inspector so that
+/// route changes are visible in the Navigator tab.
 class FlutterInspectorNavigatorObserver extends NavigatorObserver {
   /// Creates an observer that feeds events into [_inspector].
   FlutterInspectorNavigatorObserver(this._inspector);
@@ -48,8 +46,7 @@ class FlutterInspectorNavigatorObserver extends NavigatorObserver {
     return null;
   }
 
-  /// Buffers [route] as a navigation event and mirrors it to the console log
-  /// at [LogLevel.warning], matching the interceptor's logging behaviour.
+  /// Buffers [route] as a navigation event into the navigator inspector.
   void _record(NavigatorAction action, Route<dynamic> route) {
     final routeName = route.settings.name;
     final widgetType = _resolveWidgetType(route);
@@ -60,10 +57,6 @@ class FlutterInspectorNavigatorObserver extends NavigatorObserver {
         widgetType: widgetType,
         arguments: route.settings.arguments,
       ),
-    );
-    _inspector.log(
-      "Action: ${action.name}\nRoute: ${routeName ?? '-'}\nWidget: ${widgetType ?? '-'}",
-      level: LogLevel.warning,
     );
   }
 

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
 
 import '../../../core/flutter_inspector.dart';
+import '../../../models/database_entry.dart';
+import '../../../models/log_entry.dart';
 import '../../../models/log_level.dart';
+import '../../../models/navigator_entry.dart';
+import '../../../models/network_entry.dart';
+import '../../../models/timestamped_entry.dart';
 import 'console/log_detail_view.dart';
+import 'network/network_detail_view.dart';
 
-/// Tab for displaying console logs.
+/// Tab for displaying a cross-layer merged timeline (logs, network, navigation,
+/// database) with a source filter and per-type row dispatch.
 class ConsoleTab extends StatefulWidget {
   const ConsoleTab({required this.inspector, super.key});
 
@@ -15,7 +22,31 @@ class ConsoleTab extends StatefulWidget {
 }
 
 class _ConsoleTabState extends State<ConsoleTab> {
+  /// The currently selected timeline sources. Initialised to all four (the
+  /// "All" state).
+  Set<TimelineSource> _selected = {
+    TimelineSource.log,
+    TimelineSource.network,
+    TimelineSource.nav,
+    TimelineSource.db,
+  };
+
+  static const Set<TimelineSource> _all = {
+    TimelineSource.log,
+    TimelineSource.network,
+    TimelineSource.nav,
+    TimelineSource.db,
+  };
+
   void _refresh() => setState(() {});
+
+  /// Whether the filter currently equals "All" (every source selected).
+  bool get _isAll => _selected.length == _all.length;
+
+  void _selectAll() => setState(() => _selected = {..._all});
+
+  void _selectOnly(TimelineSource source) =>
+      setState(() => _selected = {source});
 
   Color _getColorForLevel(LogLevel level) {
     switch (level) {
@@ -33,13 +64,53 @@ class _ConsoleTabState extends State<ConsoleTab> {
 
   @override
   Widget build(BuildContext context) {
-    final entries = widget.inspector.logEntries;
+    final entries = widget.inspector.mergedTimeline(sources: _selected);
 
     return Column(
       children: [
         Row(
-          mainAxisAlignment: MainAxisAlignment.end,
           children: [
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    const SizedBox(width: 8),
+                    FilterChip(
+                      label: const Text('All'),
+                      selected: _isAll,
+                      onSelected: (_) => _selectAll(),
+                    ),
+                    const SizedBox(width: 8),
+                    FilterChip(
+                      label: const Text('Log'),
+                      selected: !_isAll && _selected.contains(TimelineSource.log),
+                      onSelected: (_) => _selectOnly(TimelineSource.log),
+                    ),
+                    const SizedBox(width: 8),
+                    FilterChip(
+                      label: const Text('Network'),
+                      selected: !_isAll &&
+                          _selected.contains(TimelineSource.network),
+                      onSelected: (_) => _selectOnly(TimelineSource.network),
+                    ),
+                    const SizedBox(width: 8),
+                    FilterChip(
+                      label: const Text('Nav'),
+                      selected: !_isAll && _selected.contains(TimelineSource.nav),
+                      onSelected: (_) => _selectOnly(TimelineSource.nav),
+                    ),
+                    const SizedBox(width: 8),
+                    FilterChip(
+                      label: const Text('DB'),
+                      selected: !_isAll && _selected.contains(TimelineSource.db),
+                      onSelected: (_) => _selectOnly(TimelineSource.db),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                ),
+              ),
+            ),
             IconButton(icon: const Icon(Icons.refresh), onPressed: _refresh),
             IconButton(
               icon: const Icon(Icons.delete),
@@ -53,32 +124,76 @@ class _ConsoleTabState extends State<ConsoleTab> {
         Expanded(
           child: ListView.builder(
             itemCount: entries.length,
-            itemBuilder: (context, index) {
-              final entry = entries[index];
-              final canTap = (entry.stackTrace?.isNotEmpty ?? false) ||
-                  (entry.data?.isNotEmpty ?? false);
-              return ListTile(
-                title: Text(
-                  entry.message,
-                  style: TextStyle(color: _getColorForLevel(entry.level)),
-                ),
-                subtitle: Text(entry.timestamp.toIso8601String()),
-                // Mark expandable rows with the same chevron the Network tab
-                // uses; non-expandable rows stay flat (trailing: null).
-                trailing:
-                    canTap ? const Icon(Icons.chevron_right, size: 18) : null,
-                onTap: canTap
-                    ? () => Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => LogDetailView(entry: entry),
-                          ),
-                        )
-                    : null,
-              );
-            },
+            itemBuilder: (context, index) => _buildRow(entries[index]),
           ),
         ),
       ],
+    );
+  }
+
+  /// Dispatches a [TimestampedEntry] to the matching row visual by runtime type.
+  Widget _buildRow(TimestampedEntry entry) {
+    switch (entry) {
+      case final LogEntry e:
+        return _logRow(e);
+      case final NetworkEntry e:
+        return _networkRow(e);
+      case final NavigatorEntry e:
+        return _navigatorRow(e);
+      case final DatabaseEntry e:
+        return _databaseRow(e);
+      default:
+        return const SizedBox.shrink();
+    }
+  }
+
+  Widget _logRow(LogEntry e) {
+    final canTap =
+        (e.stackTrace?.isNotEmpty ?? false) || (e.data?.isNotEmpty ?? false);
+    return ListTile(
+      title: Text(
+        e.message,
+        style: TextStyle(color: _getColorForLevel(e.level)),
+      ),
+      subtitle: Text(e.displayTime),
+      trailing: canTap ? const Icon(Icons.chevron_right, size: 18) : null,
+      onTap: canTap
+          ? () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => LogDetailView(entry: e),
+                ),
+              )
+          : null,
+    );
+  }
+
+  Widget _networkRow(NetworkEntry e) {
+    return ListTile(
+      title: Text('${e.method} ${e.statusCode ?? '-'} ${e.url}'),
+      subtitle: Text(e.displayTime),
+      trailing: const Icon(Icons.chevron_right, size: 18),
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => NetworkDetailView(
+            entry: e,
+            redactSensitiveData: widget.inspector.redactSensitiveData,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _navigatorRow(NavigatorEntry e) {
+    return ListTile(
+      title: Text('${e.action.name} ${e.displayName}'),
+      subtitle: Text(e.displayTime),
+    );
+  }
+
+  Widget _databaseRow(DatabaseEntry e) {
+    return ListTile(
+      title: Text('${e.operation.name} ${e.tableName}'),
+      subtitle: Text(e.displayTime),
     );
   }
 }

--- a/test/core/inspector_registry_merged_timeline_test.dart
+++ b/test/core/inspector_registry_merged_timeline_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/core/inspector_registry.dart';
+import 'package:flutter_inspector_kit/src/models/database_entry.dart';
+import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
+import 'package:flutter_inspector_kit/src/models/network_entry.dart';
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Fixed, staggered timestamps so ordering is deterministic.
+  final tLog = DateTime(2026, 6, 26, 10, 0, 0); // oldest
+  final tNav = DateTime(2026, 6, 26, 10, 0, 1);
+  final tNetwork = DateTime(2026, 6, 26, 10, 0, 2);
+  final tDb = DateTime(2026, 6, 26, 10, 0, 3); // newest
+
+  /// Seeds one entry into each of the four buffers with the fixed timestamps.
+  void seedAll(InspectorRegistry registry) {
+    registry.log.add(LogEntry(message: 'log msg', timestamp: tLog));
+    registry.network.add(
+      NetworkEntry(method: 'GET', url: '/api', timestamp: tNetwork),
+    );
+    registry.navigator.add(
+      NavigatorEntry(
+        action: NavigatorAction.push,
+        routeName: '/home',
+        timestamp: tNav,
+      ),
+    );
+    registry.database.add(
+      DatabaseEntry(
+        operation: DatabaseOperation.insert,
+        tableName: 'users',
+        timestamp: tDb,
+      ),
+    );
+  }
+
+  group('InspectorRegistry.mergedTimeline', () {
+    test('default returns all four entries sorted by timestamp descending', () {
+      final inspector = FlutterInspector();
+      seedAll(inspector.registry);
+
+      final result = inspector.registry.mergedTimeline();
+
+      expect(result.length, 4);
+      expect(result[0].timestamp, tDb); // newest first
+      expect(result[1].timestamp, tNetwork);
+      expect(result[2].timestamp, tNav);
+      expect(result[3].timestamp, tLog); // oldest last
+    });
+
+    test('single source {network} returns only the network entry', () {
+      final inspector = FlutterInspector();
+      seedAll(inspector.registry);
+
+      final result = inspector.registry.mergedTimeline(
+        sources: {TimelineSource.network},
+      );
+
+      expect(result.length, 1);
+      expect(result.single, isA<NetworkEntry>());
+      expect(result.single.timestamp, tNetwork);
+    });
+
+    test('sources {log, nav} returns two entries, still descending', () {
+      final inspector = FlutterInspector();
+      seedAll(inspector.registry);
+
+      final result = inspector.registry.mergedTimeline(
+        sources: {TimelineSource.log, TimelineSource.nav},
+      );
+
+      expect(result.length, 2);
+      expect(result[0].timestamp, tNav); // nav (10:00:01) before log (10:00:00)
+      expect(result[1].timestamp, tLog);
+      expect(result[0], isA<NavigatorEntry>());
+      expect(result[1], isA<LogEntry>());
+    });
+
+    test('empty buffers return an empty list', () {
+      final inspector = FlutterInspector();
+
+      expect(inspector.registry.mergedTimeline(), isEmpty);
+    });
+  });
+
+  group('FlutterInspector.mergedTimeline thin forward', () {
+    test('default returns all four entries sorted descending', () {
+      final inspector = FlutterInspector();
+      seedAll(inspector.registry);
+
+      final result = inspector.mergedTimeline();
+
+      expect(result.length, 4);
+      expect(result[0].timestamp, tDb);
+      expect(result[3].timestamp, tLog);
+    });
+
+    test('single source {network} returns only the network entry', () {
+      final inspector = FlutterInspector();
+      seedAll(inspector.registry);
+
+      final result = inspector.mergedTimeline(
+        sources: {TimelineSource.network},
+      );
+
+      expect(result.length, 1);
+      expect(result.single, isA<NetworkEntry>());
+    });
+
+    test('empty buffers return an empty list', () {
+      final inspector = FlutterInspector();
+
+      expect(inspector.mergedTimeline(), isEmpty);
+    });
+
+    test('forward is equivalent to registry.mergedTimeline (default)', () {
+      final inspector = FlutterInspector();
+      seedAll(inspector.registry);
+
+      final viaInspector = inspector.mergedTimeline();
+      final viaRegistry = inspector.registry.mergedTimeline();
+
+      expect(viaInspector, equals(viaRegistry));
+      // Same identity-order entries (thin forward returns the same pointers).
+      for (var i = 0; i < viaInspector.length; i++) {
+        expect(identical(viaInspector[i], viaRegistry[i]), isTrue);
+      }
+    });
+  });
+}

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -187,6 +187,40 @@ void main() {
       });
     });
 
+    group('no mirror debug log', () {
+      test('onResponse does not produce any log entry', () {
+        final options = RequestOptions(
+          path: 'http://example.com/api',
+          method: 'GET',
+        );
+        interceptor.onRequest(options, RequestInterceptorHandler());
+        interceptor.onResponse(
+          Response(requestOptions: options, statusCode: 200),
+          ResponseInterceptorHandler(),
+        );
+
+        expect(inspector.logEntries, isEmpty);
+      });
+
+      test('onError does not produce any log entry', () async {
+        final options = RequestOptions(
+          path: 'http://example.com/api',
+          method: 'GET',
+        );
+        interceptor.onRequest(options, RequestInterceptorHandler());
+
+        final errorHandler = ErrorInterceptorHandler();
+        interceptor.onError(
+          DioException(requestOptions: options, error: 'fail'),
+          errorHandler,
+        );
+        // ignore: invalid_use_of_protected_member
+        await errorHandler.future.then((_) {}, onError: (_) {});
+
+        expect(inspector.logEntries, isEmpty);
+      });
+    });
+
     group('isReplay flag', () {
       test('onRequest: isReplay true when extra flag set', () {
         final options = RequestOptions(

--- a/test/models/database_entry_test.dart
+++ b/test/models/database_entry_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_inspector_kit/src/models/database_entry.dart';
+import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DatabaseEntry', () {
+    final fixedTime = DateTime(2026, 6, 27, 14, 30, 1, 123);
+
+    test('implements TimestampedEntry', () {
+      final entry = DatabaseEntry(
+        operation: DatabaseOperation.query,
+        tableName: 'users',
+        timestamp: fixedTime,
+      );
+      expect(entry, isA<TimestampedEntry>());
+    });
+
+    test('displayTime returns HH:mm:ss.mmm format', () {
+      final entry = DatabaseEntry(
+        operation: DatabaseOperation.query,
+        tableName: 'users',
+        timestamp: fixedTime,
+      );
+      // fixedTime = DateTime(2026, 6, 27, 14, 30, 1, 123) → 14:30:01.123
+      expect(entry.displayTime, '14:30:01.123');
+    });
+
+    test('displayTime pads single-digit components', () {
+      final entry = DatabaseEntry(
+        operation: DatabaseOperation.insert,
+        tableName: 'orders',
+        timestamp: DateTime(2026, 1, 1, 9, 5, 3, 7),
+      );
+      expect(entry.displayTime, '09:05:03.007');
+    });
+  });
+}

--- a/test/models/log_entry_test.dart
+++ b/test/models/log_entry_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_inspector_kit/src/models/log_entry.dart';
 import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -66,6 +67,25 @@ void main() {
       );
       expect(entry.toString(), contains('error'));
       expect(entry.toString(), contains('boom'));
+    });
+
+    test('implements TimestampedEntry', () {
+      final entry = LogEntry(message: 'hello', timestamp: fixedTime);
+      expect(entry, isA<TimestampedEntry>());
+    });
+
+    test('displayTime returns HH:mm:ss.mmm format', () {
+      // fixedTime = DateTime(2026, 6, 9, 12, 0, 0) → 12:00:00.000
+      final entry = LogEntry(message: 'hello', timestamp: fixedTime);
+      expect(entry.displayTime, '12:00:00.000');
+    });
+
+    test('displayTime pads single-digit components', () {
+      final entry = LogEntry(
+        message: 'x',
+        timestamp: DateTime(2026, 1, 1, 9, 5, 3, 7),
+      );
+      expect(entry.displayTime, '09:05:03.007');
     });
   });
 }

--- a/test/models/navigator_entry_test.dart
+++ b/test/models/navigator_entry_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NavigatorEntry implements TimestampedEntry', () {
+    final fixedTime = DateTime(2026, 6, 26, 14, 30, 1, 123);
+
+    test('is a TimestampedEntry', () {
+      final entry = NavigatorEntry(
+        action: NavigatorAction.push,
+        routeName: '/home',
+        timestamp: fixedTime,
+      );
+      expect(entry, isA<TimestampedEntry>());
+    });
+
+    test('displayTime formats as HH:mm:ss.mmm', () {
+      final entry = NavigatorEntry(
+        action: NavigatorAction.push,
+        routeName: '/home',
+        timestamp: fixedTime,
+      );
+      expect(entry.displayTime, '14:30:01.123');
+    });
+  });
+}

--- a/test/models/network_entry_test.dart
+++ b/test/models/network_entry_test.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_inspector_kit/src/models/network_entry.dart';
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -171,6 +172,35 @@ void main() {
           result.substring(0, kNetworkBodyMaxLength),
           'a' * kNetworkBodyMaxLength,
         );
+      });
+    });
+
+    group('TimestampedEntry contract', () {
+      test('NetworkEntry is a TimestampedEntry', () {
+        final entry = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: fixedTime,
+        );
+        expect(entry, isA<TimestampedEntry>());
+      });
+
+      test('displayTime formats as HH:mm:ss.mmm', () {
+        final entry = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: DateTime(2026, 6, 9, 14, 30, 1, 123),
+        );
+        expect(entry.displayTime, '14:30:01.123');
+      });
+
+      test('displayTime zero-pads all components', () {
+        final entry = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: DateTime(2026, 1, 1, 1, 2, 3, 4),
+        );
+        expect(entry.displayTime, '01:02:03.004');
       });
     });
 

--- a/test/models/timestamped_entry_test.dart
+++ b/test/models/timestamped_entry_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Test-local fixture: implements the narrow contract by exposing only
+/// [timestamp], so [displayTime] is exercised purely through the extension.
+class _Fixture implements TimestampedEntry {
+  _Fixture(this.timestamp);
+
+  @override
+  final DateTime timestamp;
+}
+
+void main() {
+  group('TimestampedEntryDisplay.displayTime', () {
+    test('formats as HH:mm:ss.mmm', () {
+      final entry = _Fixture(DateTime(2026, 6, 26, 14, 30, 1, 123));
+      expect(entry.displayTime, '14:30:01.123');
+    });
+
+    test('zero-pads single-digit hour/minute/second and millisecond', () {
+      final entry = _Fixture(DateTime(2026, 1, 1, 9, 5, 3, 7));
+      expect(entry.displayTime, '09:05:03.007');
+    });
+
+    test('renders millisecond 0 as .000', () {
+      final entry = _Fixture(DateTime(2026, 1, 1, 0, 0, 0, 0));
+      expect(entry.displayTime, '00:00:00.000');
+    });
+  });
+}

--- a/test/observers/navigator_observer_test.dart
+++ b/test/observers/navigator_observer_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
-import 'package:flutter_inspector_kit/src/models/log_level.dart';
 import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
 import 'package:flutter_inspector_kit/src/observers/navigator_observer.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -124,23 +123,9 @@ void main() {
       expect(inspector.navigatorInspector.entries, isEmpty);
     });
 
-    test('mirrors a navigation event to the console log at warning level', () {
+    test('does not mirror any navigation event to the console log', () {
       final route = MaterialPageRoute(
         settings: const RouteSettings(name: '/home'),
-        builder: (_) => const SizedBox(),
-      );
-      observer.didPush(route, null);
-
-      expect(inspector.logEntries.length, 1);
-      final log = inspector.logEntries.first;
-      expect(log.level, LogLevel.warning);
-      expect(log.message, contains('Action: push'));
-      expect(log.message, contains('Route: /home'));
-    });
-
-    test('does not log for the inspector dashboard route', () {
-      final route = MaterialPageRoute(
-        settings: const RouteSettings(name: 'flutter_inspector_dashboard'),
         builder: (_) => const SizedBox(),
       );
       observer.didPush(route, null);

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/database_entry.dart';
+import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
 import 'package:flutter_inspector_kit/src/models/log_level.dart';
-import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/console_tab.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
+import 'package:flutter_inspector_kit/src/models/network_entry.dart';
 import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/console/log_detail_view.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/console_tab.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/network/network_detail_view.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('ConsoleTab', () {
+    // ---- Preserved log-only tests (still valid under default All filter) ----
+
     testWidgets('displays logs and supports clearing', (tester) async {
       final inspector = FlutterInspector();
       inspector.log('Test message 1', level: LogLevel.info);
@@ -104,7 +113,8 @@ void main() {
       );
     });
 
-    testWidgets('tapping pure info log without stackTrace or data does not navigate',
+    testWidgets(
+        'tapping pure info log without stackTrace or data does not navigate',
         (tester) async {
       final inspector = FlutterInspector();
       inspector.log('Pure info', level: LogLevel.info);
@@ -118,13 +128,201 @@ void main() {
       expect(find.text('Pure info'), findsOneWidget);
       expect(find.byType(LogDetailView), findsNothing);
 
-      // Try to tap the log entry
+      // Try to tap the log entry.
       final tile = find.byType(ListTile).first;
       await tester.tap(tile);
       await tester.pumpAndSettle();
 
-      // LogDetailView should not appear because onTap is null
+      // LogDetailView should not appear because onTap is null.
       expect(find.byType(LogDetailView), findsNothing);
+    });
+
+    // ---- New merged-timeline tests ----
+
+    testWidgets('filter chip Network shows only network rows', (tester) async {
+      final inspector = FlutterInspector();
+      inspector.log('a log', level: LogLevel.info);
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/x',
+          statusCode: 200,
+          isComplete: true,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      // Default All filter: both visible.
+      expect(find.text('a log'), findsOneWidget);
+      expect(find.textContaining('https://api.test/x'), findsOneWidget);
+
+      // Switch to Network filter.
+      await tester.tap(find.widgetWithText(FilterChip, 'Network'));
+      await tester.pump();
+
+      expect(find.text('a log'), findsNothing);
+      expect(find.textContaining('https://api.test/x'), findsOneWidget);
+    });
+
+    testWidgets('All filter shows mixed sources sorted newest-first',
+        (tester) async {
+      final inspector = FlutterInspector();
+      final tLog = DateTime(2026, 6, 26, 10, 0, 0); // oldest
+      final tNav = DateTime(2026, 6, 26, 10, 0, 1);
+      final tNet = DateTime(2026, 6, 26, 10, 0, 2);
+      final tDb = DateTime(2026, 6, 26, 10, 0, 3); // newest
+
+      inspector.registry.log.add(LogEntry(message: 'log msg', timestamp: tLog));
+      inspector.registry.navigator.add(
+        NavigatorEntry(
+          action: NavigatorAction.push,
+          routeName: '/home',
+          timestamp: tNav,
+        ),
+      );
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/x',
+          statusCode: 200,
+          isComplete: true,
+          timestamp: tNet,
+        ),
+      );
+      inspector.registry.database.add(
+        DatabaseEntry(
+          operation: DatabaseOperation.insert,
+          tableName: 'users',
+          timestamp: tDb,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      // All four sources present.
+      expect(find.text('log msg'), findsOneWidget);
+      expect(find.textContaining('/home'), findsOneWidget);
+      expect(find.textContaining('https://api.test/x'), findsOneWidget);
+      expect(find.textContaining('users'), findsOneWidget);
+
+      // Newest-first: db row above network above nav above log.
+      final dbY = tester.getTopLeft(find.textContaining('users')).dy;
+      final netY = tester.getTopLeft(find.textContaining('https://api.test/x')).dy;
+      final navY = tester.getTopLeft(find.textContaining('/home')).dy;
+      final logY = tester.getTopLeft(find.text('log msg')).dy;
+
+      expect(dbY, lessThan(netY));
+      expect(netY, lessThan(navY));
+      expect(navY, lessThan(logY));
+    });
+
+    testWidgets('network row taps into NetworkDetailView', (tester) async {
+      final inspector = FlutterInspector();
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/x',
+          statusCode: 200,
+          isComplete: true,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      expect(find.byType(NetworkDetailView), findsNothing);
+
+      await tester.tap(find.textContaining('https://api.test/x'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NetworkDetailView), findsOneWidget);
+    });
+
+    testWidgets('network row tap forwards redactSensitiveData', (tester) async {
+      final inspector = FlutterInspector(redactSensitiveData: false);
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/x',
+          statusCode: 200,
+          isComplete: true,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      await tester.tap(find.textContaining('https://api.test/x'));
+      await tester.pumpAndSettle();
+
+      final view =
+          tester.widget<NetworkDetailView>(find.byType(NetworkDetailView));
+      expect(view.redactSensitiveData, isFalse);
+    });
+
+    testWidgets('nav and db rows are not tappable (no chevron)',
+        (tester) async {
+      final inspector = FlutterInspector();
+      inspector.registry.navigator.add(
+        NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
+      );
+      inspector.registry.database.add(
+        DatabaseEntry(
+          operation: DatabaseOperation.insert,
+          tableName: 'users',
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      // Neither nav nor db row shows a chevron.
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+
+      // Tapping the nav row navigates nowhere.
+      await tester.tap(find.textContaining('/home'));
+      await tester.pumpAndSettle();
+      expect(find.byType(NetworkDetailView), findsNothing);
+      expect(find.byType(LogDetailView), findsNothing);
+
+      // Tapping the db row navigates nowhere.
+      await tester.tap(find.textContaining('users'));
+      await tester.pumpAndSettle();
+      expect(find.byType(NetworkDetailView), findsNothing);
+      expect(find.byType(LogDetailView), findsNothing);
+    });
+
+    testWidgets('each row shows displayTime (HH:mm:ss.mmm)', (tester) async {
+      final inspector = FlutterInspector();
+      inspector.registry.log.add(
+        LogEntry(message: 'tm', timestamp: DateTime(2026, 6, 26, 14, 30, 1, 123)),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      expect(find.text('14:30:01.123'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Console tab 原本靠「把其他層事件**複製成字串**塞進 log buffer」假裝呈現綜合情境。此 PR 改成**渲染當下讀四個 buffer（log/network/nav/db）、按 timestamp merge-sort、引用原 entry**，並移除 interceptor/observer 的鏡射 log。
- 混合只發生在「渲染讀取」當下，不發生在「寫入」當下 —— Console 不再擁有第二份資料，而是引用四個既有 buffer 的原始 entry。
- 頂部新增 source filter chip `[All][Log][Network][Nav][DB]`（預設 All），順帶解決 Console 原本缺的過濾 / errors-only 需求。

## 修正的問題（Issue #40）

複製式鏡射有三個病灶：

1. **第二份真相**：複製的是字串快照。network entry pending→completed 更新後，console 那份快照不會跟著變，軸上一份、詳情頁另一份對不上；點進去也看不到完整結構。
2. **偽造 level**：nav 硬塞 `LogLevel.warning`、network 硬塞 `LogLevel.debug` 只為了有顏色，污染真實 level 語意。
3. **吃 buffer 配額**：複製字串灌進 log buffer（500 格），把真正的 error log 擠出視窗。db 操作則從未鏡射，綜合情境一直缺 db。

## 修正方式

**Commit 1 — TimestampedEntry 契約地基**（`69265d9`）
- 新增 `lib/src/models/timestamped_entry.dart`：`abstract interface class TimestampedEntry`（窄契約，只 `timestamp` getter）+ `displayTime` extension（`HH:mm:ss.mmm`）+ `enum TimelineSource`。
- 四個 model `implements TimestampedEntry`，零行為改動（只在既有 `timestamp` 加 `@override`）。
- raw data（timestamp）進介面、derived（displayTime）進 extension（DRY）。

**Commit 2 — mergedTimeline + 移除鏡射**（`c362cd3`）
- `InspectorRegistry.mergedTimeline({sources})`：收集階段用 `if` 依 sources 過濾 → 合併 → 依 timestamp 降冪排序，回傳原 entry 指標（不複製、不產生第二份真相）。`FlutterInspector` 開薄轉發。
- 刪 dio interceptor 兩處 debug 鏡射、navigator observer 一處 warning 鏡射，連同不再使用的 import 與過時 doc。

**Commit 3 — console_tab UI 改寫**（`8cc8fd8`）
- 讀 `mergedTimeline(sources:)`，用 `switch`/`is` 判型分派四種視覺；log/network 列可點（→ LogDetailView / NetworkDetailView），nav/db 列不可點。
- filter chip row `[All][Log][Network][Nav][DB]`，預設 All。
- network 列跳轉傳 `redactSensitiveData: widget.inspector.redactSensitiveData`，與 NetworkTab 一致（#38 / PR #39），避免同一筆 entry 從不同入口行為分歧。

## 範圍邊界（Out of scope）

| 項目 | 原因 |
|------|------|
| buffer 合併成單一資料源 | 四 buffer 維持各自獨立（各 500 格），混合只在渲染當下 —— 這正是解決「配額互吃」的關鍵，不可合併 |
| RingBuffer 效能優化 | 500 格非真問題 |
| 獨立的 Timeline tab | 直接做進 Console，不另開 tab |
| nav / db 的 detail view | 本次 nav/db 列不可點，不補 detail view |
| 敏感資料遮罩本身 | 已於 #38 / PR #39 完成，本 PR 只負責跳轉時正確轉傳 flag |

## 驗證

- `flutter analyze lib/`：0 issues。
- 本功能相關測試全綠（逐檔指定，避開既有 10 分鐘 timeout 的 magical_tap_test）：
  - `mergedTimeline`：預設四源降冪、單一/多 source 過濾、空 buffer 回空、薄轉發等價（`identical` 指標驗證）。
  - console_tab：All 混合排序、filter 切換、network 列跳轉且正確轉傳 `redactSensitiveData`（host 設 false 時 detail view 亦為 false）、nav/db 不可點、displayTime 格式。
  - 移除鏡射守門測試：interceptor/observer 不再寫鏡射 log。
  - 向後相容：`logEntries` / `clearLogs` 語意不變，Network/Nav/DB 三 tab 不受影響。

## 已知事項（非本 PR 引入）

`test/models/network_entry_test.dart` 有 2 個 `sourceDio copyWith` 測試在 main 上即失敗（WeakReference vs same-instance 斷言過時），與本 PR 無關，已獨立開 issue #41 追蹤。本 PR 對該檔只新增 `TimestampedEntry contract` group（全綠）。

Closes #40
