### PR TITLE
docs: add architecture reference docs and refresh feature brainstorm status

### DIFF
--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -38,7 +38,7 @@
 
 ### 關鍵細節：請求重發 (Replay Request)
 在 `NetworkDetailView` 中點擊「重發」按鈕時：
-1. **安全性檢查**：必須滿足「來源 `Dio` 未被回收（`sourceDio.target != null`）」且「Body 未被截斷（`isRequestTruncated == false`）」。
+1. **安全性檢查**：必須滿足「請求已完成（`entry.isComplete == true`）」、「來源 `Dio` 未被回收（`sourceDio.target != null`）」且「Body 未被截斷（`isRequestTruncated == false`）」。
 2. **防死循環標記**：重發的請求會自動注入 `_inspector_is_replay: true` 到 `options.extra` 中。這可以使新請求在被攔截器捕獲時，標記為 `isReplay = true`，防止開發者混淆。
 
 ---

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,0 +1,279 @@
+# Flutter Inspector Kit - 數據流與功能流程 (Data Flow)
+
+> 「好的程式碼沒有特殊情況。」 —— Linus Torvalds
+
+本文件詳細剖析本套件內四大核心功能的運作流程、狀態移轉與數據傳遞軌跡，並介紹了 `v1.1.0` 重構前後跨層混合時序軸（Merged Timeline）的資料流演進。
+
+---
+
+## 1. 網路請求攔截與更新流程 (HTTP Interception & Completion)
+
+在網路請求的生命週期中，數據被低干涉地捕獲兩次：發出請求時（用於即時顯示 pending 狀態）與響應/失敗時（更新狀態碼、時長與 Body）。
+
+### 數據流時序圖
+在 `v1.1.0` 中，網絡請求純淨寫入 `NetworkInspector` 的環形快取中，不產生任何日誌鏡射。
+
+```text
+  Dio Client (App)            DioInterceptor               FlutterInspector & Registry
+       │                           │                                    │
+       │─── 1. 發起 Request ──────>│                                    │
+       │                           │─── 2. 建立 Incomplete Entry ──────>│
+       │                           │    (記錄 startTime)                │
+       │                           │<── 3. 返回 pendingEntry ───────────│
+       │                           │                                    │
+       │                           │─── 4. 存入 options.extra ──────────│
+       │<── 5. 放行 Request ───────│                                    │
+       │                           │                                    │
+       ~   ( 網絡傳輸中... )        ~                                    ~
+       │                           │                                    │
+       │─── 6. 響應/失敗 ─────────>│                                    │
+       │                           │─── 7. 從 options.extra 取得 pending│
+       │                           │─── 8. 原地更替為 Completed Entry ─>│
+       │                           │    (透過 RingBuffer.replace())     │
+       │                           │                                    │
+       │                           │─── 9. [選用] 發送平台自適應通知 ──>│
+       │                           │    (經 AlertThrottler 靜默限制)    │
+       │<── 10. 返回 Response ─────│                                    │
+```
+
+### 關鍵細節：請求重發 (Replay Request)
+在 `NetworkDetailView` 中點擊「重發」按鈕時：
+1. **安全性檢查**：必須滿足「來源 `Dio` 未被回收（`sourceDio.target != null`）」且「Body 未被截斷（`isRequestTruncated == false`）」。
+2. **防死循環標記**：重發的請求會自動注入 `_inspector_is_replay: true` 到 `options.extra` 中。這可以使新請求在被攔截器捕獲時，標記為 `isReplay = true`，防止開發者混淆。
+
+---
+
+## 2. 🧵 跨層混合時序軸的設計與歸併排序 (Merged Timeline)
+
+在 `v1.1.0` 重構後，我們徹底刪除了擷取層的 `_inspector.log(...)` 鏡射呼叫，從而實現了單一真相源（Single Source of Truth）。
+
+### 2.1 執行時序對比區塊圖 (Execution Timeline Comparison)
+
+這兩者在「事件發生」與「UI 渲染」兩個不同階段的執行時序有本質上的差異：
+
+#### 歷史方案 A：v1.1.0 之前的複製式鏡射 (Mirroring)
+在事件發生時，攔截器強行進行「雙寫（Double Write）」，將資料轉為字串拷貝，導致快取重疊與狀態不同步。
+
+```text
+  【 1. 事件發生 (e.g. 網絡完成) 】
+  ┌──────────────────────────────────────────────────┐
+  │  事件源 (Dio/Navigator/DB)                        │
+  └────────┬───────────────────────────────┬─────────┘
+           │                               │
+           ▼ (寫入結構化數據)              ▼ (複製為字串鏡射)
+  ┌────────────────────────────────┐ ┌──────────────────────────────┐
+  │  目標 Buffer (Network/Nav/DB)  │ │  Log RingBuffer              │
+  │  (原地更新為 Completed)         │ │  (寫入 LogEntry)              │
+  └────────────────────────────────┘ └──────────────┬───────────────┘
+                                                    │ (讀取日誌緩存)
+                                                    ▼
+                                     ┌──────────────────────────────┐
+                                     │  UI ConsoleTab               │
+                                     │  (僅能顯示純文字、無互動跳轉)│
+                                     └──────────────────────────────┘
+```
+
+#### 現行方案 B：v1.1.0 的 `Merged Timeline` 動態排序
+事件發生時純淨寫入（單一真相源），僅在 UI 渲染時按需進行歸併排序。
+
+```text
+  【 1. 事件發生 】
+  ┌──────────────────────────────────────────────────┐
+  │  事件源 (Dio/Navigator/DB)                        │
+  └────────┬─────────────────────────────────────────┘
+           │ (純淨寫入結構化數據，無複製鏡射，零贅餘)
+           ▼
+  ┌──────────────────────────────────────────────────┐
+  │  各自 RingBuffer (Network / Navigator / DB / Log) │
+  └────────┬─────────────────────────────────────────┘
+           │
+           │ 【 2. UI 渲染期 】
+           │ (呼叫 mergedTimeline(sources))
+           ▼
+  ┌──────────────────────────────────────────────────┐
+  │  InspectorRegistry 核心                           │
+  │  → 讀取所有啟用源 (Log + Network + Nav + DB)      │
+  │  → 拍扁 (Flatten) 所有數據                        │
+  │  → 依 timestamp 進行記憶體中降序 Merge-Sort       │
+  └────────┬─────────────────────────────────────────┘
+           │ (回傳 List<TimestampedEntry>)
+           ▼
+  ┌──────────────────────────────────────────────────┐
+  │  UI ConsoleTab                                   │
+  │  → 依 Entry 實際類型分派渲染                       │
+  │  → Network 類型 Row 點擊可跳轉 DetailView 交互   │
+  └──────────────────────────────────────────────────┘
+```
+
+---
+
+### 2.2 核心指標與機制對照
+
+| 階段 | 歷史方案 A: 複製式鏡射 (v1.1.0 之前) | 現行方案 B: 歸併排序 (v1.1.0 之後) |
+| :--- | :--- | :--- |
+| **擷取期 (Capture)** | 寫入 Network RingBuffer，同時產生一條字串 `LogEntry` 寫入 Log RingBuffer。 | **只寫入 Network RingBuffer**，日誌快取維持 100% 純淨。 |
+| **狀態更新 (Update)** | Network 快取原地更新為 Completed，但 Log 快取內的字串依然是舊的 pending 快照。 | 各快取獨立，Network 原地更新。**不存在第二份真相**。 |
+| **讀取期 (Read)** | UI `ConsoleTab` 只需單純讀取 `LogInspector.entries`。 | UI `ConsoleTab` 通過 `FlutterInspector.mergedTimeline(sources)` 向 Registry 查詢。 |
+| **整合排序 (Sort)** | 無需排序（因為寫入時已按先後順序轉為 Log 字串）。 | **渲染時排序**：讀取四個 RingBuffer 拍扁（Flatten）成 `List<TimestampedEntry>`，並在內存中按 `timestamp` 進行降序 merge-sort。 |
+| **點擊查看 (Interaction)** | 點擊鏡射日誌只能看字串，無 Headers/Body，因為它只是個 `LogEntry`。 | 點擊 Network 類型的時序軸列，會利用 `is` 判型直接跳轉至完整的 `NetworkDetailView`，支持 cURL/Replay。 |
+
+---
+
+### 2.3 Merged Timeline 歸併排序運作流程
+
+```text
+  ┌────────────────────────────────────────┐
+  │         ConsoleTab 進行 UI 渲染        │
+  └───────────────────┬────────────────────┘
+                      │ 呼叫
+                      ▼
+  ┌────────────────────────────────────────┐
+  │    FlutterInspector.mergedTimeline     │
+  └───────────────────┬────────────────────┘
+                      │ 轉發
+                      ▼
+  ┌────────────────────────────────────────┐
+  │   InspectorRegistry.mergedTimeline     │
+  └───────────────────┬────────────────────┘
+                      │
+                      ├─► 讀取 Log RingBuffer (TimelineSource.log)
+                      ├─► 讀取 Network RingBuffer (TimelineSource.network)
+                      ├─► 讀取 Navigator RingBuffer (TimelineSource.nav)
+                      └─► 讀取 Database RingBuffer (TimelineSource.db)
+                      │
+                      ▼
+  ┌────────────────────────────────────────┐
+  │          List.addAll 合併列表          │
+  └───────────────────┬────────────────────┘
+                      │
+                      ▼
+  ┌────────────────────────────────────────┐
+  │  list.sort 按 timestamp 降序 Memory 排序│
+  └───────────────────┬────────────────────┘
+                      │ 回傳 List<TimestampedEntry>
+                      ▼
+  ┌────────────────────────────────────────┐
+  │  UI層 ListView.builder (依 is 判型渲染) │
+  ├────────────────────────────────────────┤
+  │  → LogEntry: 渲染日誌行                 │
+  │  → NetworkEntry: 渲染網絡行 (支援點擊)  │
+  │  → NavigatorEntry: 渲染導航行           │
+  │  → DatabaseEntry: 渲染資料庫行           │
+  └────────────────────────────────────────┘
+```
+
+---
+
+## 3. 路由導航監聽流程 (Navigation Observing)
+
+透過將 `FlutterInspectorNavigatorObserver` 註冊至 `MaterialApp.navigatorObservers`，套件能實時記錄路由事件。
+
+```text
+  ┌────────────────────────────────────────┐
+  │          App 發生路由導航變化          │
+  └───────────────────┬────────────────────┘
+                      │ (didPush / didPop / didReplace / didRemove)
+                      ▼
+  ┌────────────────────────────────────────┐
+  │     NavigatorObserver 監聽攔截         │
+  └───────────────────┬────────────────────┘
+                      │
+                      ▼
+            是否為控制台頁面？
+            (flutter_inspector_dashboard)
+           ╱        ╲
+        (Yes)       (No)
+         ╱            ╲
+  ┌───────────┐   ┌────────────────────────┐
+  │ 忽略，不記 │   │   安全解析 Widget 類型  │
+  │ 防止自循環│   └───────────┬────────────┘
+  └───────────┘               │
+                              ▼
+                       路由設定類型？
+                      ╱              ╲
+                (settings is Page)  (其他)
+                  ╱                      ╲
+  ┌───────────────────────┐      Route 是否有 builder？
+  │ 獲取 page.child 的    │     ╱                      ╲
+  │ runtimeType           │   (Yes)                   (No)
+  └──────────┬────────────┘   ╱                          ╲
+             │       ┌───────────────┐          ┌──────────────────┐
+             │       │ 安全呼叫      │          │ 降級使用路由名稱  │
+             │       │ builder 獲取  │          │ settings.name    │
+             │       │ runtimeType   │          │ (或 'Unknown')   │
+             │       └───────┬───────┘          └────────┬─────────┘
+             ▼               ▼                           ▼
+  ┌────────────────────────────────────────────────────────────────┐
+  │                       建立 NavigatorEntry                      │
+  └───────────────────────────────┬────────────────────────────────┘
+                                  │
+                                  └─► 寫入 NavigatorInspector RingBuffer
+```
+
+---
+
+## 4. 未捕獲錯誤鏈接與轉發流程 (Error Handling & Chaining)
+
+當配置 `captureUncaughtErrors: true` 時，套件會主動掛載錯誤處理鉤子。為保證向後兼容性（Never break userspace），我們決不能吞掉錯誤。
+
+```text
+                  主應用發生 Uncaught Error
+                              │
+                              ▼
+                      錯誤發生在何處？
+               ┌──────────────┼──────────────┐
+               │              │              │
+               ▼ (渲染/UI)    ▼ (非同步/Dart) ▼ (Widget 構建崩潰)
+         FlutterError   PlatformDispatcher  ErrorWidget
+           .onError        .instance.onError   .builder
+               │              │              │
+               └──────────────┼──────────────┘
+                              ▼
+                     建立 LogEntry (Error)
+                              │
+                              ▼
+                 安全處理 (try-catch 隔離包裹)
+                              │
+                              ▼
+                寫入 LogInspector RingBuffer
+                              │
+                              ▼
+                   是否存在 Host 原始 Handler？
+                    ╱                      ╲
+                  (Yes)                    (No)
+                  ╱                          ╲
+  ┌────────────────────────┐      ┌────────────────────────┐
+  │ 調用舊 Handler 轉發錯誤 │      │ 調用系統預設錯誤處理    │
+  │ (如發送至 Crashlytics) │      │ (或崩潰紅畫面渲染)     │
+  └────────────────────────┘      └────────────────────────┘
+```
+
+- **安全防護**：如上圖所示，即使寫入過程發生任何異常，控制權也會在 `finally` 中被交回給 `Forward` 或 `System`，Host 應用絕不會因為除錯套件的日誌記錄失敗而產生二次崩潰。
+
+---
+
+## 5. 資料庫操作虛擬化與瀏覽流程 (Database Virtualization)
+
+套件提供了可擴充的 `DatabaseBrowserSource` 介面，不僅支持真正的 App 資料庫（如 SQLite），還利用該介面設計了「操作日誌瀏覽器」。
+
+```text
+  App 執行 SQL 操作 ──► FlutterInspector ──► DatabaseInspector RingBuffer
+                                                    │
+                                                    ▼
+                                         OperationLogSource 虛擬化
+                                        ┌───────────┴───────────┐
+                                        │                       │
+                                        ▼                       ▼
+                                   虛擬資料表              虛擬資料行
+                                  (依 SQL 影響表名分群)   (格式化欄位與 timestamp)
+                                        │                       │
+                                        ▼                       ▼
+                                   DatabaseTab (UI) ◄─── 動態分頁載入 (Load More)
+                                   (支援排序與分頁)
+```
+
+### 資料分頁與排序 (TableRowsView & TableSort)
+1. **動態加載 (Load More)**：`TableRowsView` 採用 `limit` (預設 200) 與 `offset` 機制進行分頁加載。用戶滑動到底部時觸發 `Load More`，累加 `offset` 並向資料源重新請求數據。
+2. **表頭排序 (Sort)**：點擊表頭時，由 `table_sort.dart` 的 `sortRows` 執行內存排序：
+   - 排序原則：`Null` 值一律排在最後（不論正序/倒序）。
+   - 數值類型按數值大小比較，其餘類型轉為字串比較。

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -114,7 +114,7 @@
 | **擷取期 (Capture)** | 寫入 Network RingBuffer，同時產生一條字串 `LogEntry` 寫入 Log RingBuffer。 | **只寫入 Network RingBuffer**，日誌快取維持 100% 純淨。 |
 | **狀態更新 (Update)** | Network 快取原地更新為 Completed，但 Log 快取內的字串依然是舊的 pending 快照。 | 各快取獨立，Network 原地更新。**不存在第二份真相**。 |
 | **讀取期 (Read)** | UI `ConsoleTab` 只需單純讀取 `LogInspector.entries`。 | UI `ConsoleTab` 通過 `FlutterInspector.mergedTimeline(sources)` 向 Registry 查詢。 |
