### PR TITLE
feat(network): capture and display structured DioException type and stack trace

### DIFF
--- a/docs/features/2026-07-03-structured-network-error.md
+++ b/docs/features/2026-07-03-structured-network-error.md
@@ -1,0 +1,152 @@
+# 功能規格：Dio 結構化錯誤捕捉（Structured Network Error）
+
+> **建立日期**：2026-07-03
+> **狀態**：規格草案（待確認）
+> **對應 brainstorm**：`docs/brainstorm/2026-07-01-features-brainstorm.md` #4（🟡 部分完成）
+> **Effort 評級**：low–medium ｜ **排查價值**：⭐⭐⭐⭐
+
+> 本文件只描述 **What & Why**（要什麼、為什麼要），不含實作步驟與程式碼。實作計畫另立於 `docs/plans/`。
+
+---
+
+## 1. 背景與問題
+
+`FlutterInspectorDioInterceptor` 目前在 `onError` 中已擷取相當多結構化資訊：`statusCode`、`requestHeaders`、`requestBody`、`responseHeaders`、`responseBody`、`isReplay`。但錯誤的**根因分類**卻被丟棄——第 99 行仍是 `error: err.toString()`，這行把 `DioException` 壓縮成一坨純文字，同時丟掉了兩個關鍵欄位：
+
+- `err.type`（`DioExceptionType`）——錯誤的**機器可讀分類**（connectionTimeout / sendTimeout / receiveTimeout / badCertificate / connectionError / cancel / badResponse / unknown）。
+- `err.stackTrace`——錯誤發生點的呼叫堆疊，排查非 HTTP 語意失敗時的唯一線索。
+
+### 核心痛點
+
+對於 **4xx / 5xx 錯誤**，`statusCode` 已顯示在 `NetworkDetailView` 的 General section，開發者可以辨識（是 server 回了錯誤碼）。**真正的盲區是 `statusCode == null` 的傳輸層失敗**：斷網、DNS 解析失敗、SSL 握手錯誤、connection timeout、request cancel。這些情況下：
+
+- General section 的 Status 只顯示 `-`（因 `statusCode == null`）。
+- Error section 只有一坨 `err.toString()` 字串。
+
+開發者無法從 UI 分辨「這筆 Failed 到底是**斷網（傳輸層沒到 server）**，還是**後端回了錯誤（server 有回應）**」。這是排查網路問題時最基本、也最常需要的一刀切分，目前卻要靠肉眼從 toString() 字串裡猜。
+
+### 為什麼值得做
+
+- **消滅猜謎**：一條清楚的判斷——`response == null` → 傳輸層失敗；`response != null` → server 回了錯誤碼——就能把「Failed 是斷網還是後端壞了」這個高頻疑問變成 UI 上一眼可辨的事實。
+- **零新框架**：核心抽象都已存在（`@immutable` 的 `NetworkEntry`、`DioExceptionType` enum、`NetworkDetailView` 的 card 分層 section、`LogDetailView` 已證明的可複製 stackTrace 區段）。這是**組合既有零件**，不是造新輪子。
+- **擴充式、零破壞**：只新增可選欄位與新的 UI section，不改動任何既有公開 API 行為。
+
+---
+
+## 2. 使用者故事
+
+1. **作為開發者**，當我的請求因斷網 / DNS 失敗而失敗時，我想在 `NetworkDetailView` 一眼看出「這是傳輸層失敗，根本沒到 server」，而不是對著一坨 toString() 字串猜是網路問題還是後端問題。
+
+2. **作為 QA**，當我回報一筆網路錯誤時，我想知道錯誤的**分類名稱**（例如 connectionTimeout、badCertificate），這樣我在 bug ticket 上能寫出精確的根因描述，而不是貼一段看不懂的例外文字。
+
+3. **作為開發者**，當請求因非 HTTP 語意的例外（例如 response 解析失敗、SSL 錯誤）而失敗時，我想展開並**複製 stackTrace**，定位到程式碼中真正出錯的位置——就像我在 `LogDetailView` 對 error log 做的一樣。
+
+4. **作為開發者**，當 server 回了 4xx/5xx 時，我想在同一個 section 同時看到「錯誤分類」「status code」「server 回傳的錯誤說明（response body）」，把「傳輸成功但語意失敗」的完整脈絡收在一處。
+
+---
+
+## 3. 功能需求
+
+### 3.1 資料模型：`NetworkEntry` 新增結構化錯誤欄位
+
+在 `NetworkEntry`（`@immutable`）新增兩個**可選**欄位，用來承載被丟棄的結構化資訊：
+
+- **`errorType`**：錯誤的機器可讀分類，型別為 `DioExceptionType?`（`package:dio` 已導出的 enum）。傳輸層失敗與 server 錯誤都會帶此欄位；成功請求為 `null`。
+- **`errorStackTrace`**：錯誤發生點的呼叫堆疊，型別為 `StackTrace?`（或其字串化形式，實作時決定；規格層面只要求「可展示、可複製的堆疊文字」）。成功請求為 `null`。
+
+**相容性硬性要求**：兩個新欄位必須是**可選且具預設值 `null`**，使既有所有 `NetworkEntry(...)` 建構呼叫（含測試、含 example）無需修改即可編譯通過。`copyWith`、`operator ==`、`hashCode`、`toString` 需一併把新欄位納入，維持 value-equality 語意的一致性。
+
+> **註**：`error`（`String?`）欄位**保留**。它承載人類可讀的錯誤摘要文字，與 `errorType`（機器分類）並存、不互斥。既有依賴 `entry.error != null` 判斷「是否失敗」的邏輯（例如 `statusColorFor`）不受影響。
+
+### 3.2 擷取：`dio_interceptor.onError` 保留結構化欄位
+
+`onError` 建立失敗的 `NetworkEntry` 時，除既有欄位外，額外帶入：
+
+- `errorType: err.type`
+- `errorStackTrace: err.stackTrace`
+
+`error` 欄位的填法可維持人類可讀摘要（實作決定是否仍用 `err.toString()` 或改用更精簡的 `err.message`）——規格層面**不強制**改動 `error` 的內容，只要求**不再丟棄** `err.type` 與 `err.stackTrace`。
+
+`onResponse`（成功路徑）不受影響，`errorType` / `errorStackTrace` 保持 `null`。
+
+### 3.3 UI：`NetworkDetailView` 新增「Exception Details」section
+
+當 entry 代表一筆失敗（判準見下）時，`NetworkDetailView` 新增一個 **Exception Details** card section，取代或補強現有的單一 `Error` section，分層展示：
+
+- **錯誤類別標題**：明確標示這是**傳輸層失敗**還是 **server 錯誤回應**（見 3.4 的判斷規則）。
+- **Error Type**：`errorType` 的可讀名稱（例如 `connectionTimeout`、`badCertificate`、`badResponse`）。`null` 時不顯示該列。
+- **錯誤訊息**：既有 `error` 文字（沿用目前 `_errorSection` 的呈現）。
+- **Stack Trace**：`errorStackTrace` 的**可複製**區段，沿用 `LogDetailView` 已有的可複製 stackTrace 呈現慣例。`null` 時不顯示該區段。
+
+呈現須沿用既有的 `_section` card 分層與 `_kv` / `KeyValueTable` 排版慣例，維持 detail view 的視覺一致性。
+
+### 3.4 傳輸層失敗 vs server 錯誤：呈現上的區分
+
+核心判斷一條，貫穿 General section 與 Exception Details section：
+
+- **`response == null`（即 `statusCode == null` 且 `errorType != null`）→ 傳輸層失敗**：請求根本沒到 server（斷網、DNS、SSL、timeout、cancel）。Exception Details 標題明確標為「傳輸層失敗」語意；此時**不應**顯示或誤導性呈現一個假的 status。
+- **`response != null`（即 `statusCode != null`）→ server 回了錯誤碼**：傳輸成功，是應用層/語意失敗。Exception Details 與既有的 Response Headers / Response Body section 並存，讓「server 回傳的錯誤說明」可被看見。
+
+此區分只需依現有欄位（`statusCode` 是否為 `null`）加上新的 `errorType` 即可判定，**不需要**新增額外的布林旗標。既有的 `statusColorFor(statusCode, error != null)` 已能正確著色（`statusCode == null && hasError` → 紅色），不需改動。
+
+---
+
+## 4. 驗收條件
+
+以下為可測試的具體條件：
+
+### 資料模型層
+
+- [ ] `NetworkEntry` 具備 `errorType`（`DioExceptionType?`）與 `errorStackTrace`（`StackTrace?` 或等效可展示形式）兩個可選欄位，預設值均為 `null`。
+- [ ] 既有不帶新欄位的 `NetworkEntry(...)` 建構呼叫**無需修改**即可編譯（相容性測試：任一既有測試 fixture 不改動仍通過）。
+- [ ] `copyWith` 能正確帶入/保留 `errorType` 與 `errorStackTrace`。
+- [ ] `operator ==` 與 `hashCode` 已將新欄位納入：兩筆 `errorType` 不同的 entry 不相等；`errorType` 相同的其餘欄位相同時相等。
+
+### 擷取層
+
+- [ ] 給定一個 `err.response == null` 的 `DioException`（例如 `DioExceptionType.connectionError`），`onError` 產生的 `NetworkEntry` 之 `errorType == DioExceptionType.connectionError` 且 `statusCode == null`。
+- [ ] 給定一個 `err.response != null`（例如 500）的 `DioException`（`DioExceptionType.badResponse`），`onError` 產生的 `NetworkEntry` 之 `errorType == DioExceptionType.badResponse` 且 `statusCode == 500`。
+- [ ] `onError` 產生的 `NetworkEntry` 之 `errorStackTrace` 非 `null`（當 `err.stackTrace` 存在時）。
+- [ ] 成功請求（`onResponse` 路徑）產生的 `NetworkEntry` 之 `errorType == null` 且 `errorStackTrace == null`。
+
+### UI 層
+
+- [ ] 當 `errorType != null` 且 `statusCode == null` 時，`NetworkDetailView` 顯示標示為「傳輸層失敗」語意的 Exception Details section。
+- [ ] 當 `errorType != null` 且 `statusCode != null` 時，`NetworkDetailView` 顯示標示為「server 錯誤回應」語意的 Exception Details section，且與 Response Headers / Response Body section 並存。
+- [ ] Exception Details section 顯示 `errorType` 的可讀名稱。
+- [ ] `errorStackTrace != null` 時，Exception Details section 提供**可複製**的 stackTrace 區段。
+- [ ] `errorType == null`（成功請求）時，**不**顯示 Exception Details section。
+- [ ] 既有的 General section Status 著色行為不變（`statusCode == null && error != null` 仍為紅色）。
+
+---
+
+## 5. 範圍邊界（Out of Scope）
+
+以下**明確排除**，避免範圍蔓延：
+
+1. **#7 錯誤聚合摘要（Error Aggregation）**：本規格只負責在**單筆** entry 上補齊 `errorType` 這個分組所需的欄位；「按 `(statusCode, errorType)` 分組計數 + 首末時間 + Error Summary 卡」屬 #7，不在本規格範圍。本規格為 #7 提供地基，但不實作 #7 本身。
+2. **HAR timing waterfall（DNS/TLS/TTFB 分段）**：明確為 anti-feature。Dio 多版本拿不到可靠分段 timing，硬湊是假精度。保留既有 total duration + timeout 分類已足夠，不追 timing 瀑布。
+3. **API mocking / 動態回應改寫**：明確為 anti-feature，違反 Never break userspace，交給外部 proxy。
+4. **不破壞既有 `NetworkEntry` 建構參數相容性**：新欄位必為可選具預設值。任何要求既有呼叫端修改建構參數的方案都不接受。
+5. **不改動既有公開 API 行為**：`FlutterInspector` 對外行為、`error` 欄位既有語意（`error != null` 代表失敗）皆不變。
+6. **不新增額外相依**：`DioExceptionType` 來自既有的 `package:dio`，無需引入新 package。
+
+---
+
+## 6. 對既有功能的影響評估
+
+| 既有功能 | 是否受影響 | 說明 / 需跟進項 |
+|---|:---:|---|
+| **Resend（`_ResendAction`）** | 否 | Resend 邏輯只依賴 `sourceDio`、`isComplete`、`isRequestTruncated`，不觸及新欄位。新欄位純為記錄用，重送不需帶入。重送結果作為新 `NetworkEntry` 記回，其 `errorType` / `errorStackTrace` 由 `onError` 自然填入。**無需修改**。 |
+| **Redaction（`redactSensitiveData`）** | 需評估 | `redactSensitiveData` 目前只作用於**分享/匯出路徑**（`buildCurl` / `buildPlainText`），不影響畫面顯示。`errorType` 是 enum、`errorStackTrace` 是呼叫堆疊，**通常不含使用者輸入的敏感資料**，預設不需遮蔽。**但**：任何跳轉 `NetworkDetailView` 的入口都必須沿用既有慣例傳入 `redactSensitiveData`（否則 opt-out 行為分歧）——新增 Exception Details section **不改變**此入口約定。若日後 stackTrace 被納入分享文字，需一併評估遮蔽策略（見下）。 |
+| **Console mergedTimeline** | 否（自動受益） | `NetworkEntry` 實作 `TimestampedEntry`，console 混合時間軸依 `timestamp` 排序，新增欄位不影響排序。console Network 列點擊仍跳 `NetworkDetailView`，自動獲得 Exception Details 呈現，無需改動 console 端程式碼。 |
+| **序列化 / 分享文字（`buildPlainText` / `buildCurl`）** | 需決策 | 目前 `buildPlainText` 是否納入 `errorType` / `errorStackTrace` 需一項決策：**建議**在 `buildPlainText` 加入 `errorType`（純分類、無敏感風險），提升 QA 分享的排查價值；`errorStackTrace` 是否納入分享文字則需權衡（可能很長、且需確認遮蔽策略）。`buildCurl` 只描述請求，**不涉及**錯誤欄位，無需改動。此項為**建議的跟進**，非本規格核心驗收條件——可在計畫階段決定是否納入首版。 |
+| **`statusColorFor` 著色** | 否 | 既有簽章 `statusColorFor(statusCode, error != null)` 已能正確處理 `statusCode == null && hasError` → 紅色。新增 `errorType` 不改變著色輸入。**無需修改**。 |
+
+---
+
+## 附錄：關鍵設計判準摘要
+
+- **一條核心判斷**：`response == null` → 傳輸層失敗；`response != null` → server 回錯。此判斷用既有 `statusCode == null` + 新 `errorType != null` 即可推導，**不新增布林旗標**（消滅特殊情況）。
+- **`error` 與 `errorType` 並存**：`error` 是人類可讀摘要，`errorType` 是機器分類，兩者不互斥、不取代。既有 `error != null` 判斷失敗的語意完全保留。
+- **新欄位可選具預設值**：這是相容性的地基，也是「Never break userspace」在本功能上的具體落實。

