### PR TITLE
fix(console): clear button only wipes logs, leaves network/nav/db entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,4 @@ app.*.symbols
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
-!/dev/ci/**/Gemfile.lock.worktrees/
+!/dev/ci/**/Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,4 @@ app.*.symbols
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
-!/dev/ci/**/Gemfile.lock
+!/dev/ci/**/Gemfile.lock.worktrees/

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -116,6 +116,9 @@ class _ConsoleTabState extends State<ConsoleTab> {
               icon: const Icon(Icons.delete),
               onPressed: () {
                 widget.inspector.clearLogs();
+                widget.inspector.clearNetwork();
+                widget.inspector.clearNavigator();
+                widget.inspector.clearDatabase();
                 _refresh();
               },
             ),

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -37,47 +37,53 @@ void main() {
       expect(find.text('Test message 2'), findsNothing);
     });
 
-    testWidgets('clearing wipes all four merged-timeline sources, not just logs',
-        (tester) async {
-      final inspector = FlutterInspector();
-      inspector.log('log msg', level: LogLevel.info);
-      inspector.registry.navigator.add(
-        NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
-      );
-      inspector.logNetwork(
-        NetworkEntry(
-          method: 'GET',
-          url: 'https://api.test/x',
-          statusCode: 200,
-          isComplete: true,
-        ),
-      );
-      inspector.registry.database.add(
-        DatabaseEntry(operation: DatabaseOperation.insert, tableName: 'users'),
-      );
+    testWidgets(
+      'clearing wipes all four merged-timeline sources, not just logs',
+      (tester) async {
+        final inspector = FlutterInspector();
+        inspector.log('log msg', level: LogLevel.info);
+        inspector.registry.navigator.add(
+          NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
+        );
+        inspector.logNetwork(
+          NetworkEntry(
+            method: 'GET',
+            url: 'https://api.test/x',
+            statusCode: 200,
+            isComplete: true,
+          ),
+        );
+        inspector.registry.database.add(
+          DatabaseEntry(
+            operation: DatabaseOperation.insert,
+            tableName: 'users',
+          ),
+        );
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(body: ConsoleTab(inspector: inspector)),
-        ),
-      );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: ConsoleTab(inspector: inspector)),
+          ),
+        );
 
-      expect(find.text('log msg'), findsOneWidget);
-      expect(find.textContaining('/home'), findsOneWidget);
-      expect(find.textContaining('https://api.test/x'), findsOneWidget);
-      expect(find.textContaining('users'), findsOneWidget);
+        expect(find.text('log msg'), findsOneWidget);
+        expect(find.textContaining('/home'), findsOneWidget);
+        expect(find.textContaining('https://api.test/x'), findsOneWidget);
+        expect(find.textContaining('users'), findsOneWidget);
 
-      await tester.tap(find.byIcon(Icons.delete));
-      await tester.pump();
+        await tester.tap(find.byIcon(Icons.delete));
+        await tester.pump();
 
-      expect(find.text('log msg'), findsNothing);
-      expect(find.textContaining('/home'), findsNothing);
-      expect(find.textContaining('https://api.test/x'), findsNothing);
-      expect(find.textContaining('users'), findsNothing);
-    });
+        expect(find.text('log msg'), findsNothing);
+        expect(find.textContaining('/home'), findsNothing);
+        expect(find.textContaining('https://api.test/x'), findsNothing);
+        expect(find.textContaining('users'), findsNothing);
+      },
+    );
 