-| **整合排序 (Sort)** | 無需排序（因為寫入時已按先後順序轉為 Log 字串）。 | **渲染時排序**：讀取四個 RingBuffer 拍扁（Flatten）成 `List<TimestampedEntry>`，並在內存中按 `timestamp` 進行降序 merge-sort。 |
+| **整合排序 (Sort)** | 無需排序（因為寫入時已按先後順序轉為 Log 字串）。 | **渲染時排序**：讀取四個 RingBuffer 拍扁（Flatten）成 `List<TimestampedEntry>`，並在記憶體中按 `timestamp` 進行降序 merge-sort。 |
 | **點擊查看 (Interaction)** | 點擊鏡射日誌只能看字串，無 Headers/Body，因為它只是個 `LogEntry`。 | 點擊 Network 類型的時序軸列，會利用 `is` 判型直接跳轉至完整的 `NetworkDetailView`，支持 cURL/Replay。 |
 
 ---
@@ -274,6 +274,6 @@
 
 ### 資料分頁與排序 (TableRowsView & TableSort)
 1. **動態加載 (Load More)**：`TableRowsView` 採用 `limit` (預設 200) 與 `offset` 機制進行分頁加載。用戶滑動到底部時觸發 `Load More`，累加 `offset` 並向資料源重新請求數據。