--- a/docs/plans/2026-07-03-structured-network-error.md
+++ b/docs/plans/2026-07-03-structured-network-error.md
@@ -1,0 +1,274 @@
+# 實作計畫：Dio 結構化錯誤捕捉（Structured Network Error）
+
+- **日期**：2026-07-03
+- **階段**：STAGE 0b — 實作計畫（只寫 How）
+- **對應規格**：`docs/features/2026-07-03-structured-network-error.md`（source of truth）
+- **性質**：純擴充式增補。在 `@immutable` 的 `NetworkEntry` 加兩個可選欄位、`onError` 停止丟棄 `err.type`/`err.stackTrace`、`NetworkDetailView` 補一個 Exception Details section。零新框架、零新相依、零破壞既有建構呼叫。
+
+---
+
+## 1. 拍板決策（規格 §3.1 §6 的兩個開放點）
+
+### 決策 A：`errorStackTrace` 型別 → **`String?`**
+
+**結論**：存字串化形式 `String?`，不存原生 `StackTrace?`。
+
+**一行理由**：`LogEntry.stackTrace` 既有慣例就是 `String?`（`log_entry.dart:29`，UI 用 `SelectableText(entry.stackTrace!)` 直接展示、`buildLogPlainText` 直接寫入），`NetworkEntry` 是 `@immutable` 純資料模型、UI 只需展示與複製文字，保持與既有 stackTrace 慣例一致；`onError` 端以 `err.stackTrace?.toString()` 轉入。
+
+**衍生規則**：`onError` 寫入時用 `err.stackTrace?.toString()`。`StackTrace.toString()` 對 `StackTrace.empty` 會回空字串，UI/formatter 沿用 `LogEntry` 慣例以 `?.isNotEmpty ?? false` 判空，空字串等同不顯示。
+
+### 決策 B：`buildPlainText` 納入範圍 → **納入 `errorType`，納入 `errorStackTrace`**
+
+**結論**：`buildPlainText` 的 Error section 補上 `Error Type:` 一行（`errorType != null` 時），並在其後新增 `=== Stack Trace ===` 區段（`errorStackTrace` 非空時），對齊 `buildLogPlainText` 已證明的結構。
+
+**一行理由**：`errorType` 是純 enum 分類、無敏感風險，直接提升 QA 分享排查價值（規格 §6 「建議納入」）；`errorStackTrace` 已決定為字串、`buildLogPlainText` 早已把 stackTrace 納入分享文字且未遮蔽（stackTrace 是呼叫堆疊、非使用者輸入敏感資料），兩者一致納入不製造分歧。長度風險由既有 body 已可達 10KB 的現實吸收，不另設截斷（YAGNI，規格未要求）。
+
+**遮蔽策略**：`errorType`/`errorStackTrace` 皆**不經 `redactHeaders`**——它們不是 header、不含使用者輸入敏感資料，與 `buildLogPlainText` 對 stackTrace 的處理一致。`redact` 參數對這兩個欄位無作用（不改變 redaction 既有約定）。
+
+---
+
+## 2. 資料結構變更：`NetworkEntry` 新增兩欄位
+
+在 `lib/src/models/network_entry.dart` 加兩個可選欄位，全部具預設 `null`。
+
+### 2.1 欄位定義
+
+```dart
+/// Machine-readable error classification from Dio, if the request failed.
+final DioExceptionType? errorType;
+
+/// Stringified stack trace captured at the point of failure, if any.
+final String? errorStackTrace;
+```
+
+- `import 'package:dio/dio.dart';` — 檔案**已有此 import**（`network_entry.dart:3`，供 `sourceDio` 用），`DioExceptionType` 直接可用，零新相依。
+- 建構子加兩個具預設值的具名參數：`this.errorType,` 與 `this.errorStackTrace,`，放在 `this.error` 之後、`this.isComplete` 之前，維持既有欄位排列直覺（錯誤相關欄位聚在一起）。
+
+### 2.2 `copyWith`
+
+在參數列加 `DioExceptionType? errorType,` 與 `String? errorStackTrace,`（`sourceDio` 之前，對齊欄位順序），body 加：
+
+```dart
+errorType: errorType ?? this.errorType,
+errorStackTrace: errorStackTrace ?? this.errorStackTrace,
+```
+
+> **note**：沿用既有 `?? this.xxx` 慣例。這代表 `copyWith` 無法把已設值清回 `null`（既有所有欄位皆此語意，含 `error`），與現況一致、不引入新特殊情況。onError 是一次性建構完整 entry，不依賴 copyWith 清空。
+
+### 2.3 `operator ==`
+
+在既有比較鏈末端（`other.isReplay == isReplay` 之前或之後）加：
+
+```dart
+other.errorType == errorType &&
+other.errorStackTrace == errorStackTrace &&
+```
+
+- `DioExceptionType` 是 enum，`==` 為 identity 比較，穩定可靠。
+- `String?` 的 `==` 為值相等，穩定可靠。
+
+### 2.4 `hashCode`
+
+在 `Object.hash(...)` 參數列加 `errorType, errorStackTrace,`。
+
+> **既有慣例確認**：現有 `hashCode` 刻意省略 `requestHeaders`/`responseHeaders`（map hash 不穩），但納入 `error`、`isReplay` 等穩定欄位。`errorType`（enum）與 `errorStackTrace`（String）皆為穩定 hash，納入符合既有慣例，且與 `==` 對齊（`==` 比的欄位 hashCode 應納入以維持契約）。
+
+### 2.5 `toString`
+
+`toString` 現況只印 `method/url/status/complete`（`network_entry.dart:213`）。**不改動**——它是除錯用簡短摘要，非驗收條件，加 errorType 會拉長且無明確需求（YAGNI）。
+
+---
+
+## 3. 任務拆分
+
+每個任務標註：寫入檔案（scope）、複雜度（快/便宜｜標準｜最強）、驗收方式、依賴。
+
+> **並行分組**：T1、T2 寫入路徑互不重疊（model vs interceptor），但 T2 建構 entry 時要帶新欄位、依賴 T1 的欄位存在 → T2 依賴 T1。T4（formatter）與 T5（UI）都依賴 T1，彼此寫入路徑不重疊可並行。整體關鍵路徑：T1 → {T2, T4, T5 並行} → T6（回歸驗證）。
+
+---
+
+### T1 — `NetworkEntry` 新增欄位 + copyWith/==/hashCode + 單元測試
+
+- **scope**：
+  - `lib/src/models/network_entry.dart`（改）
+  - `test/models/network_entry_test.dart`（增測試 group）
+- **複雜度**：**快/便宜**（機械性：照 §2 定義加欄位、比對鏈、hash 參數；測試照既有 group 模板複製）
+- **內容**：實作 §2.1–§2.4。測試新增一個 `group('structured error fields')`，涵蓋：
+  - 預設值：不帶新欄位建構 → `errorType == null && errorStackTrace == null`（驗收：規格 §4 「預設 null」）
+  - 相容性：**沿用既有 fixture（如 `sample`/現有測試建構）不改動仍編譯通過並綠**（此為既有測試自然覆蓋，本任務不改任何既有測試）
+  - `copyWith` 帶入：`base.copyWith(errorType: DioExceptionType.connectionError, errorStackTrace: 's')` → 兩欄位正確設入、其餘欄位不變
+  - `copyWith` 保留：`base(帶 errorType).copyWith(isReplay: true)` → errorType 保留
+  - `==`/`hashCode`：兩筆僅 `errorType` 不同 → `isNot(equals)` 且 hashCode 不同；兩筆 `errorType` 相同其餘相同 → 相等且 hashCode 相同
+  - `==`：兩筆僅 `errorStackTrace` 不同 → 不相等
+- **驗收**：`fvm flutter test test/models/network_entry_test.dart` 全綠（含既有所有 case 不改動仍通過）
+- **依賴**：無（起點）
+
+---
+
+### T2 — `dio_interceptor.onError` 保留 `err.type` / `err.stackTrace` + 傳輸層/server 兩路徑測試
+
+- **scope**：
+  - `lib/src/interceptors/dio_interceptor.dart`（改：僅 `onError` 建構 entry 處）
+  - `test/interceptors/dio_interceptor_test.dart`（增測試）
+- **複雜度**：**標準**（整合：改建構、確認 `err.response == null` 分岔的 statusCode 與 errorType 對應正確；測試要用 `DioException` 帶不同 `type`/`response`）
+- **內容**：
+  - `onError` 建構 `NetworkEntry` 時，除既有欄位外加：
+    ```dart
+    errorType: err.type,
+    errorStackTrace: err.stackTrace.toString(),
+    ```
+    > `err.stackTrace` 在 Dio 5.x 是 non-nullable `StackTrace`（`DioException.stackTrace`），`toString()` 直接可用。若為 `StackTrace.empty` 會得空字串，UI/formatter 以非空判斷自然略過（見決策 A 衍生規則）。
+  - `error` 欄位**維持 `err.toString()`**（規格 §3.2「不強制改動 error 內容」，保留人類可讀摘要，避免動到既有 `entry.error != null` 判斷失敗的語意）。
+  - `onResponse`/`onRequest` **不動**（成功路徑 errorType/errorStackTrace 自然為 null）。
+- **新增測試**（沿用既有 `errorHandler.future.then((_){}, onError:(_){})` 觀察慣例，避免 unhandled）：
+  - **傳輸層路徑**：`DioException(requestOptions, type: DioExceptionType.connectionError, error: 'x')`（`response == null`）→ entry `errorType == DioExceptionType.connectionError` 且 `statusCode == null`（驗收：規格 §4 擷取層第 1 條）
+  - **server 路徑**：`DioException(requestOptions, type: DioExceptionType.badResponse, response: Response(statusCode: 500, requestOptions:...))` → entry `errorType == DioExceptionType.badResponse` 且 `statusCode == 500`（驗收：規格 §4 擷取層第 2 條）
+  - **stackTrace 非 null**：帶 `stackTrace: StackTrace.current` 的 DioException → entry `errorStackTrace != null`（驗收：規格 §4 擷取層第 3 條）
+  - **成功路徑**：`onResponse` 產生的 entry → `errorType == null && errorStackTrace == null`（驗收：規格 §4 擷取層第 4 條）
+- **驗收**：`fvm flutter test test/interceptors/dio_interceptor_test.dart` 全綠（含既有 onError case，其斷言 `entry.error, isNotNull` 不受影響）
+- **依賴**：**T1**（entry 需先有 errorType/errorStackTrace 欄位才能建構）
+
+---
+
+### T4 — `buildPlainText` 納入 errorType + stackTrace + formatter 測試
+
+- **scope**：
+  - `lib/src/utils/network_formatters.dart`（改：僅 `buildPlainText` 的 Error 尾段）
+  - `test/utils/network_formatters_test.dart`（增測試）
+- **複雜度**：**快/便宜**（機械性：照 `buildLogPlainText` 的 stackTrace 區段模板；純字串組裝）
+- **內容**：改 `buildPlainText` 尾段（現 `if (entry.error != null)` 區塊，`network_formatters.dart:145-149`）：
+  ```dart
+  if (entry.error != null || entry.errorType != null) {
+    b.writeln('\n=== Error ===');
+    if (entry.errorType != null) {
+      b.writeln('Error Type: ${entry.errorType!.name}');
+    }
+    if (entry.error != null) {
+      b.writeln(entry.error);
+    }
+  }
+  final st = entry.errorStackTrace;
+  if (st != null && st.isNotEmpty) {
+    b
+      ..writeln('\n=== Stack Trace ===')
+      ..writeln(st);
+  }
+  ```
+  > `DioExceptionType.name`（enum `.name`）給可讀分類字串。stackTrace 區段沿用 `buildLogPlainText` 的 `!= null && isNotEmpty` 判空慣例。**不經 redact**（見決策 B 遮蔽策略）。
+- **新增測試**：
+  - Error section 含 `Error Type:` 行：entry 帶 `errorType: DioExceptionType.connectionError, error: 'x'` → text 含 `'Error Type: connectionError'` 且含 `'x'`
+  - Stack Trace section：entry 帶 `errorStackTrace: '#0 foo'` → text 含 `'=== Stack Trace ==='` 且含 `'#0 foo'`
+  - 成功 entry（無 error/errorType/stackTrace）→ text **不含** `'=== Error ==='` 也不含 `'=== Stack Trace ==='`（驗證既有「無 error 不輸出 Error section」不回歸）
+  - redaction 無作用於這兩欄：帶 stackTrace 的 entry，`buildPlainText(entry)` 與 `buildPlainText(entry, redact:false)` 的 stackTrace 段內容一致（不被遮蔽）
+- **驗收**：`fvm flutter test test/utils/network_formatters_test.dart` 全綠（含既有 `buildPlainText` 「includes ... error sections」case，其 `error: 'Server error'` 仍輸出）
+- **依賴**：**T1**（讀取 entry.errorType/errorStackTrace）。與 T2、T5 可並行（寫入路徑不重疊）
+
+---
+
+### T5 — `NetworkDetailView` 新增 Exception Details section + widget 測試
+
+- **scope**：
+  - `lib/src/ui/dashboard/tabs/network/network_detail_view.dart`（改：`build` 的 section 列 + 替換/補強 `_errorSection`）
+  - `test/ui/tabs/network_detail_view_test.dart`（增測試 group）
+- **複雜度**：**最強**（設計判斷：傳輸層 vs server 標題文案、section 何時取代既有 `_errorSection`、失敗判準的一致落地、stackTrace 可複製區段沿用 LogDetailView 慣例；牽涉 UX 呈現決策）
+- **內容**：
+  - **失敗判準**（規格 §3.4，不新增布林旗標）：定義局部 `final bool hasStructuredError = entry.errorType != null;`。
+  - **section 掛載**：`build` 的 `children` 尾段，把現有 `if (entry.error != null) _errorSection(context)` 改為條件掛 Exception Details——當 `entry.errorType != null || entry.error != null` 時顯示 `_exceptionDetailsSection(context)`。
+    > **相容性 note**：舊資料（來自舊版、只有 `error` 無 `errorType` 的 entry）仍能顯示（走 `error != null` 分支，標題退化為中性 'Exception Details'，只印 error 文字）。這確保 ring buffer 內既存 entry 不因升級而丟失 error 呈現。
+  - **`_exceptionDetailsSection`**（新私有方法，取代 `_errorSection`）：一個 `_section(context, 'Exception Details', Column(...))`，內含（沿用 `_kv`/`_kvWidget` 與 `_bodySection` 的 stackTrace 容器慣例）：
+    1. **類別標題列**（`_kv`）：
+       - `entry.errorType != null && entry.statusCode == null` → `_kv(context, 'Kind', '傳輸層失敗 (transport failure — request did not reach server)')`
+       - `entry.errorType != null && entry.statusCode != null` → `_kv(context, 'Kind', 'Server 錯誤回應 (server responded with error)')`
+       - `entry.errorType == null`（僅舊 error）→ 不顯示 Kind 列
+    2. **Error Type 列**：`entry.errorType != null` → `_kv(context, 'Error Type', entry.errorType!.name)`；null 時不顯示（規格 §3.3）
+    3. **錯誤訊息**：`entry.error != null` → 沿用既有 `_errorSection` 的紅色 `SelectableText(entry.error!)` 呈現，包成一個 `_kvWidget` 或直接一列
+    4. **Stack Trace 區段**：`entry.errorStackTrace` 非空 → 沿用 `LogDetailView._stackTraceSection` 的 monospace + `surfaceContainerHighest` 容器 + `SelectableText`（可複製），標題可用內嵌 'Stack Trace' 子標；null/空時不顯示（規格 §3.3）
+  - **`_errorSection` 移除或內聯**：原 `_errorSection` 只印 error 文字，其職責併入 `_exceptionDetailsSection` 的第 3 點。移除 `_errorSection` 方法。
+  - **General section 不動**：`statusColorFor(entry.statusCode, entry.error != null)` 著色輸入不變（規格 §3.4 明言不改），Status 顯示 `'${entry.statusCode ?? '-'}'` 不動——傳輸層失敗自然顯示 `-`，不造假 status。
+  - **pump surface**：沿用既有 `physicalSize = Size(1200, 4000)` 避免 overflow。
+- **新增測試 group `Exception Details section`**：
+  - **傳輸層失敗**：entry `errorType: DioExceptionType.connectionError, statusCode: null, error: 'x'` → `find.text('Exception Details')` 一個、含「傳輸層失敗」文案、含 `'connectionError'`（驗收：規格 §4 UI 層第 1、3 條）
+  - **server 錯誤**：entry `errorType: DioExceptionType.badResponse, statusCode: 500, error: 'x', responseHeaders:{...}, responseBody:'oops'` → 含「Server 錯誤回應」文案、`find.text('Response Headers')` 與 `find.text('Response Body')` 仍在（並存，驗收：規格 §4 UI 層第 2 條）
+  - **stackTrace 可複製**：entry 帶 `errorStackTrace: '#0 foo\n#1 bar'` → section 內含該文字的 `SelectableText`（沿用 LogDetailView 測試「`find.byType(SelectableText)`」慣例）（驗收：規格 §4 UI 層第 4 條）
+  - **成功不顯示**：`sample()`（errorType null、error null）→ `find.text('Exception Details')` findsNothing（驗收：規格 §4 UI 層第 5 條）
+  - **General 著色不回歸**：既有 `statusColorFor` test 已覆蓋，本 group 額外斷言傳輸層失敗 entry 的 Status 文字為 `'-'`（不造假）
+- **驗收**：`fvm flutter test test/ui/tabs/network_detail_view_test.dart` 全綠（含既有 'renders all sections'、redaction、Resend 全部 case）
+- **依賴**：**T1**（讀 entry.errorType/errorStackTrace）。與 T2、T4 可並行
+
+---
+
+### T6 — 全套回歸 + 分析器
+
+- **scope**：無新寫入（純驗證任務）
+- **複雜度**：**快/便宜**（跑既有指令）
+- **內容**：跑分析器與相關測試套件，確認零回歸。
+- **驗收**：
+  - `fvm flutter analyze`（或專案慣用 lint 指令）零 error/warning
+  - `fvm flutter test test/models/ test/interceptors/ test/utils/ test/ui/tabs/network_detail_view_test.dart` 全綠
+  - **console 跳轉不回歸**：確認 `test/ui/tabs/console_tab_test.dart`（若涵蓋 Network 列點擊跳 NetworkDetailView）仍綠；若無此覆蓋則手動確認 console mergedTimeline 端無 import 改動（本計畫未動 console 檔）
+- **依賴**：T2、T4、T5 全部完成
+
+> **測試效能守則（依 MEMORY）**：STAGE 3 review 不重跑已在 T1/T2/T4/T5 驗過的測試；`magical_tap_test` 有既有 10 分鐘 timeout，跑全套前先排除或單獨處理。本計畫 T6 只跑受影響套件，不必全 repo 掃。
+
+---
+
+## 4. 測試計畫（新增案例彙總）
+
+| 層 | 檔案 | 新增案例 | 對應規格驗收 |
+|---|---|---|---|
+| model | `network_entry_test.dart` | 預設 null｜copyWith 帶入/保留｜`==`/`hashCode` errorType 差異｜`==` errorStackTrace 差異 | §4 資料模型層 4 條 |
+| interceptor | `dio_interceptor_test.dart` | 傳輸層路徑（connectionError, status null）｜server 路徑（badResponse, 500）｜stackTrace 非 null｜成功路徑雙 null | §4 擷取層 4 條 |
+| formatter | `network_formatters_test.dart` | Error Type 行｜Stack Trace 段｜成功無 Error/Stack 段｜redact 不作用於這兩欄 | 決策 B（規格 §6 建議） |
+| UI | `network_detail_view_test.dart` | 傳輸層失敗標題+Error Type｜server 錯誤標題+並存 Response 段｜stackTrace 可複製｜成功不顯示｜Status 顯示 `-` 不造假 | §4 UI 層 6 條 |
+
+**兩路徑核心區分測試（interceptor）**是本功能的技術重心：`response == null` → `statusCode == null` + `errorType != null`（傳輸層）；`response != null` → `statusCode != null` + `errorType != null`（server）。這兩條測試鎖住規格 §3.4 的「一條核心判斷」。
+
+---
+
+## 5. 風險與回歸檢查點（不可破壞的既有行為）
+
+| # | 不可破壞項 | 為何有風險 | 檢查點 |
+|---|---|---|---|
+| R1 | **`NetworkEntry` 建構相容性** | 新欄位若無預設值，既有數十處 `NetworkEntry(...)` 呼叫（含所有測試 fixture、example）全部編譯失敗 | 兩欄位皆 `this.errorType,`/`this.errorStackTrace,` 具名可選、預設 null。T1 明令「既有 fixture 不改動仍綠」。`fvm flutter analyze` 零 error 即證 |
+| R2 | **`error != null` 代表失敗的既有語意** | `statusColorFor(statusCode, error != null)`、任何依 `entry.error != null` 判失敗的邏輯 | `error` 欄位保留、`onError` 仍填 `err.toString()`（T2）。`error` 與 `errorType` 並存不互斥。既有 statusColorFor test 不改仍綠 |
+| R3 | **Resend（`_ResendAction`）** | 若誤把新欄位塞進 replay 請求或 disabled 判斷 | Resend 只依賴 `sourceDio`/`isComplete`/`isRequestTruncated`（規格 §6 表列「否」）。本計畫**不碰** `_ResendAction`、`buildReplayRequest`。既有 Resend 全 case（T5 檔內）不改仍綠 |
+| R4 | **Redaction 約定** | 若 Exception Details 入口漏傳 `redactSensitiveData`，或 stackTrace 被誤當 header 遮蔽 | 新 section 在既有 `NetworkDetailView` 內，**沿用同一 widget 的 `redactSensitiveData`**，不新增跳轉入口（不改入口約定）。errorType/stackTrace 不經 `redactHeaders`（決策 B）。既有 redaction test（cURL/text 遮蔽 Authorization/Cookie）不改仍綠 |
+| R5 | **console mergedTimeline 跳轉** | 若動到 NetworkEntry 排序相關或 console 端 import | `NetworkEntry` 實作 `TimestampedEntry`，新欄位不影響 `timestamp` 排序。本計畫**不動** console 任何檔，Network 列點擊仍跳 `NetworkDetailView`，自動獲得新 section（規格 §6「自動受益」）。T6 確認 console 測試綠 |
+| R6 | **`buildCurl` 只描述請求** | 若誤把錯誤欄位混進 cURL | 本計畫**不碰** `buildCurl`（規格 §6「不涉及錯誤欄位」）。既有 buildCurl test 全綠 |
+| R7 | **`hashCode`/`==` 契約一致** | `==` 比的欄位若未同步進 hashCode，違反 equals/hashCode 契約 | T1 §2.3/§2.4 明令 errorType/errorStackTrace 同步進 `==` 與 `hashCode`（皆穩定 hash 型別）。T1 測試斷言兩者一致 |
+
+---
+
+## 6. 範圍邊界（本計畫明確不做）
+
+對齊規格 §5 Out-of-Scope：
+
+- **#7 錯誤聚合**：本計畫只在單筆 entry 補 `errorType` 欄位（為 #7 提供地基），**不**做 `(statusCode, errorType)` 分組計數/Error Summary 卡。
+- **HAR timing waterfall**：不做（anti-feature）。
+- **API mocking**：不做（anti-feature）。
+- **改 `NetworkEntry` 既有建構參數 / 公開 API 行為**：不做（新欄位純可選增補）。
+- **改 `toString`**：不做（§2.5，YAGNI）。
+- **改 `buildCurl` / Resend / console**：不做（R3/R5/R6）。
+
+---
+
+## 7. 執行方式建議（供 orchestrator 選擇）
+
+本計畫關鍵路徑短、任務界線清楚，兩種執行方式皆可：
+
+### 方式一：subagent-driven（單 session 序列委派，推薦）
+
+- 適合本計畫規模（5 個實作任務 + 1 驗證）。
+- 順序：**T1（起點，必先）** → 委派 T2、T4、T5 給獨立 implementer subagent（三者僅共同依賴 T1、寫入路徑互不重疊，可並行委派）→ **T6 匯總回歸**。
+- 好處：T1 完成後三個 subagent 可同時展開；主 session 只需在 T6 收斂驗證，context 負擔低。
+
+### 方式二：parallel session（多 terminal 並行）
+
+- T1 完成並 commit 後，開三個 session 分別跑 T2 / T4 / T5，各自 branch 或同 branch 不同檔（寫入路徑不重疊，無衝突）。
+- 適合有多人或想壓縮 wall-clock 時間時。收斂時合流跑 T6。
+
+**model 選型提示**（依複雜度標註）：
+
+- T1、T4、T6 → **快/便宜 model**（機械性、有明確模板）
+- T2 → **標準 model**（整合，需正確處理 response==null 分岔與 Dio API）
+- T5 → **最強 model**（UX 呈現設計判斷、section 取代邏輯、stackTrace 慣例移植）

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -97,6 +97,8 @@ class FlutterInspectorDioInterceptor extends Interceptor {
       ),
       responseBody: _stringifyData(err.response?.data),
       error: err.toString(),
