### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+### Added
+* **Navigator active route stack visualization**: the Navigator tab now offers an "Active Stack" / "Event History" toggle. Active Stack derives the current route stack live from the recorded push/pop/replace/remove events and renders it top-first as vertical cards, with the current screen highlighted; Event History remains the original raw event log, unchanged.
+
 ## 1.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 - 🧵 **Merged timeline**: the Console tab interleaves logs, network, navigation, and database events on one timestamp-sorted timeline, with per-source filter chips
 - 📡 **Network**: intercept HTTP traffic via Dio, inspect structured request/response details, search/filter, share as cURL
 - 🛡️ **Sensitive-data redaction**: secure by default — sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`) are masked in every share/export path
-- 🧭 **Navigator**: track route pushes, pops, and replacements automatically
+- 🧭 **Navigator**: track route pushes, pops, and replacements automatically, with an "Active Stack" view that derives and visualizes the current route stack
 - 🗄️ **Database**: record insert / update / delete / query operations with affected-row counts and payloads
 - 👆 **Magical tap & floating button**: open the dashboard with a hidden multi-tap gesture or a draggable in-app FAB
 - 🔔 **Live notification (opt-in)**: a system notification that summarises the latest API call and the running total
@@ -36,7 +36,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.1.0
+  flutter_inspector_kit: ^1.2.0
 ```
 
 Then run `flutter pub get`.
@@ -314,6 +314,11 @@ Captured errors appear as red logs in the **Console** tab. Tap any log that carr
 ### Track navigation
 
 Nothing to do here — routes are tracked automatically once you register `inspector.navigatorObserver` in `navigatorObservers` (see [Initialize](#initialize)). Pushes, pops, and replacements all show up in the Navigator tab.
+
+The Navigator tab offers two views, toggled via chips at the top:
+
+- **Event History**: the raw log of push/pop/replace/remove events (the original behavior).
+- **Active Stack**: the current route stack, derived live from the event history and rendered top-first as vertical cards — the topmost card (the current screen) is highlighted. Shows "Empty stack history" when no routes have been recorded yet.
 
 ### Track database operations
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary
[#52](https://github.com/Yomiamy/flutter_inspector_kit/issues/52) Release: Version v1.2.0

**[修正問題]**
發布新版 `1.2.0`，整合最近合併入 `main` 的 Navigator Tab Active Stack 可視化（PR #51）變更，並同步更新 `pubspec.yaml`、說明文檔與變更日誌。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號為 `1.2.0`。
2. **`README.md`**：更新安裝版號為 `^1.2.0`，於 Features 清單補上 Active Stack 說明，並在 Navigator 章節新增「Event History / Active Stack」雙視圖用法說明。
3. **`CHANGELOG.md`**：新增 `1.2.0` 的 Added 異動：Navigator active route stack visualization。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Navigator 页面新增“Active Stack”视图，可根据导航事件实时展示当前路由栈，并高亮当前页面。
  * 顶部可在“Active Stack”和“Event History”两种视图间切换。

* **文档**
  * 更新了版本说明与使用文档，补充了 Navigator 的新视图说明。
  * 版本号已更新为 1.2.0。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->