-2. **表頭排序 (Sort)**：點擊表頭時，由 `table_sort.dart` 的 `sortRows` 執行內存排序：
+2. **表頭排序 (Sort)**：點擊表頭時，由 `table_sort.dart` 的 `sortRows` 執行記憶體排序：
    - 排序原則：`Null` 值一律排在最後（不論正序/倒序）。
    - 數值類型按數值大小比較，其餘類型轉為字串比較。

--- a/docs/architecture/file-reference.md
+++ b/docs/architecture/file-reference.md
@@ -1,0 +1,81 @@
+# Flutter Inspector Kit - 檔案用途與類型參考表 (File Reference)
+
+本文件列出專案中所有核心源檔的單一職責、包含的關鍵類別與模組歸屬，並記錄了跨層混合時序軸（Merged Timeline）在 `v1.1.0` 重構實作後的代碼現狀。
+
+---
+
+## 📂 核心模組與檔案結構
+
+### 1. 入口與核心層 (`lib/src/core/`)
+
+| 檔案路徑 | 關鍵類別/列舉 | 單一職責 (Single Responsibility) | v1.1.0 混合時序軸重構實作現狀 |
+| :--- | :--- | :--- | :--- |
+| [`flutter_inspector_kit.dart`](../../lib/flutter_inspector_kit.dart) | - | Barrel 檔案，導出本套件對外公開的 API。 | - |
+| [`flutter_inspector.dart`](../../lib/src/core/flutter_inspector.dart) | `FlutterInspector` | 主入口。初始化註冊表、附加 FAB Overlay、配置全域未捕獲錯誤捕捉、調用資料收集。 | **已實裝** `mergedTimeline()`，薄轉發調用註冊表以獲取混合排序後的數據。 |
+| [`inspector_registry.dart`](../../lib/src/core/inspector_registry.dart) | `InspectorRegistry` | 中央註冊表。統一管理四個領域的專屬 Inspector 實例。 | **已實裝** `mergedTimeline()`，負責讀取 Log、Network、Nav、DB 等四個 RingBuffer 並進行歸併排序。 |
+| [`ring_buffer.dart`](../../lib/src/core/ring_buffer.dart) | `RingBuffer<T>` | 基礎 FIFO 環形緩存。提供高效率的 `removeAt(0)` 及就地 `replace` 功能，為所有數據緩存之基石。 | 無影響，維持最單純的高效 FIFO 結構。 |
+
+### 2. 數據模型層 (`lib/src/models/`)
+
+| 檔案路徑 | 關鍵類別/列舉 | 單一職責 (Single Responsibility) | v1.1.0 混合時序軸重構實作現狀 |
+| :--- | :--- | :--- | :--- |
+| [`timestamped_entry.dart`](../../lib/src/models/timestamped_entry.dart) | `TimestampedEntry`<br>`TimelineSource` (enum) | 定義混合時序軸排序契約介面、統一的時間格式化 extension (`displayTime`) 與來源列舉。 | **已新增此檔案**。作為四大領域 Entry 在時序軸排序的核心基礎契約。 |
+| [`log_level.dart`](../../lib/src/models/log_level.dart) | `LogLevel` (enum) | 標記 Console 日誌的嚴重性等級 (`verbose` 至 `error`)。 | - |
+| [`log_entry.dart`](../../lib/src/models/log_entry.dart) | `LogEntry` | 單條日誌記錄，包含訊息、級別、堆疊追蹤與附加的 structured payload。 | **已實作** `TimestampedEntry`，實現 `timestamp` 介面。 |
+| [`network_entry.dart`](../../lib/src/models/network_entry.dart) | `NetworkEntry` | 網路 HTTP 請求記錄，包含 Method、URL、Headers、截斷的 Body、狀態碼與 `WeakReference<Dio>`。 | **已實作** `TimestampedEntry`，實現 `timestamp` 介面。 |
+| [`navigator_action.dart`](../../lib/src/models/navigator_action.dart) | `NavigatorAction` (enum) | 導航動作類型（`push`、`pop`、`replace`、`remove`）。 | - |
+| [`navigator_entry.dart`](../../lib/src/models/navigator_entry.dart) | `NavigatorEntry` | 導航事件記錄，解析 Route Name、頁面 Widget 類型與參數。 | **已實作** `TimestampedEntry`，實現 `timestamp` 介面。 |
+| [`database_operation.dart`](../../lib/src/models/database_operation.dart) | `DatabaseOperation` (enum) | 資料庫操作類型（`insert`、`update`、`delete`、`query`）。 | - |
+| [`database_entry.dart`](../../lib/src/models/database_entry.dart) | `DatabaseEntry` | SQL/資料庫操作記錄，包含操作類型、表名、影響行數與結構化數據。 | **已實作** `TimestampedEntry`，實現 `timestamp` 介面。 |
+| [`database_browser_source.dart`](../../lib/src/models/database_browser_source.dart) | `DatabaseBrowserSource`<br>`DatabaseTableInfo`<br>`DatabaseTablePage` | 抽象介面。定義如何列出資料庫表與分頁獲取行資料，使 UI 與具體資料庫實現解耦。 | - |
+
+### 3. 控制與收集器層 (`lib/src/inspectors/` 等)
+
+| 檔案路徑 | 關鍵類別/列舉 | 單一職責 (Single Responsibility) | v1.1.0 混合時序軸重構實作現狀 |
+| :--- | :--- | :--- | :--- |
+| [`log_inspector.dart`](../../lib/src/inspectors/log_inspector.dart) | `LogInspector` | 對 Console 日誌 `RingBuffer` 的包裝，提供級別過濾。 | - |
+| [`network_inspector.dart`](../../lib/src/inspectors/network_inspector.dart) | `NetworkInspector` | 對網路請求 `RingBuffer` 的包裝，提供 Body 自動截斷與 completion 替換。 | - |
+| [`navigator_inspector.dart`](../../lib/src/inspectors/navigator_inspector.dart) | `NavigatorInspector` | 對導航事件 `RingBuffer` 的包裝。 | - |
+| [`database_inspector.dart`](../../lib/src/inspectors/database_inspector.dart) | `DatabaseInspector` | 對資料庫操作 `RingBuffer` 的包裝，提供表名或操作類型過濾。 | - |
+| [`dio_interceptor.dart`](../../lib/src/interceptors/dio_interceptor.dart) | `FlutterInspectorDioInterceptor` | Dio 網路攔截器，在 `onRequest`、`onResponse` 與 `onError` 自動轉換並更新快取。 | **已移除**任何主動向 `LogInspector` 寫入鏡射字串的程式碼，日誌緩存保持 100% 純淨。 |
+| [`navigator_observer.dart`](../../lib/src/observers/navigator_observer.dart) | `FlutterInspectorNavigatorObserver` | 導航監聽器，捕捉路由變更，並利用反射/ builder 解析頁面的真實 Widget 類型。 | **已移除**任何主動向 `LogInspector` 寫入 Warning 鏡射的程式碼，修正了時序衝突。 |
+| [`operation_log_source.dart`](../../lib/src/sources/operation_log_source.dart) | `OperationLogSource` | 將 `DatabaseInspector` 的 SQL 日誌包裝為虛擬 `DatabaseBrowserSource` 供給 UI。 | - |
+
+### 4. 平台適應通知層 (`lib/src/notifications/`)
+
+| 檔案路徑 | 關鍵類別/列舉 | 單一職責 (Single Responsibility) | v1.1.0 混合時序軸重構實作現狀 |
+| :--- | :--- | :--- | :--- |
+| [`alert_throttler.dart`](../../lib/src/notifications/alert_throttler.dart) | `AlertThrottler` | 限制通知頻率。保證每兩秒最多觸發一次系統 heads-up banner 通知。 | - |
+| [`network_notifier.dart`](../../lib/src/notifications/network_notifier.dart) | - | 平台導出分流器。在 Web 上載入 no-op，在 Native 上載入 `network_notifier_io`。 | - |
+| [`network_notifier_io.dart`](../../lib/src/notifications/network_notifier_io.dart) | `NetworkNotifier` (Native) | 使用 `flutter_local_notifications` 顯示動態更新的 HTTP 通知，點擊可喚醒控制台。 | - |
+| [`network_notifier_web.dart`](../../lib/src/notifications/network_notifier_web.dart) | `NetworkNotifier` (Web) | Web no-op 實現，排除 `dart:io` 防止破壞 WASM 編譯。 | - |
+
+### 5. 無狀態工具層 (`lib/src/utils/`)
+
+| 檔案路徑 | 關鍵類別/列舉 | 單一職責 (Single Responsibility) | v1.1.0 混合時序軸重構實作現狀 |
+| :--- | :--- | :--- | :--- |
+| [`log_formatters.dart`](../../lib/src/utils/log_formatters.dart) | - | 將 `LogEntry` 轉換為純文字導出格式。 | - |
+| [`network_formatters.dart`](../../lib/src/utils/network_formatters.dart) | `ReplayRequest` | 提供網路請求的格式化工具，如 `buildCurl` 產出 cURL、`prettyJson` 縮排、`formatBytes` 等。 | - |
+| [`network_search.dart`](../../lib/src/utils/network_search.dart) | `NetworkStatusGroup`<br>`NetworkFilter` | 網路請求的搜尋過濾邏輯（基於關鍵字、Method 與 HTTP 狀態分組）。 | - |
+| [`redaction.dart`](../../lib/src/utils/redaction.dart) | - | 安全過濾。識別敏感 header（如 `authorization`）並將其內容遮蔽為 `••••`。 | - |
+| [`share_text.dart`](../../lib/src/utils/share_text.dart) | - | 分享平台分流器。Web 端匯出 `share_text_web`，Native 端匯出 `share_text_io` | - |
+| [`share_text_io.dart`](../../lib/src/utils/share_text_io.dart) | - | 使用 `share_plus` 開啟手機系統原生分享面板。 | - |
+| [`share_text_web.dart`](../../lib/src/utils/share_text_web.dart) | - | 使用 Web Share API `navigator.share`，降級則複製到剪貼簿。 | - |
+| [`table_sort.dart`](../../lib/src/utils/table_sort.dart) | - | 提供虛擬資料庫表格的單列排序與單元格預覽。 | - |
+
+### 6. UI 表現層 (`lib/src/ui/`)
+
+| 檔案路徑 | 關鍵類別/列舉 | 單一職責 (Single Responsibility) | v1.1.0 混合時序軸重構實作現狀 |
+| :--- | :--- | :--- | :--- |
+| [`dashboard_modal.dart`](../../lib/src/ui/dashboard/dashboard_modal.dart) | `DashboardModal` | 控制台的主視窗 Dialog。封裝 `TabBarView` 結構與自訂頁。 | - |
+| [`dashboard_tab_bar.dart`](../../lib/src/ui/dashboard/dashboard_tab_bar.dart) | `DashboardTabBar` | 頂部導航 Tab 項目渲染。 | - |
+| [`console_tab.dart`](../../lib/src/ui/dashboard/tabs/console_tab.dart) | `ConsoleTab` | 顯示日誌清單，區分顏色，點擊可開啟日誌詳細視窗。 | **已大幅重構**。新增 `TimelineSource` 頂部過濾晶片列，基於 `mergedTimeline` 讀取混合數據，並按 `is` 判型進行多樣化視圖渲染與點擊詳情跳轉。 |
+| [`log_detail_view.dart`](../../lib/src/ui/dashboard/tabs/console/log_detail_view.dart) | `LogDetailView` | 顯示單條日誌的 General、Stack Trace 與 Data 卡片，支援分享。 | - |
+| [`network_tab.dart`](../../lib/src/ui/dashboard/tabs/network_tab.dart) | `NetworkTab` | 提供網路請求清單、即時搜尋、Method/Status Chip 過濾器。 | - |
+| [`network_detail_view.dart`](../../lib/src/ui/dashboard/tabs/network/network_detail_view.dart) | `NetworkDetailView` | 展示詳細請求/響應 Headers 與 Body，支持 Replay、複製為 cURL 或文字分享。 | - |
+| [`navigator_tab.dart`](../../lib/src/ui/dashboard/tabs/navigator_tab.dart) | `NavigatorTab` | 以時間軸列表展示路由事件與傳參。 | - |
+| [`database_tab.dart`](../../lib/src/ui/dashboard/tabs/database_tab.dart) | `DatabaseTab` | 數據源表瀏覽器。支援動態下拉切換不同的 `DatabaseBrowserSource`。 | - |
+| [`table_rows_view.dart`](../../lib/src/ui/dashboard/tabs/database/table_rows_view.dart) | `TableRowsView` | 表格二維數據瀏覽器。支援動態加載（Load More）、點擊單元格查看/複製完整內容，以及點擊表頭排序。 | - |
+| [`inspector_fab.dart`](../../lib/src/ui/widgets/inspector_fab.dart) | `InspectorFab` | 全螢幕飄移懸浮按鈕。使用 `GestureDetector.onPanUpdate` 與 `clamp` 實現拖曳邊界控制。 | - |
+| [`magical_tap.dart`](../../lib/src/ui/widgets/magical_tap.dart) | `FlutterInspectorMagicalTap` | 透明手勢防護罩。可用於靜默包覆 App，監聽快速連擊（預設 5 次，每次小於 500ms）開啟 Dashboard。 | - |
+| [`key_value_table.dart`](../../lib/src/ui/widgets/key_value_table.dart) | `KeyValueTable` | 通用的緊湊二欄式鍵值表格組件。 | - |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,116 @@
+# Flutter Inspector Kit - 整體架構概覽 (Overview)
+
+> 「差勁的程式員只擔心程式碼，優秀的程式員關心資料結構。」 —— Linus Torvalds
+
+`flutter_inspector_kit` 是一個輕量、低干涉且實用的 Flutter 開發期調試工具。它將 Console 日誌、網路請求（HTTP）、頁面導航（Navigator）以及資料庫操作（Database）集成在單一的懸浮按鈕（FAB）與全螢幕儀表板中。
+
+---
+
+## 🏗️ 核心架構分層
+
+本套件遵循「資料驅動」與「低侵入性」的設計原則，將架構劃分為四個主要層次：
+
+```text
+  ┌────────────────────────────────────────────────────────┐
+  │                 表現層 (Presentation Layer)            │
+  │  [DashboardModal]  [InspectorFab]  [ConsoleTab (Merged)]│
+  └───────────────────────────┬────────────────────────────┘
+                              │ 讀取與操作
+                              ▼
+  ┌────────────────────────────────────────────────────────┐
+  │                 核心調試引擎 (Core Engine)             │
+  │   [FlutterInspector]  [InspectorRegistry]  [RingBuffer]│
+  └───────────────────────────┬────────────────────────────┘
+                              │ 持有與快取
+                              ▼
+  ┌────────────────────────────────────────────────────────┐
+  │                 領域模型層 (Domain Models)             │
+  │               [TimestampedEntry] (抽象介面)            │
+  │   [LogEntry]  [NetworkEntry]  [NavigatorEntry]  [DB]   │
+  └───────────────────────────▲────────────────────────────┘
+                              │ 結構化寫入
+                              │
+  ┌───────────────────────────┴────────────────────────────┐
+  │               資料擷取層 (Collectors / Interceptors)   │
+  │  [DioInterceptor]  [NavigatorObserver]  [ErrorHandlers]│
+  └────────────────────────────────────────────────────────┘
+```
+
+### 1. 基礎核心層 (Core Engine)
+- **`FlutterInspector`**：全域單例管理器。負責協調各子系統、註冊全域錯誤 Handler、掛載/卸載 UI Overlay、接收各類數據輸入。
+- **`InspectorRegistry`**：中央緩衝註冊表，集中持有四個領域的專屬 Inspector。
+- **`RingBuffer`**：最核心的底層資料結構，為一個固定容量的 FIFO 快取。**所有**數據搜集（日誌、網絡、導航、資料庫）皆基於它來儲存。
+
+### 2. 數據模型層 (Domain Models)
+- 採用 **Immutable (不可變)** 的設計模式。
+- 包括 `LogEntry`、`NetworkEntry`、`NavigatorEntry` 與 `DatabaseEntry`。
+- **好品味體現**：快取中的數據一旦寫入就不應被隨意修改。對於 `NetworkEntry` 等需要異步更新的數據，採用 `copyWith` 與 `RingBuffer.replace` 在快取中原地替換，防止列表重建時發生狀態混亂與不必要的內存拷貝。
+
+### 3. 數據擷取層 (Collectors / Interceptors)
+- **`DioInterceptor`** 〔獨立 class · `lib/src/interceptors/dio_interceptor.dart`〕：攔截 Dio 請求與響應，處理 pending 狀態更新，並支持請求重發（Replay）。
+- **`NavigatorObserver`** 〔獨立 class · `lib/src/observers/navigator_observer.dart`〕：自動監聽路由變化，安全解析頁面 Widget 類型。
+- **`ErrorHandlers`** 〔非獨立 class · 由 `FlutterInspector.setupErrorHandlers()` 直接以 callback 設定〕：無侵入地鏈接 FlutterError、PlatformDispatcher 與 ErrorWidget 錯誤鉤子。該 method 將 closure 直接賦值給 Flutter 的全域鉤子（`FlutterError.onError`、`PlatformDispatcher.instance.onError`、`ErrorWidget.builder`），不存在獨立的 handler 類別。
+- **`OperationLogSource`** 〔獨立 class · `lib/src/sources/operation_log_source.dart`〕：將資料庫操作日誌轉換為虛擬表格，以配合資料庫瀏覽器展示。
+
+#### 設計模式標注：Adapter + Constructor Injection
+
+`FlutterInspectorDioInterceptor` 與 `FlutterInspectorNavigatorObserver` 自身不持有任何儲存，它們只作為「第一手資料的接入口」，拿到原始事件後立即轉派給 `FlutterInspector`。此結構是兩個經典模式的疊加：
+
+- **Adapter Pattern（Object Adapter）**：`Interceptor`（Dio）與 `NavigatorObserver`（Flutter）是第三方框架定義、無法修改的介面；這兩個類別把「框架的回呼語言」翻譯成「Inspector 的記錄語言」，透過組合（持有 `_inspector` 參考）而非繼承來轉接，正是 Object Adapter 的標準形態。
+
+  ```text
+  Dio 的 onRequest/onResponse/onError    ──adapt──▶  FlutterInspector.logNetwork()
+  Flutter 的 didPush/didPop/didReplace   ──adapt──▶  FlutterInspector.navigatorInspector.add()
+  ```
+
+- **Constructor Injection（DI 技巧，非 GoF 模式）**：`FlutterInspectorDioInterceptor(this._inspector)` 將 inspector 由建構子注入，而非在內部硬抓全域單例。它解決的是「依賴從哪取得」，與「架構角色（Adapter）」是兩個獨立維度。好處是測試時可注入 mock inspector，無需依賴全域狀態。
+
+> ⚠️ **常見誤判**：`NavigatorObserver` 名稱帶 "Observer"，易誤認為 GoF 的 Observer Pattern。實則不然——它只是 Flutter 提供的回呼介面（callback hook），這兩個類別實作後將事件「轉發」出去，屬 Adapter 行為，並非 Observer 的「subject 維護 observer 清單、主動通知」協作結構。
+
+> **品味守則**：Adapter 必須維持薄翻譯層，不得在其中滋長業務邏輯（如 `dio_interceptor.dart` 中 `_stringifyData` 這類純格式轉換是可接受的邊界）。
+
+### 4. 表現層 (Presentation Layer)
+- **`InspectorFab`**：支持手勢拖拽的懸浮按鈕，限制在屏幕安全區域內。
+- **`DashboardModal`**：包含四大 Tab 的全螢幕控制台，支持自訂第五個開發者 Tab。
+- **`MagicalTap`**：靜默連擊偵測組件，可在隱藏 FAB 的情況下通過連擊手勢喚醒控制台。
+
+---
+
+## 🛠️ 架構設計原則與「好品味」
+
+### 1. 平台自適應與 WASM 相容性 (Conditional Exports)
+在網路通知 (`NetworkNotifier`) 與文字分享 (`ShareText`) 模組中，為了解決 Native（依賴 `dart:io` 與三方套件）與 Web（WASM 相容）之間的平台差異：
+- 採用 **條件匯出 (Conditional Exports)** 技術：
+  - Web 端自動切換為 no-op stub，或直接調用 Web 原生的 API（例如 Web Share API）。
+  - Native 端則載入對應的插件（例如 `flutter_local_notifications`、`share_plus`）。
+- **結果**：完全阻斷 `dart:io` 傳遞式匯入進入 Web 編譯鏈，保持 Flutter 網頁端 WASM 構建的乾淨相容。
+
+### 2. 弱引用與防洩漏設計 (WeakReference)
+在 `NetworkEntry` 中，重發（Replay）功能需要調用發起請求的 `Dio` 實例：
+- **致命風險**：如果直接持有 `Dio` 實例強引用，隨著 RingBuffer 達到上限並拋棄舊 Entry，這些已失效的 `Dio` 將無法被垃圾回收，造成嚴重的內存洩漏。
+- **Linus 式解法**：在 `NetworkEntry` 中使用 `WeakReference<Dio>`。這是一個暫時性的運行期引用，只在 Replay 時嘗試獲取。此欄位被刻意排除在 `==`、`hashCode` 與所有導出序列化之外，確保安全、乾淨且零洩漏。
+
+### 3. 無害的錯誤鉤子 (Never Break Host App)
+在捕獲 uncaught exceptions 時：
+- `setupErrorHandlers` 嚴格包裹現有 Host 處理程序（`FlutterError.onError` 等）。
+- 寫入日誌的邏輯完全置於 `try-catch` 中，不論日誌儲存是否失敗，**都必須確保將錯誤原樣轉發回 downstream**。
+- **原則**：我們的職責是輔助調試，絕不能因為套件自身的崩潰或錯誤導致主 App 的行為改變。
+
+---
+
+## 🧵 跨層混合時序軸 (Cross-Layer Merged Timeline) - v1.1.0 新特點
+
+自 `v1.1.0` 起（PR #40 / #42 合入後），控制台的主體時間軸已完成重構，實現了高品味的跨層混合時序軸。
+
+### 1. 單一真相源與歸併排序
+- **設計**：所有領域模型（`LogEntry`、`NetworkEntry`、`NavigatorEntry`、`DatabaseEntry`）皆實現了統一的 `TimestampedEntry` 介面，暴露單一 `timestamp` 與 `displayTime`。
+- **時序軸渲染**：擷取層（攔截器與觀察者）**純淨寫入**各自的專屬緩存，不進行任何日誌鏡射。在 UI 渲染期，`ConsoleTab` 呼叫 `FlutterInspector.mergedTimeline(sources)`，由底層的 `InspectorRegistry` 將四個獨立的 `RingBuffer` 拍扁（Flatten），並在記憶體中依 `timestamp` 降序進行歸併排序（Merge-Sort），即時引用原始 Entry 物件。
+- **富交互**：時序軸行依 `entry is NetworkEntry` 等類型動態分派渲染。點擊 Network 類型列直接跳轉至 `NetworkDetailView`，支援 cURL 複製與 Replay 重發請求。
+
+### 2. 歷史演進：為什麼要進行此項重構？
+在 `v1.1.0` 之前，套件是靠「複製式鏡射 (Mirroring)」來假裝呈現綜合時間軸：在擷取到網絡/路由事件時，強行將 Method/URL/路由名稱**複製為字串**，主動調用 `_inspector.log(...)` 灌入日誌緩存。
+
+這帶來了三大低品味痛點，已在 `v1.1.0` 被徹底消滅：
+1. **第二份真相**：網路請求進度更新為 Completed 時，日誌緩存中的 pending 字串拷貝無法原地更新，造成狀態不同步。
+2. **污染日誌級別**：路由導航事件強制佔用了 `warning` 級別，混淆了真正的 Warning 錯誤。
+3. **互吃緩存配額**：大量的網絡與路由字串塞滿了限額 500 條的日誌緩存，將主應用真正的 Error 日誌無情擠出 RingBuffer。

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -44,7 +44,7 @@
 ### 2. 數據模型層 (Domain Models)
 - 採用 **Immutable (不可變)** 的設計模式。
 - 包括 `LogEntry`、`NetworkEntry`、`NavigatorEntry` 與 `DatabaseEntry`。