+      errorType: err.type,
+      errorStackTrace: err.stackTrace.toString(),
       isComplete: true,
       timestamp: startTime,
       sourceDio: sourceDio,

--- a/lib/src/models/network_entry.dart
+++ b/lib/src/models/network_entry.dart
@@ -31,6 +31,8 @@ class NetworkEntry implements TimestampedEntry {
     this.responseHeaders,
     this.responseBody,
     this.error,
+    this.errorType,
+    this.errorStackTrace,
     this.isComplete = false,
     this.isReplay = false,
     Dio? sourceDio,
@@ -69,6 +71,12 @@ class NetworkEntry implements TimestampedEntry {
   /// Error message if the request failed.
   final String? error;
 
+  /// Machine-readable error classification from Dio, if the request failed.
+  final DioExceptionType? errorType;
+
+  /// Stringified stack trace captured at the point of failure, if any.
+  final String? errorStackTrace;
+
   /// Whether the response or error has been recorded.
   final bool isComplete;
 
@@ -103,6 +111,8 @@ class NetworkEntry implements TimestampedEntry {
     Map<String, dynamic>? responseHeaders,
     String? responseBody,
     String? error,
+    DioExceptionType? errorType,
+    String? errorStackTrace,
     bool? isComplete,
     bool? isReplay,
     Dio? sourceDio,
@@ -118,6 +128,8 @@ class NetworkEntry implements TimestampedEntry {
       responseHeaders: responseHeaders ?? this.responseHeaders,
       responseBody: responseBody ?? this.responseBody,
       error: error ?? this.error,
+      errorType: errorType ?? this.errorType,
+      errorStackTrace: errorStackTrace ?? this.errorStackTrace,
       isComplete: isComplete ?? this.isComplete,
       isReplay: isReplay ?? this.isReplay,
       sourceDio: sourceDio ?? this.sourceDio?.target,
@@ -137,6 +149,8 @@ class NetworkEntry implements TimestampedEntry {
         mapEquals(other.responseHeaders, responseHeaders) &&
         other.responseBody == responseBody &&
         other.error == error &&
+        other.errorType == errorType &&
+        other.errorStackTrace == errorStackTrace &&
         other.isComplete == isComplete &&
         other.isReplay == isReplay;
   }
@@ -151,6 +165,8 @@ class NetworkEntry implements TimestampedEntry {
     requestBody,
     responseBody,
     error,
+    errorType,
+    errorStackTrace,
     isComplete,
     isReplay,
   );

--- a/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
@@ -84,7 +84,11 @@ class NetworkDetailView extends StatelessWidget {
               entry.responseBody!,
               entry.isResponseJson,
             ),
-          if (entry.error != null) _errorSection(context),
+          if (entry.error != null ||
+              entry.errorType != null ||
+              (entry.errorStackTrace != null &&
+                  entry.errorStackTrace!.isNotEmpty))
+            _exceptionDetailsSection(context),
         ],
       ),
     );
@@ -160,13 +164,64 @@ class NetworkDetailView extends StatelessWidget {
     );
   }
 
