### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.0
+
+### Added
+* **Structured DioException error capture**: `FlutterInspectorDioInterceptor.onError` now preserves the machine-readable `errorType` (`DioExceptionType`) and the `errorStackTrace` (stringified stack trace) instead of discarding them.
+* **Exception Details section**: the Network detail view now displays an "Exception Details" card section for failed requests. It clearly distinguishes between transport-layer failures (where the request did not reach the server, showing `statusCode == null`) and server-side responses (where the server returned an error status code). It also provides a monospace-styled, copyable stack trace for debugging.
+* **Text export support**: `buildPlainText` exports now include the `Error Type` and the `Stack Trace` when present, improving the diagnostic value of shared logs.
+
 ## 1.2.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.2.1
+  flutter_inspector_kit: ^1.3.0
 ```
 
 Then run `flutter pub get`.
@@ -138,7 +138,7 @@ inspector.logNetwork(completedEntry, replaces: pending);
 ### Inside the Network tab
 
 - **Search & filter**: filter the call list by URL, method, or status code (case-insensitive); method and status (`2xx`/`3xx`/`4xx`/`5xx`/`Failed`) chips narrow it further.
-- **Call details**: tap any call for a structured view — General (method, URL, status with color coding, duration, request/response sizes), Query Parameters, Headers, and JSON-pretty bodies. Truncated bodies are clearly marked.
+- **Call details**: tap any call for a structured view — General (method, URL, status with color coding, duration, request/response sizes), Query Parameters, Headers, and JSON-pretty bodies. Truncated bodies are clearly marked. Failed requests display an **Exception Details** section distinguishing between transport-layer failures and server-side errors, with a copyable stack trace.
 - **Sharing**: copy the call as a runnable `cURL` command, copy the full details as text, or open the system share sheet (native via `share_plus`, web via the browser Web Share API — falls back to the clipboard when unavailable).
 - **Replay / Resend**: for requests captured with a `sourceDio` provided to the interceptor, you can trigger a "Resend" action in the detail view to replay the request locally using the same Dio client (carrying the same headers, base URL, and interceptors). Replayed requests automatically show up as new entries with a dedicated "Replay" label.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 1.2.1
+version: 1.3.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary
[#63](https://github.com/Yomiamy/flutter_inspector_kit/issues/63) Release: Version 1.3.0

**[修正問題]**
發布新版 `1.3.0`，整合最近合併入 `main` 的 Dio 結構化錯誤捕捉（Structured Network Error）等變更，並同步更新 `pubspec.yaml`、說明文檔與變更日誌。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號為 `1.3.0`。
2. **`README.md`**：更新安裝版號為 `^1.3.0`，並同步更新說明文檔，在 Network 詳細視圖說明中補充新引入的 Exception Details 錯誤展示與 stack trace 複製功能。
3. **`CHANGELOG.md`**：新增 `1.3.0` 的版本日誌，分類記錄各項 Added 異動（包括結構化錯誤擷取、Exception Details 區段以及 plain-text 匯出支援）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 网络请求详情新增错误信息区块，可区分传输失败与服务端错误。
  * 失败请求支持查看并复制堆栈信息。
  * 导出的纯文本内容在出错时会包含错误类型和堆栈信息。

* **文档**
  * 更新了版本说明与使用文档，反映最新的错误展示与导出内容。
  * 版本号已更新至 1.3.0。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->