-- **好品味體現**：快取中的數據一旦寫入就不應被隨意修改。對於 `NetworkEntry` 等需要異步更新的數據，採用 `copyWith` 與 `RingBuffer.replace` 在快取中原地替換，防止列表重建時發生狀態混亂與不必要的內存拷貝。
+- **好品味體現**：快取中的數據一旦寫入就不應被隨意修改。對於 `NetworkEntry` 等需要異步更新的數據，採用 `copyWith` 與 `RingBuffer.replace` 在快取中原地替換，防止列表重建時發生狀態混亂與不必要的記憶體拷貝。
 
 ### 3. 數據擷取層 (Collectors / Interceptors)
 - **`DioInterceptor`** 〔獨立 class · `lib/src/interceptors/dio_interceptor.dart`〕：攔截 Dio 請求與響應，處理 pending 狀態更新，並支持請求重發（Replay）。
@@ -87,7 +87,7 @@
 
 ### 2. 弱引用與防洩漏設計 (WeakReference)
 在 `NetworkEntry` 中，重發（Replay）功能需要調用發起請求的 `Dio` 實例：
-- **致命風險**：如果直接持有 `Dio` 實例強引用，隨著 RingBuffer 達到上限並拋棄舊 Entry，這些已失效的 `Dio` 將無法被垃圾回收，造成嚴重的內存洩漏。
+- **致命風險**：如果直接持有 `Dio` 實例強引用，隨著 RingBuffer 達到上限並拋棄舊 Entry，這些已失效的 `Dio` 將無法被垃圾回收，造成嚴重的記憶體洩漏。
 - **Linus 式解法**：在 `NetworkEntry` 中使用 `WeakReference<Dio>`。這是一個暫時性的運行期引用，只在 Replay 時嘗試獲取。此欄位被刻意排除在 `==`、`hashCode` 與所有導出序列化之外，確保安全、乾淨且零洩漏。
 
 ### 3. 無害的錯誤鉤子 (Never Break Host App)