-  Widget _errorSection(BuildContext context) {
+  Widget _exceptionDetailsSection(BuildContext context) {
     return _section(
       context,
-      'Error',
-      SelectableText(
-        entry.error!,
-        style: TextStyle(color: Theme.of(context).colorScheme.error),
+      'Exception Details',
+      Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (entry.errorType != null) ...[
+            if (entry.statusCode == null)
+              _kv(
+                context,
+                'Kind',
+                '傳輸層失敗 (transport failure — request did not reach server)',
+              )
+            else
+              _kv(
+                context,
+                'Kind',
+                'Server 錯誤回應 (server responded with error)',
+              ),
+            _kv(context, 'Error Type', entry.errorType!.name),
+          ],
+          if (entry.error != null)
+            _kvWidget(
+              context,
+              'Error',
+              SelectableText(
+                entry.error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          if (entry.errorStackTrace != null &&
+              entry.errorStackTrace!.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              'Stack Trace',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            const SizedBox(height: 6),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: SelectableText(
+                entry.errorStackTrace!,
+                style: const TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                ),
+              ),
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/lib/src/utils/network_formatters.dart
+++ b/lib/src/utils/network_formatters.dart
@@ -142,10 +142,20 @@ String buildPlainText(NetworkEntry entry, {bool redact = true}) {
       );
   }
 
-  if (entry.error != null) {
+  if (entry.error != null || entry.errorType != null) {
+    b.writeln('\n=== Error ===');
+    if (entry.errorType != null) {
+      b.writeln('Error Type: ${entry.errorType!.name}');
+    }
+    if (entry.error != null) {
+      b.writeln(entry.error);
+    }
+  }
+  final st = entry.errorStackTrace;
+  if (st != null && st.isNotEmpty) {
     b
-      ..writeln('\n=== Error ===')
-      ..writeln(entry.error);
+      ..writeln('\n=== Stack Trace ===')
+      ..writeln(st);
   }
 
   return b.toString().trimRight();

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -286,5 +286,87 @@ void main() {
         expect(inspector.registry.network.entries.first.isReplay, false);
       });
     });
+
+    group('structured error fields', () {
+      test('transport layer failure sets errorType and null statusCode', () async {
+        final options = RequestOptions(path: 'http://example.com/api');
+        interceptor.onRequest(options, RequestInterceptorHandler());
+
+        final errorHandler = ErrorInterceptorHandler();
+        final err = DioException(
+          requestOptions: options,
+          type: DioExceptionType.connectionError,
+          error: 'x',
+        );
+        interceptor.onError(err, errorHandler);
+        // ignore: invalid_use_of_protected_member
+        await errorHandler.future.then((_) {}, onError: (_) {});
+
+        expect(inspector.registry.network.entries.length, 1);
+        final entry = inspector.registry.network.entries.first;
+        expect(entry.errorType, DioExceptionType.connectionError);
+        expect(entry.statusCode, isNull);
+      });
+
+      test('server error path sets errorType, statusCode and responseBody', () async {
+        final options = RequestOptions(path: 'http://example.com/api');
+        interceptor.onRequest(options, RequestInterceptorHandler());
+
+        final errorHandler = ErrorInterceptorHandler();
+        final err = DioException(
+          requestOptions: options,
+          type: DioExceptionType.badResponse,
+          response: Response(
+            requestOptions: options,
+            statusCode: 500,
+            data: 'oops',
+          ),
+        );
+        interceptor.onError(err, errorHandler);
+        // ignore: invalid_use_of_protected_member
+        await errorHandler.future.then((_) {}, onError: (_) {});
+
+        expect(inspector.registry.network.entries.length, 1);
+        final entry = inspector.registry.network.entries.first;
+        expect(entry.errorType, DioExceptionType.badResponse);
+        expect(entry.statusCode, 500);
+        expect(entry.responseBody, 'oops');
+      });
+
+      test('stackTrace is recorded and not null or empty', () async {
+        final options = RequestOptions(path: 'http://example.com/api');
+        interceptor.onRequest(options, RequestInterceptorHandler());
+
+        final errorHandler = ErrorInterceptorHandler();
+        final st = StackTrace.current;
+        final err = DioException(
+          requestOptions: options,
+          type: DioExceptionType.connectionError,
+          stackTrace: st,
+        );
+        interceptor.onError(err, errorHandler);
+        // ignore: invalid_use_of_protected_member
+        await errorHandler.future.then((_) {}, onError: (_) {});
+
+        expect(inspector.registry.network.entries.length, 1);
+        final entry = inspector.registry.network.entries.first;
+        expect(entry.errorStackTrace, isNotNull);
+        expect(entry.errorStackTrace, isNotEmpty);
+        expect(entry.errorStackTrace, contains('dio_interceptor_test.dart'));
+      });
+
+      test('success path does not have errorType or errorStackTrace', () async {
+        final options = RequestOptions(path: 'http://example.com/api');
+        interceptor.onRequest(options, RequestInterceptorHandler());
+
+        final response = Response(requestOptions: options, statusCode: 200);
+        interceptor.onResponse(response, ResponseInterceptorHandler());
+
+        expect(inspector.registry.network.entries.length, 1);
+        final entry = inspector.registry.network.entries.first;
+        expect(entry.errorType, isNull);
+        expect(entry.errorStackTrace, isNull);
+      });
+    });
   });
 }

