### PR TITLE
chore(release): bump version to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.1
+
+### Fixed
+* **Console tab clear button**: clearing the Console tab's merged timeline now wipes all four underlying sources (log, network, navigator, database) instead of only logs. Previously, network/navigator/database entries would reappear after clearing because they share the same buffers rendered in the Console tab's merged timeline.
+
 ## 1.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.2.0
+  flutter_inspector_kit: ^1.2.1
 ```
 
 Then run `flutter pub get`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary
[#56](https://github.com/Yomiamy/flutter_inspector_kit/issues/56) Release: Version v1.2.1

**[修正問題]**
發布新版 `1.2.1`，整合最近合併入 `main` 的 Console tab 清除按鈕修正（PR #55），並同步更新 `pubspec.yaml`、安裝版號與變更日誌。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號為 `1.2.1`。
2. **`README.md`**：更新安裝版號為 `^1.2.1`（本次為 bug fix，無使用者可見的用法變更，其餘章節維持不動）。
3. **`CHANGELOG.md`**：新增 `1.2.1` 的 Fixed 異動：Console tab 清除按鈕修正（不再只清 logs，同步清空 network/navigator/database）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了 Console 标签页的清空行为：清空后会同步移除所有相关数据，避免部分记录在刷新后重新出现。
* **Documentation**
  * 更新了变更记录，补充本次修复说明。
  * 同步调整了安装示例中的版本号，指向最新发布版本。
* **Chores**
  * 将项目版本号更新为 `1.2.1`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->