--- a/docs/brainstorm/2026-06-25-features-brainstorm.md
+++ b/docs/brainstorm/2026-06-25-features-brainstorm.md
@@ -1,5 +1,7 @@
 # 🩺 Flutter Inspector 錯誤問題排查與分析：功能腦力激盪報告
 
+> **建立日期**：2026-06-25（檔名）｜**最後更新**：2026-06-29（含 v1.1.0 完成度核對）
+
 > 「好代碼沒有特殊情況。」 —— Linus Torvalds
 >
 > 這份報告**只聚焦一件事**：當 app 出錯時，`flutter_inspector_kit` 能不能讓開發者/QA 用最少的步驟「看見錯誤、關聯原因、帶走證據」。
@@ -7,24 +9,25 @@
 
 ---
 
-## 📊 完成度總覽（截至 2026-06-25）
+## 📊 完成度總覽（截至 2026-06-29 · 含 v1.1.0）
 
 > 以下狀態依實際 codebase 與 git history 核對標注。✅ 完成 ｜ 🟡 部分完成 ｜ ⬜ 未實作。
+> **更新說明**：原 6/25 快照已過時。v1.1.0（PR #40 / #42）把 console 重構為真正的混合時間軸後，**#2 由 ⬜ 升級為 🟡**（時序關聯的主體已落地）。
 
 | # | 功能 | 狀態 | 備註 |
 |---|------|:---:|------|
 | #1 | 全局未捕捉例外捕捉 | ✅ | PR #30：`captureUncaughtErrors`(default off) + 三掛點 chain，含去重 |