-    testWidgets('tapping error log with stackTrace opens LogDetailView',
-        (tester) async {
+    testWidgets('tapping error log with stackTrace opens LogDetailView', (
+      tester,
+    ) async {
       final inspector = FlutterInspector();
       inspector.log(
         'Error occurred',
@@ -100,8 +106,9 @@ void main() {
       expect(find.byType(LogDetailView), findsOneWidget);
     });
 
-    testWidgets('tapping error log with data opens LogDetailView',
-        (tester) async {
+    testWidgets('tapping error log with data opens LogDetailView', (
+      tester,
+    ) async {
       final inspector = FlutterInspector();
       inspector.log(
         'Error with data',
@@ -153,28 +160,29 @@ void main() {
     });
 
     testWidgets(
-        'tapping pure info log without stackTrace or data does not navigate',
-        (tester) async {
-      final inspector = FlutterInspector();
-      inspector.log('Pure info', level: LogLevel.info);
+      'tapping pure info log without stackTrace or data does not navigate',
+      (tester) async {
+        final inspector = FlutterInspector();
+        inspector.log('Pure info', level: LogLevel.info);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(body: ConsoleTab(inspector: inspector)),
-        ),
-      );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: ConsoleTab(inspector: inspector)),
+          ),
+        );
 
-      expect(find.text('Pure info'), findsOneWidget);
-      expect(find.byType(LogDetailView), findsNothing);
+        expect(find.text('Pure info'), findsOneWidget);
+        expect(find.byType(LogDetailView), findsNothing);
 
-      // Try to tap the log entry.
-      final tile = find.byType(ListTile).first;
-      await tester.tap(tile);
-      await tester.pumpAndSettle();
+        // Try to tap the log entry.
+        final tile = find.byType(ListTile).first;
+        await tester.tap(tile);
+        await tester.pumpAndSettle();
 
-      // LogDetailView should not appear because onTap is null.
-      expect(find.byType(LogDetailView), findsNothing);
-    });
+        // LogDetailView should not appear because onTap is null.
+        expect(find.byType(LogDetailView), findsNothing);
+      },
+    );
 
     // ---- New merged-timeline tests ----
 
@@ -208,8 +216,9 @@ void main() {
       expect(find.textContaining('https://api.test/x'), findsOneWidget);
     });
 
-    testWidgets('All filter shows mixed sources sorted newest-first',
-        (tester) async {
+    testWidgets('All filter shows mixed sources sorted newest-first', (
+      tester,
+    ) async {
       final inspector = FlutterInspector();
       final tLog = DateTime(2026, 6, 26, 10, 0, 0); // oldest
       final tNav = DateTime(2026, 6, 26, 10, 0, 1);
@@ -255,7 +264,9 @@ void main() {
 
       // Newest-first: db row above network above nav above log.
       final dbY = tester.getTopLeft(find.textContaining('users')).dy;
-      final netY = tester.getTopLeft(find.textContaining('https://api.test/x')).dy;
+      final netY = tester
+          .getTopLeft(find.textContaining('https://api.test/x'))
+          .dy;
       final navY = tester.getTopLeft(find.textContaining('/home')).dy;
       final logY = tester.getTopLeft(find.text('log msg')).dy;
 
@@ -309,22 +320,21 @@ void main() {
       await tester.tap(find.textContaining('https://api.test/x'));
       await tester.pumpAndSettle();
 
-      final view =
-          tester.widget<NetworkDetailView>(find.byType(NetworkDetailView));
+      final view = tester.widget<NetworkDetailView>(
+        find.byType(NetworkDetailView),
+      );
       expect(view.redactSensitiveData, isFalse);
     });
 
-    testWidgets('nav and db rows are not tappable (no chevron)',
-        (tester) async {
+    testWidgets('nav and db rows are not tappable (no chevron)', (
+      tester,
+    ) async {
       final inspector = FlutterInspector();
       inspector.registry.navigator.add(
         NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
       );
       inspector.registry.database.add(
-        DatabaseEntry(
-          operation: DatabaseOperation.insert,
-          tableName: 'users',
-        ),
+        DatabaseEntry(operation: DatabaseOperation.insert, tableName: 'users'),
       );
 
       await tester.pumpWidget(
@@ -352,7 +362,10 @@ void main() {
     testWidgets('each row shows displayTime (HH:mm:ss.mmm)', (tester) async {
       final inspector = FlutterInspector();
       inspector.registry.log.add(
-        LogEntry(message: 'tm', timestamp: DateTime(2026, 6, 26, 14, 30, 1, 123)),
+        LogEntry(
+          message: 'tm',
+          timestamp: DateTime(2026, 6, 26, 14, 30, 1, 123),
+        ),
       );
 
       await tester.pumpWidget(

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -37,6 +37,45 @@ void main() {
       expect(find.text('Test message 2'), findsNothing);
     });
 
+    testWidgets('clearing wipes all four merged-timeline sources, not just logs',
+        (tester) async {
+      final inspector = FlutterInspector();
+      inspector.log('log msg', level: LogLevel.info);
+      inspector.registry.navigator.add(
+        NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
+      );
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/x',
+          statusCode: 200,
+          isComplete: true,
+        ),
+      );
+      inspector.registry.database.add(
+        DatabaseEntry(operation: DatabaseOperation.insert, tableName: 'users'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      expect(find.text('log msg'), findsOneWidget);
+      expect(find.textContaining('/home'), findsOneWidget);
+      expect(find.textContaining('https://api.test/x'), findsOneWidget);
+      expect(find.textContaining('users'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.delete));
+      await tester.pump();
+
+      expect(find.text('log msg'), findsNothing);
+      expect(find.textContaining('/home'), findsNothing);
+      expect(find.textContaining('https://api.test/x'), findsNothing);
+      expect(find.textContaining('users'), findsNothing);
+    });
+
     testWidgets('tapping error log with stackTrace opens LogDetailView',
         (tester) async {
       final inspector = FlutterInspector();


### PR DESCRIPTION
### Summary
Closes #54

**[修正問題]**
Console tab（合併時間軸）點擊垃圾桶按鈕清除後，只要 timeline 中含有 network、navigator 或 database 來源的條目，這些條目不會被清空，畫面上仍殘留部分項目。

**[修正方式]**
1. **`lib/src/ui/dashboard/tabs/console_tab.dart`**：`ConsoleTab` 顯示的是 `mergedTimeline()`，合併 `log`/`network`/`navigator`/`database` 四個獨立 buffer，但垃圾桶按鈕原本只呼叫 `clearLogs()`，僅清空其中一份。改為同時呼叫 `clearLogs()`/`clearNetwork()`/`clearNavigator()`/`clearDatabase()`，清空 timeline 實際涵蓋的全部四個來源。
2. **`test/ui/tabs/console_tab_test.dart`**：新增回歸測試，餵入四種來源各一筆，驗證點擊垃圾桶後全部消失；已確認此測試在修正前會失敗、修正後通過。
3. **`.gitignore`**：順手修正一行因缺換行符而與既有規則黏成壞掉 pattern 的殘留（`!/dev/ci/**/Gemfile.lock` 白名單規則復原），與本次 bug fix 無邏輯關聯但影響同一檔案，一併處理。

**設計權衡說明**：此修正會讓 Console tab 的清空操作連帶清空 Network/Navigator/Database 各自 tab 的資料，因為四者共享同一份 buffer（無第二份真相），這是既有架構下唯一正確的選擇，已於 Issue #54 載明為預期行為。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 清除控制台内容时，现在会在一次操作中同时清空日志、网络、导航和数据库相关记录，并刷新界面。
  * 调整了特定锁定文件的忽略例外规则，避免在指定目录中被错误忽略。
* **Tests**
  * 新增了界面测试：点击清除后，不仅移除日志，也验证网络、导航和数据库时间线内容同时消失。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->