### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.0
+
+### Added
+* **Merged cross-layer timeline**: the Console tab now interleaves logs, network, navigation, and database events on a single timestamp-sorted timeline (newest first), with a filter chip per source to narrow it down. The same view is exposed programmatically via `FlutterInspector.mergedTimeline({sources})`, which returns `List<TimestampedEntry>` sorted by `timestamp` descending. Filter with the new `TimelineSource` enum (`log` / `network` / `nav` / `db`); a shared `displayTime` (`HH:mm:ss.mmm`) helper is available on every timeline entry.
+* **Sensitive-data redaction**: a new `redactSensitiveData` constructor flag on `FlutterInspector` (defaults to `true`) masks sensitive headers — `Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key` (matched case-insensitively) — with `••••` across every Network share/export path (copy as cURL, copy as text, system share sheet). Secure by default; pass `redactSensitiveData: false` to opt out. Headers shown live inside the dashboard are unaffected.
+
+### Changed
+* The Console timeline is now assembled by merging the four event buffers at render time instead of mirroring network and navigation events into the Console as separate log strings. As a result, `FlutterInspectorDioInterceptor` no longer emits an extra `debug`-level Console log per request, and `FlutterInspectorNavigatorObserver` no longer mirrors route changes as `warning`-level logs (both introduced in 0.2.4) — those events still appear on the merged timeline via their own buffers, without the duplicate log entries.
+
 ## 1.0.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 ## 📦 Features
 
 - 🪵 **Console**: capture logs across five severity levels, with optional structured data and stack traces
+- 🧵 **Merged timeline**: the Console tab interleaves logs, network, navigation, and database events on one timestamp-sorted timeline, with per-source filter chips
 - 📡 **Network**: intercept HTTP traffic via Dio, inspect structured request/response details, search/filter, share as cURL
+- 🛡️ **Sensitive-data redaction**: secure by default — sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`) are masked in every share/export path
 - 🧭 **Navigator**: track route pushes, pops, and replacements automatically
 - 🗄️ **Database**: record insert / update / delete / query operations with affected-row counts and payloads
 - 👆 **Magical tap & floating button**: open the dashboard with a hidden multi-tap gesture or a draggable in-app FAB
@@ -31,7 +33,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.0.0
+  flutter_inspector_kit: ^1.1.0
 ```
 
 Then run `flutter pub get`.
@@ -136,6 +138,22 @@ inspector.logNetwork(completedEntry, replaces: pending);
 - **Call details**: tap any call for a structured view — General (method, URL, status with color coding, duration, request/response sizes), Query Parameters, Headers, and JSON-pretty bodies. Truncated bodies are clearly marked.
 - **Sharing**: copy the call as a runnable `cURL` command, copy the full details as text, or open the system share sheet (native via `share_plus`, web via the browser Web Share API — falls back to the clipboard when unavailable).
 - **Replay / Resend**: for requests captured with a `sourceDio` provided to the interceptor, you can trigger a "Resend" action in the detail view to replay the request locally using the same Dio client (carrying the same headers, base URL, and interceptors). Replayed requests automatically show up as new entries with a dedicated "Replay" label.
+
+### Redact sensitive headers
+
+Every share/export path in the Network detail view — copy as `cURL`, copy as text, and the system share sheet — **masks sensitive headers by default**, so secrets never leak to the clipboard, a share sheet, or a screenshot. The masked keys are `Authorization`, `Cookie`, `Set-Cookie`, and `X-Api-Key` (matched case-insensitively); their values are replaced with `••••`.
+
+This is controlled by the `redactSensitiveData` constructor flag, which defaults to `true`:
+
+```dart
+// Secure by default — sensitive headers are masked in shared/exported output.
+final inspector = FlutterInspector();
+
+// Opt out (e.g. internal builds where you need the raw values).
+final inspector = FlutterInspector(redactSensitiveData: false);
+```
+
+The flag only affects shared/exported text — the headers shown live inside the dashboard are always the real values.
 
 ### Live notification (opt-in)
 
@@ -252,6 +270,27 @@ inspector.log(
 ```
 
 Available levels: `verbose`, `debug`, `info`, `warning`, `error`.
+
+### Read the merged timeline
+
+The **Console** tab already interleaves logs, network, navigation, and database events on a single timeline (newest first), with a filter chip per source. You can also read that same merged view programmatically:
+
+```dart
+// All sources, newest first.
+final entries = inspector.mergedTimeline();
+
+// Filter to specific sources only.
+final networkAndLogs = inspector.mergedTimeline(
+  sources: {TimelineSource.network, TimelineSource.log},
+);
+
+for (final entry in entries) {
+  // displayTime is a shared HH:mm:ss.mmm helper on every TimestampedEntry.
+  print('${entry.displayTime}  $entry');
+}
+```
+
+`mergedTimeline` returns `List<TimestampedEntry>` sorted by `timestamp` descending. Available sources: `TimelineSource.log`, `.network`, `.nav`, `.db` (defaults to all). The entries are the live buffer objects, so a pending network call that later completes is reflected on the next read.
 
 ### Uncaught error capture (opt-in)
 

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -20,7 +20,7 @@ import 'inspector_registry.dart';
 /// The core entry point for the Flutter Inspector.
 class FlutterInspector {
   /// Package version.
-  static const String version = '1.0.0';
+  static const String version = '1.1.0';
 
   /// Creates a new FlutterInspector instance.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues

--- a/test/flutter_inspector_test.dart
+++ b/test/flutter_inspector_test.dart
@@ -9,7 +9,7 @@ void main() {
     });
 
     test('exposes the package version', () {
-      expect(FlutterInspector.version, '0.2.3');
+      expect(FlutterInspector.version, '1.1.0');
     });
   });
 }


### PR DESCRIPTION
### Summary
[#44](https://github.com/Yomiamy/flutter_inspector_kit/issues/44) Release: Version 1.1.0

**[修正問題]**
發布新版 `1.1.0`，整合最近合併入 `main` 的兩條核心變更——**跨層合併時序軸（merged cross-layer timeline）** 與 **敏感資料遮蔽（sensitive-data redaction）**，並同步更新 `pubspec.yaml`、`lib` 版號常數、說明文檔與變更日誌。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號 `1.0.0` → `1.1.0`。
2. **`lib/src/core/flutter_inspector.dart`**：同步 `FlutterInspector.version` 常數至 `1.1.0`。
3. **`test/flutter_inspector_test.dart`**：修正硬編碼版號斷言（`0.2.3` → `1.1.0`），修掉 `main` 上既有的測試紅燈（v1.0.0 release 時漏改）。
4. **`README.md`**：安裝版號 `^1.0.0` → `^1.1.0`；Features 清單補上 merged timeline 與 redaction；新增 `redactSensitiveData` 用法與 `mergedTimeline()` API 說明段落。
5. **`CHANGELOG.md`**：新增 `1.1.0` 區塊，分類記錄 Added（merged timeline、redaction）與 Changed（移除 0.2.4 的 Console string mirroring）。