-| #4 | Dio 結構化錯誤捕捉 | 🟡 | 已抓 statusCode/headers/body；**缺** `errorType`/`errorStackTrace` 結構化分類與 Exception Details section |
-| #5 | ConsoleTab 排查化 | 🟡 | `LogDetailView`(stackTrace/data/分享) 完成；**缺** 搜尋欄 / LogLevel FilterChip / errors-only 過濾 |
-| #2 | 跨 Inspector 時序關聯 | ⬜ | 未實作（現僅有 nav/network 鏡射到 console log 的廉價替代） |
-| #3 | 一鍵診斷報告 | ⬜ | 未實作 |
 | #6 | 網路請求重放 | ✅ | PR #36 / v1.0.0 已完成：支援 per-Dio 原樣重送、`isReplay` 標記、狀態回饋與防連點保護 |
-| #7 | 錯誤聚合摘要 | ⬜ | 未實作 |
-| #8 | 當前路由堆疊可視化 | ⬜ | 未實作 |
+| #2 | 跨 Inspector 時序關聯 | 🟡 | **v1.1.0 大幅推進**：ConsoleTab 已改用 `mergedTimeline`（四 buffer 按 `timestamp` 歸併排序），即文件「做法 B：Timeline 視圖」的本體已成；**缺** 做法 A（detail view 的 ±5s 同時段側欄） |
+| #4 | Dio 結構化錯誤捕捉 | 🟡 | 已抓 statusCode/headers/body；**缺** `errorType`/`errorStackTrace` 結構化分類與 Exception Details section |
+| #5 | ConsoleTab 排查化 | 🟡 | `LogDetailView`(stackTrace/data/分享) 完成；**缺** 搜尋欄 / LogLevel FilterChip / errors-only 過濾（`utils/` 下仍無 log_search） |
+| #3 | 一鍵診斷報告 | ⬜ | 未實作（查無 `buildDiagnosticReport`） |
+| #7 | 錯誤聚合摘要 | ⬜ | 未實作（查無 `ErrorSummary`） |
+| #8 | 當前路由堆疊可視化 | ⬜ | 未實作（查無 `currentStack`） |
 
 **Anti-features**（Profiler / 落盤 crash history / HAR timing / API mocking）— ✅ 正確地皆未實作，守住「不走向微核心」。
 