--- a/test/models/network_entry_test.dart
+++ b/test/models/network_entry_test.dart
@@ -208,6 +208,99 @@ void main() {
       });
     });
 
+    group('structured error fields', () {
+      test('defaults to null when not provided', () {
+        final entry = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: fixedTime,
+        );
+        expect(entry.errorType, isNull);
+        expect(entry.errorStackTrace, isNull);
+      });
+
+      test('copyWith sets errorType and errorStackTrace', () {
+        final base = NetworkEntry(
+          method: 'POST',
+          url: 'https://api',
+          timestamp: fixedTime,
+        );
+        final updated = base.copyWith(
+          errorType: DioExceptionType.connectionError,
+          errorStackTrace: '#0 foo\n#1 bar',
+        );
+        expect(updated.errorType, DioExceptionType.connectionError);
+        expect(updated.errorStackTrace, '#0 foo\n#1 bar');
+        expect(updated.method, base.method);
+        expect(updated.url, base.url);
+      });
+
+      test('copyWith preserves errorType when not specified', () {
+        final base = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: fixedTime,
+          errorType: DioExceptionType.badResponse,
+        );
+        final updated = base.copyWith(isReplay: true);
+        expect(updated.errorType, DioExceptionType.badResponse);
+        expect(updated.isReplay, isTrue);
+      });
+
+      test('equality differs when errorType differs', () {
+        final a = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: fixedTime,
+          errorType: DioExceptionType.connectionError,
+        );
+        final b = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: fixedTime,
+          errorType: DioExceptionType.badResponse,
+        );
+        expect(a, isNot(equals(b)));
+        expect(a.hashCode, isNot(b.hashCode));
+      });
+
+      test('equality differs when errorStackTrace differs', () {
+        final a = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: fixedTime,
+          errorStackTrace: '#0 foo',
+        );
+        final b = NetworkEntry(
+          method: 'GET',
+          url: 'https://x',
+          timestamp: fixedTime,
+          errorStackTrace: '#0 bar',
+        );
+        expect(a, isNot(equals(b)));
+        expect(a.hashCode, isNot(b.hashCode));
+      });
+
+      test('equality and hashCode same when errorType and errorStackTrace match', () {
+        final a = NetworkEntry(
+          method: 'POST',
+          url: 'https://api',
+          timestamp: fixedTime,
+          errorType: DioExceptionType.badResponse,
+          errorStackTrace: '#0 trace',
+        );
+        final b = NetworkEntry(
+          method: 'POST',
+          url: 'https://api',
+          timestamp: fixedTime,
+          errorType: DioExceptionType.badResponse,
+          errorStackTrace: '#0 trace',
+        );
+        expect(a, equals(b));
+        expect(a.hashCode, b.hashCode);
+      });
+    });
+
     group('derived getters', () {
       test('size getters count UTF-8 bytes, 0 for null', () {
         final entry = NetworkEntry(

--- a/test/ui/tabs/network_detail_view_test.dart
+++ b/test/ui/tabs/network_detail_view_test.dart
@@ -477,4 +477,94 @@ void main() {
       await tester.pumpAndSettle();
     });
   });
+
+  group('Exception Details section', () {
+    testWidgets('transport layer failure renders kind and error type', (tester) async {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test',
+        statusCode: null,
+        errorType: DioExceptionType.connectionError,
+        error: 'Connection failed',
+        isComplete: true,
+        timestamp: t,
+      );
+
+      await pumpView(tester, entry);
+
+      expect(find.text('Exception Details'), findsOneWidget);
+      expect(find.text('傳輸層失敗 (transport failure — request did not reach server)'), findsOneWidget);
+      expect(find.text('connectionError'), findsOneWidget);
+      expect(find.text('Connection failed'), findsOneWidget);
+
+      // Verify Status displays '-'
+      expect(
+        find.descendant(
+          of: find.byType(Row),
+          matching: find.byWidgetPredicate((widget) => widget is SelectableText && widget.data == '-'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('server error failure renders kind and is displayed with response sections', (tester) async {
+      final entry = NetworkEntry(
+        method: 'POST',
+        url: 'https://api.test',
+        statusCode: 500,
+        errorType: DioExceptionType.badResponse,
+        error: 'Internal Server Error',
+        responseHeaders: {'content-type': 'application/json'},
+        responseBody: 'oops',
+        isComplete: true,
+        timestamp: t,
+      );
+
+      await pumpView(tester, entry);
+
+      expect(find.text('Exception Details'), findsOneWidget);
+      expect(find.text('Server 錯誤回應 (server responded with error)'), findsOneWidget);
+      expect(find.text('badResponse'), findsOneWidget);
+      expect(find.text('Internal Server Error'), findsOneWidget);
+
+      // Verify response headers and body are also rendered
+      expect(find.text('Response Headers'), findsOneWidget);
+      expect(find.text('Response Body'), findsOneWidget);
+    });
+
+    testWidgets('renders selectable and copyable stack trace', (tester) async {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test',
+        errorStackTrace: '#0 foo\n#1 bar',
+        isComplete: true,
+        timestamp: t,
+      );
+
+      await pumpView(tester, entry);
+
+      expect(find.text('Exception Details'), findsOneWidget);
+      final selectableTextFinder = find.byWidgetPredicate(
+        (widget) => widget is SelectableText && widget.data == '#0 foo\n#1 bar',
+      );
+      expect(selectableTextFinder, findsOneWidget);
+      
+      final selectableText = tester.widget<SelectableText>(selectableTextFinder);
+      expect(selectableText.style?.fontFamily, 'monospace');
+    });
+
+    testWidgets('does not render Exception Details for success request', (tester) async {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test',
+        statusCode: 200,
+        isComplete: true,
+        timestamp: t,
+      );
+
+      await pumpView(tester, entry);
+
+      expect(find.text('Exception Details'), findsNothing);
+    });
+  });
 }

--- a/test/utils/network_formatters_test.dart
+++ b/test/utils/network_formatters_test.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_inspector_kit/src/models/network_entry.dart';
 import 'package:flutter_inspector_kit/src/utils/network_formatters.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -164,6 +165,60 @@ void main() {
       expect(text.contains('=== Request Body ==='), isTrue);
       expect(text.contains('=== Error ==='), isTrue);
       expect(text.contains('Server error'), isTrue);
+    });
+
+    test('includes error type in Error section when errorType is present', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/items',
+        errorType: DioExceptionType.connectionError,
+        error: 'Connection failed',
+        timestamp: fixedTime,
+      );
+      final text = buildPlainText(entry);
+      expect(text.contains('=== Error ==='), isTrue);
+      expect(text.contains('Error Type: connectionError'), isTrue);
+      expect(text.contains('Connection failed'), isTrue);
+    });
+
+    test('includes Stack Trace section when errorStackTrace is present', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/items',
+        errorStackTrace: '#0 foo\n#1 bar',
+        timestamp: fixedTime,
+      );
+      final text = buildPlainText(entry);
+      expect(text.contains('=== Stack Trace ==='), isTrue);
+      expect(text.contains('#0 foo\n#1 bar'), isTrue);
+    });
+
+    test('does not include Error or Stack Trace sections for success entry', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/items',
+        statusCode: 200,
+        timestamp: fixedTime,
+      );
+      final text = buildPlainText(entry);
+      expect(text.contains('=== Error ==='), isFalse);
+      expect(text.contains('=== Stack Trace ==='), isFalse);
+    });
+
+    test('redact does not affect errorType or errorStackTrace', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/items',
+        errorType: DioExceptionType.connectionError,
+        errorStackTrace: '#0 foo',
+        timestamp: fixedTime,
+      );
+      final redactedText = buildPlainText(entry, redact: true);
+      final clearText = buildPlainText(entry, redact: false);
+      expect(redactedText.contains('Error Type: connectionError'), isTrue);
+      expect(redactedText.contains('=== Stack Trace ==='), isTrue);
+      expect(redactedText.contains('#0 foo'), isTrue);
+      expect(redactedText, equals(clearText));
     });
   });
 


