### PR TITLE
fix(test): unwrap WeakReference in sourceDio copyWith assertions (#41)

### DIFF
--- a/test/models/network_entry_test.dart
+++ b/test/models/network_entry_test.dart
@@ -126,7 +126,9 @@ void main() {
           isComplete: true,
         );
         final withDio = entry.copyWith(sourceDio: dio);
-        expect(withDio.sourceDio, same(dio));
+        // sourceDio is stored as a WeakReference<Dio>; unwrap .target to
+        // compare against the original instance.
+        expect(withDio.sourceDio?.target, same(dio));
         expect(withDio.method, entry.method);
         expect(withDio.url, entry.url);
         expect(withDio.statusCode, entry.statusCode);
@@ -143,7 +145,9 @@ void main() {
           sourceDio: dio,
         );
         final copied = entry.copyWith(isReplay: true);
-        expect(copied.sourceDio, same(dio));
+        // sourceDio is stored as a WeakReference<Dio>; unwrap .target to
+        // compare against the original instance.
+        expect(copied.sourceDio?.target, same(dio));
         expect(copied.isReplay, isTrue);
       });
     });


### PR DESCRIPTION
## Summary

- `test/models/network_entry_test.dart` 有 2 個 `sourceDio copyWith` 測試在 main 上持續失敗，本 PR 修正其過時斷言，讓 `flutter test test/models/network_entry_test.dart` 回到全綠。
- **純測試修正**，不動任何生產程式碼。

## 修正的問題（Issue #41）

PR #36 把 `NetworkEntry.sourceDio` 型別從 `Dio?` 改成 `WeakReference<Dio>?`（防止 ring buffer 滯留 Dio instance），但對應測試仍用 `expect(..sourceDio, same(dio))` 期待原始 `Dio`：

```
Expected: same instance as <Instance of 'DioForNative'>
  Actual: _WeakReference<Dio>:<_WeakReference<Dio>>
```

型別對不上 → 測試恆失敗。這是測試斷言過時，非生產碼錯誤（runtime 行為正確）。

## 修正方式

兩處斷言解包 `.target` 後比對，並加註解說明為何要解包（避免未來被「修回」`same(dio)`）：

```dart
expect(withDio.sourceDio?.target, same(dio));
expect(copied.sourceDio?.target, same(dio));
```

`equality / hashCode` 那條測試驗的是「sourceDio 不影響 ==」，不碰值比對，正確無需改動。

## 範圍邊界（Out of scope）

- **不改生產程式碼**：`network_entry.dart` 的 `WeakReference` 設計是 PR #36 刻意為防記憶體滯留而做，正確，保留不動。

## 驗證

- `flutter analyze test/models/network_entry_test.dart`：0 issues。
- `flutter test test/models/network_entry_test.dart`：21 tests 全綠（先前 2 個 sourceDio 失敗轉綠）。

## 備註

此問題於 #40（console merged timeline）開發期間發現，經 git stash 切 main 對照確認為 pre-existing，當時獨立開 #41 追蹤，本 PR 處理。

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