-**進度結論**：五階段路徑走完「第一階段一半 + 第二階段一半」。下一刀應收尾 **#4 結構化分類** 與 **#5 console 搜尋/過濾**。
+**進度結論**：8 項裡 **3 項完成**（#1、#6，以及 v1.1.0 實質完成的 **#2 時序軸主體**），**2 項半成品**（#4 結構化錯誤、#5 console 搜尋/過濾），**3 項未動**（#3、#7、#8）。下一刀應收尾 **#4 結構化分類** 與 **#5 console 搜尋/過濾**——這兩項是 console 排查化僅剩的缺口。
 
 ---
 
@@ -71,7 +74,7 @@
 * **Effort**：medium ｜ **排查價值**：⭐⭐⭐⭐⭐
 * **✅ 實作現況**：PR #30 已完成。`FlutterInspector(captureUncaughtErrors: false)` 入口 + `setupErrorHandlers()` 三掛點（`FlutterError.onError` chain、`PlatformDispatcher.onError`、`ErrorWidget.builder`）皆落地，並補上同一例外的去重；`runGuarded` 已移除改用 `PlatformDispatcher.onError`。
 
-### 2. 跨 Inspector 時序關聯（Correlated Timeline）— ⬜ 未實作（原 🔴 排查的靈魂）
+### 2. 跨 Inspector 時序關聯（Correlated Timeline）— 🟡 部分完成（原 🔴 排查的靈魂）
 * **痛點**：錯誤幾乎都是跨層的——「點了某按鈕（nav）→ 發了某 API（network）→ 5xx → 印了某 error log」。但現在這四件事躺在四個孤立 buffer 裡，開發者得在四個 tab 之間用肉眼對時間戳，這是排查最大的摩擦。
 * **好品味設計**：
   > 四個 buffer 共用 `timestamp`——這個共通欄位就是答案，不需要新資料管線。
@@ -80,6 +83,7 @@
 * **重用**：各 entry 的 `timestamp`、`InspectorRegistry` 已持有四個 buffer、`LogLevel` 配色、`KeyValueTable`。
 * **品味守則**：`TimelineEvent` 只是**指標包裝**（指向既有 entry），不複製資料、不引入第二份真相。
 * **Effort**：A=low / B=medium ｜ **排查價值**：⭐⭐⭐⭐⭐