### PR DESCRIPTION
### Summary
[#61](https://github.com/Yomiamy/flutter_inspector_kit/issues/61) Dio 結構化錯誤捕捉（Structured Network Error）

**[修正問題]**

原先 `FlutterInspectorDioInterceptor` 在 `onError` 攔截到請求失敗時，會將錯誤壓縮成單一字串 `error: err.toString()`，因而丟棄了錯誤的機器可讀分類 `err.type`（`DioExceptionType`）與呼叫堆疊 `err.stackTrace`。這導致開發者無法在 UI 上一眼區分「請求是因為斷網等傳輸層失敗（未抵達伺服器）」還是「伺服器回傳了錯誤狀態碼（語意失敗）」，也無法複製詳細的 stack trace 進行除錯。

**[修正方式]**

1. **擴充資料模型 (`NetworkEntry`)**：
   - 新增 `errorType` (`DioExceptionType?`) 與 `errorStackTrace` (`String?`) 兩個可選屬性（預設為 `null`，確保向後相容）。
   - 更新 `copyWith`、`operator ==` 與 `hashCode` 以納入這兩個屬性，並在 `network_entry_test.dart` 中建立對應的值相等性測試。
2. **攔截器錯誤擷取 (`FlutterInspectorDioInterceptor`)**：
   - 在 `onError` 處建構 `NetworkEntry` 時，保留 `err.type` 與 `err.stackTrace.toString()`，不再丟棄。
   - 在 `dio_interceptor_test.dart` 中新增測試，分別驗證傳輸層失敗（`response == null`）與伺服器回應錯誤（`response != null`）兩條路徑的欄位寫入正確性。
3. **格式化輸出優化 (`network_formatters.dart`)**：
   - 修改 `buildPlainText` 匯出格式，在 `=== Error ===` 區段中印出 `Error Type`，且在有 stack trace 時輸出獨立的 `=== Stack Trace ===` 段落，並在 `network_formatters_test.dart` 中進行覆蓋測試。
4. **UI 層區分呈現 (`network_detail_view.dart`)**：
   - 以新的 `_exceptionDetailsSection` 取代舊有的簡單 `_errorSection`。
   - 根據 `statusCode` 是否為 `null`，在 Exception Details 中將 Kind 標示為「傳輸層失敗 (transport failure)」或「Server 錯誤回應 (server responded with error)」。
   - 將 stack trace 渲染於一塊等寬字型（monospace）的軟體包裝容器中，使用 `SelectableText` 支援開發者直接複製。
   - 在 `network_detail_view_test.dart` 中實作 Widget 測試，確認在各種錯誤路徑下 UI 區段與資訊皆正確呈現，且成功請求時不誤顯示此區段。