+* **🟡 實作現況（v1.1.0 / PR #40 #42）**：**做法 B 已落地，且實作得比原構想更乾淨**——沒有引入 `TimelineEvent` union，而是讓四個 entry model 共同實作 `TimestampedEntry` 介面，由 `InspectorRegistry.mergedTimeline()` 把四個 `RingBuffer` 拍扁後依 `timestamp` 降序歸併排序，`ConsoleTab` 直接渲染（`ConsoleTab` 的 `build()` 內呼叫 `inspector.mergedTimeline(sources: _selected)`），按 entry runtime type 動態分派渲染、點 Network 列跳 `NetworkDetailView`。這同時消滅了 v1.1.0 前「鏡射到 console log 的廉價替代」（見本文件頂部與 overview 的歷史演進）。**未完成**：做法 A 的「±5s 同時段側欄」尚未做（現為整條混合時間軸，無以單筆為中心的時間窗聚焦）。
 
 ### 3. 一鍵診斷報告（Diagnostic Report）— ⬜ 未實作（原 🔴 QA 提 bug 的剛需）
 * **痛點**：QA 重現 bug 後，要手動切四個 tab、逐筆截圖/複製、再手打 device/OS/版本資訊。耗時且容易漏，回報品質參差。
@@ -114,12 +118,13 @@
 
 ## 🚀 第二部分：加分但非核心（中優先）
 
-### 6. 網路請求重放（Replay / Resend）— ⬜ 未實作
+### 6. 網路請求重放（Replay / Resend）— ✅ 已完成（PR #36 / v1.0.0）
 * **價值**：API 出錯時，原地重送（可改 header/body）即時確認「是否仍重現 / server 是否恢復」，免去複製 cURL 跳終端的 context switch。
 * **設計**：`NetworkDetailView` 加「Resend」按鈕，從 entry 重建請求（沿用 `buildCurl()` 已證明的請求重組邏輯）經注入的 Dio 重送，結果作為新 `NetworkEntry` 記回 buffer。
 * **重用**：`buildCurl()` 的請求重組、init 時傳入的 Dio client。
 * **Effort**：medium ｜ **排查價值**：⭐⭐⭐⭐
 * **邊界**：只「重送原請求」。**不**做 mocking、不做腳本化改寫——那是 Proxyman/Charles 的地盤（見 anti-features）。
+* **✅ 實作現況**：PR #36 / v1.0.0 已完成。`NetworkDetailView` 的「Resend」按鈕經原始 `sourceDio`（`WeakReference<Dio>`）原樣重送，重送結果以 `isReplay` 標記記回 buffer，並含狀態回饋與防連點保護。
 
 ### 7. 錯誤聚合摘要（Error Aggregation）— ⬜ 未實作
 * **價值**：同一個 502 每 30 秒打一次 → 現在是 500 條各自獨立的列表項。聚合成「502 Bad Gateway × N 次，最近 5 分鐘」一張卡，一眼看出是「持續故障」還是「偶發」。
@@ -160,8 +165,10 @@
 
 1. **第一階段 · 點亮盲區**（🟡 進行中）：實作 **#1 全局未捕捉例外捕捉**（可選 default-off）✅ + **#4 Dio 結構化錯誤捕捉** 🟡（結構化分類欄位待補）。此後 inspector 才真正「看得見」錯誤。
 2. **第二階段 · ConsoleTab 排查化**（🟡 進行中）：實作 **#5**（stackTrace 詳情 ✅ + error 搜尋/過濾 ⬜ 待補），讓捕捉到的錯誤可被秒速定位與檢視。
-3. **第三階段 · 建立關聯**（⬜ 未開始）：實作 **#2 做法 A**（detail view 的 ±5s 同時段側欄）——最低成本就讓跨層關聯落地；行有餘力再上做法 B 的 Timeline 視圖。
+3. **第三階段 · 建立關聯**（🟡 主體已完成）：**#2 做法 B（Timeline 混合視圖）已於 v1.1.0 落地** ✅（`mergedTimeline` + `TimestampedEntry`）；僅剩 **做法 A**（detail view 的 ±5s 同時段側欄 ⬜）尚未做，可視回饋決定是否補上。
 4. **第四階段 · 帶走證據**（⬜ 未開始）：實作 **#3 一鍵診斷報告**（含 #8 路由堆疊快照、device info）。QA 提 bug 的剛需在此閉環。
-5. 第五階段 · 加分項（✅ 已完成）：#6 Replay 已於 v1.0.0 完成實作；後續可視回饋實作 #7 錯誤聚合摘要。
+5. 第五階段 · 加分項（✅ 部分完成）：#6 Replay 已於 v1.0.0 完成實作；後續可視回饋實作 #7 錯誤聚合摘要。
+
+> **收尾建議（截至 2026-06-29）**：console 排查鏈只剩兩個明確缺口——**#4 的結構化錯誤分類** 與 **#5 的搜尋/過濾**。兩者寫入路徑不重疊（#4 動 interceptor + model、#5 動 console UI），可並行收掉，console 排查化即閉環。其後再進第四階段 #3 診斷報告。
 
 > 每一階段都是獨立可上線的增量，且彼此寫入路徑不重疊（#1 動 core、#4 動 interceptor、#5 動 console UI、#3 動 utils + dashboard），適合並行推進。


### PR DESCRIPTION
## Summary

新增 `docs/architecture/` 三份架構參考文件，並把 `docs/brainstorm/2026-06-25-features-brainstorm.md` 的完成度標注核對更新至 2026-06-29（含 v1.1.0）。本 PR 純文件，不含任何 lib/ 程式行為變更。

Closes #46

## 修正問題

- **缺少集中的架構文件**：架構知識散落各 source 檔，新進者只能靠讀 code 拼湊分層與資料流。
- **brainstorm 完成度過時**：標注停在 6/25 快照，未反映 v1.1.0（PR #40 / #42）的 console 混合時間軸重構。
- **brainstorm 內部不一致**：#6 網路請求重放在總覽表標 ✅，但第二部分章節仍留著舊的 ⬜ 未實作。

## 修正方式

**新增 `docs/architecture/`（3 檔）**
- `overview.md`：四層架構概覽，含資料擷取層的設計模式標注（Adapter + Constructor Injection；DioInterceptor / NavigatorObserver / OperationLogSource 為獨立 class、ErrorHandlers 為 `setupErrorHandlers()` 內 callback 的型態辨析）。
- `data-flow.md`：跨層資料流說明（含 Replay 請求流、RingBuffer 原地替換）。
- `file-reference.md`：檔案結構索引。

**更新 `docs/brainstorm/...`**
- #2 跨 Inspector 時序關聯：⬜ → 🟡（`mergedTimeline` 混合時間軸已落地）。
- #6 網路請求重放：第二部分章節 ⬜ → ✅，與總覽表對齊。
- 完成度總覽表、進度結論、實作路徑同步至實際 codebase grep 核對結果。
- 檔首補「最後更新」註記；以穩定的 `build()` 描述取代寫死行號引用。

## Verification

- `docs/architecture/` 三檔內容經多 lens 審查與 codebase 核對，技術主張與程式碼一致。
- brainstorm 8 項完成度的「總覽表 vs 各章節標題」狀態已全數核對一致。
- diff 範圍：4 個 .md 檔，+495/-12，零程式碼變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)