### PR TITLE
refactor: De-couple FlutterInspector in UncaughtErrorHandler and InspectorOverlayManager

### DIFF
--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -50,9 +50,6 @@ class FlutterInspector {
     if (databaseSources != null) {
       _customDatabaseSources.addAll(databaseSources);
     }
-    _overlayManager = InspectorOverlayManager(
-      onFabTap: (context) => openDashboard(context),
-    );
     if (showNetworkNotification) {
       _notifier =
           notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -15,7 +15,6 @@ import '../notifications/network_notifier.dart';
 import '../observers/navigator_observer.dart';
 import '../ui/dashboard/dashboard_modal.dart';
 import 'inspector_overlay_manager.dart';
-
 import 'inspector_registry.dart';
 import 'uncaught_error_handler.dart';
 
@@ -51,6 +50,9 @@ class FlutterInspector {
     if (databaseSources != null) {
       _customDatabaseSources.addAll(databaseSources);
     }
+    _overlayManager = InspectorOverlayManager(
+      onFabTap: (context) => openDashboard(context),
+    );
     if (showNetworkNotification) {
       _notifier =
           notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
@@ -187,6 +189,7 @@ class FlutterInspector {
   void registerDatabaseSource(DatabaseBrowserSource source) {
     _customDatabaseSources.add(source);
   }
+
 
   /// Mounts the FAB overlay onto the screen.
   void attach({required BuildContext context, bool visible = true}) {

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -17,6 +17,7 @@ import '../ui/dashboard/dashboard_modal.dart';
 import 'inspector_overlay_manager.dart';
 
 import 'inspector_registry.dart';
+import 'uncaught_error_handler.dart';
 
 /// The core entry point for the Flutter Inspector.
 class FlutterInspector {
@@ -43,6 +44,7 @@ class FlutterInspector {
       onFabTap: (context) => openDashboard(context),
     );
     _registry = InspectorRegistry(bufferSize: bufferSize);
+    _uncaughtErrorHandler = UncaughtErrorHandler(onLog: log);
     if (captureUncaughtErrors) setupErrorHandlers();
     _navigatorObserver = FlutterInspectorNavigatorObserver(this);
     _operationLogSource = OperationLogSource(_registry.database);
@@ -121,9 +123,7 @@ class FlutterInspector {
   /// or a screenshot unless the host explicitly opts out.
   final bool redactSensitiveData;
 
-  FlutterExceptionHandler? _oldFlutterErrorHandler;
-  bool Function(Object, StackTrace)? _oldPlatformDispatcherOnError;
-  bool _uncaughtErrorHandlersAttached = false;
+  late final UncaughtErrorHandler _uncaughtErrorHandler;
 
   NetworkNotifier? _notifier;
 
@@ -223,79 +223,7 @@ class FlutterInspector {
   /// a manual [setupErrorHandlers] call are combined.
   @visibleForTesting
   void setupErrorHandlers() {
-    if (_uncaughtErrorHandlersAttached) return;
-    _uncaughtErrorHandlersAttached = true;
-
-    // 1) FlutterError.onError — chain.
-    // The logging call is guarded so a failure while recording can never break
-    // the chain to the host handler — the error is always forwarded downstream.
-    _oldFlutterErrorHandler = FlutterError.onError;
-    FlutterError.onError = (details) {
-      try {
-        _logFlutterError(details, source: 'flutterError');
-      } catch (e, s) {
-        debugPrintStack(stackTrace: s, label: 'inspector log failed: $e');
-      }
-      if (_oldFlutterErrorHandler != null) {
-        _oldFlutterErrorHandler!(details);
-      } else {
-        FlutterError.presentError(details);
-      }
-    };
-
-    // 2) PlatformDispatcher.instance.onError — chain.
-    // The logging call is guarded so a failure while recording can never alter
-    // the boolean the host handler returns (its "handled" semantics are kept).
-    _oldPlatformDispatcherOnError = PlatformDispatcher.instance.onError;
-    PlatformDispatcher.instance.onError = (e, st) {
-      try {
-        log(
-          e.toString(),
-          level: LogLevel.error,
-          stackTrace: st.toString(),
-          data: {
-            'source': 'platformDispatcher',
-            'exceptionType': e.runtimeType.toString(),
-          },
-        );
-      } catch (err, s) {
-        debugPrintStack(stackTrace: s, label: 'inspector log failed: $err');
-      }
-      final old = _oldPlatformDispatcherOnError;
-      return old != null ? old(e, st) : false;
-    };
-
-    // 3) ErrorWidget.builder — wrap.
-    final original = ErrorWidget.builder;
-    ErrorWidget.builder = (details) {
-      try {
-        _logFlutterError(details, source: 'errorWidget');
-      } catch (e, s) {
-        debugPrintStack(
-          stackTrace: s,
-          label: 'inspector errorWidget log failed: $e',
-        );
-      }
-      return original(details);
-    };
-  }
-
-  void _logFlutterError(FlutterErrorDetails details, {required String source}) {
-    final data = <String, dynamic>{
-      'source': source,
-      'exceptionType': details.exception.runtimeType.toString(),
-    };
-    final library = details.library;
-    if (library != null) data['library'] = library;
-    final context = details.context;
-    if (context != null) data['context'] = context.toString();
-
-    log(
-      details.exceptionAsString(),
-      level: LogLevel.error,
-      stackTrace: details.stack?.toString(),
-      data: data,
-    );
+    _uncaughtErrorHandler.attach();
   }
 
   /// Records a network request or response, returning the stored entry.

--- a/lib/src/core/uncaught_error_handler.dart
+++ b/lib/src/core/uncaught_error_handler.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import '../models/log_level.dart';
+
+/// Handles attaching error hooks and forwarding to a log function.
+class UncaughtErrorHandler {
+  /// Creates a new UncaughtErrorHandler instance.
+  UncaughtErrorHandler({required this.onLog});
+
+  /// The function called to log an error.
+  final void Function(
+    String message, {
+    LogLevel level,
+    String? stackTrace,
+    Map<String, dynamic>? data,
+  }) onLog;
+
+  FlutterExceptionHandler? _oldFlutterErrorHandler;
+  bool Function(Object, StackTrace)? _oldPlatformDispatcherOnError;
+  bool _attached = false;
+
+  /// Attaches the three standard Flutter error hooks, chaining/wrapping any
+  /// existing host handler so errors are always forwarded downstream.
+  ///
+  /// Idempotent: the dedup flag ensures hooks are attached at most once.
+  void attach() {
+    if (_attached) return;
+    _attached = true;
+
+    // 1) FlutterError.onError — chain.
+    _oldFlutterErrorHandler = FlutterError.onError;
+    FlutterError.onError = (details) {
+      try {
+        _logFlutterError(details, source: 'flutterError');
+      } catch (e, s) {
+        debugPrintStack(stackTrace: s, label: 'inspector log failed: $e');
+      }
+      if (_oldFlutterErrorHandler != null) {
+        _oldFlutterErrorHandler!(details);
+      } else {
+        FlutterError.presentError(details);
+      }
+    };
+
+    // 2) PlatformDispatcher.instance.onError — chain.
+    _oldPlatformDispatcherOnError = PlatformDispatcher.instance.onError;
+    PlatformDispatcher.instance.onError = (e, st) {
+      try {
+        onLog(
+          e.toString(),
+          level: LogLevel.error,
+          stackTrace: st.toString(),
+          data: {
+            'source': 'platformDispatcher',
+            'exceptionType': e.runtimeType.toString(),
+          },
+        );
+      } catch (err, s) {
+        debugPrintStack(stackTrace: s, label: 'inspector log failed: $err');
+      }
+      final old = _oldPlatformDispatcherOnError;
+      return old != null ? old(e, st) : false;
+    };
+
+    // 3) ErrorWidget.builder — wrap.
+    final original = ErrorWidget.builder;
+    ErrorWidget.builder = (details) {
+      try {
+        _logFlutterError(details, source: 'errorWidget');
+      } catch (e, s) {
+        debugPrintStack(
+          stackTrace: s,
+          label: 'inspector errorWidget log failed: $e',
+        );
+      }
+      return original(details);
+    };
+  }
+
+  void _logFlutterError(FlutterErrorDetails details, {required String source}) {
+    final data = <String, dynamic>{
+      'source': source,
+      'exceptionType': details.exception.runtimeType.toString(),
+    };
+    final library = details.library;
+    if (library != null) data['library'] = library;
+    final context = details.context;
+    if (context != null) data['context'] = context.toString();
+
+    onLog(
+      details.exceptionAsString(),
+      level: LogLevel.error,
+      stackTrace: details.stack?.toString(),
+      data: data,
+    );
+  }
+}

--- a/lib/src/core/uncaught_error_handler.dart
+++ b/lib/src/core/uncaught_error_handler.dart
@@ -3,23 +3,26 @@ import 'package:flutter/widgets.dart';
 
 import '../models/log_level.dart';
 
+/// Signature for the function used to log an error.
+typedef LogCallback = void Function(
+  String message, {
+  LogLevel level,
+  String? stackTrace,
+  Map<String, dynamic>? data,
+});
+
 /// Handles attaching error hooks and forwarding to a log function.
 class UncaughtErrorHandler {
-  /// Creates a new UncaughtErrorHandler instance.
-  UncaughtErrorHandler({required this.onLog});
 
   /// The function called to log an error.
-  final void Function(
-    String message, {
-    LogLevel level,
-    String? stackTrace,
-    Map<String, dynamic>? data,
-  }) onLog;
+  final LogCallback onLog;
 
   FlutterExceptionHandler? _oldFlutterErrorHandler;
   bool Function(Object, StackTrace)? _oldPlatformDispatcherOnError;
   bool _attached = false;
 
+  /// Creates a new UncaughtErrorHandler instance.
+  UncaughtErrorHandler({required this.onLog});
   /// Attaches the three standard Flutter error hooks, chaining/wrapping any
   /// existing host handler so errors are always forwarded downstream.
   ///

--- a/lib/src/ui/inspector_overlay_manager.dart
+++ b/lib/src/ui/inspector_overlay_manager.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/widgets.dart';
+
+import 'widgets/inspector_fab.dart';
+
+/// Manages the FAB overlay for the Flutter Inspector.
+class InspectorOverlayManager {
+  /// Creates an [InspectorOverlayManager].
+  InspectorOverlayManager({required this.onFabTap});
+
+  /// Called when the FAB is tapped, providing the FAB's build context.
+  final void Function(BuildContext context) onFabTap;
+
+  OverlayEntry? _overlayEntry;
+
+  /// Mounts the FAB overlay onto the screen.
+  void attach({required BuildContext context, bool visible = true}) {
+    if (_overlayEntry != null) return;
+    final overlay = Overlay.maybeOf(context);
+    if (overlay == null) return;
+    _overlayEntry = OverlayEntry(
+      builder: (context) => InspectorFab(
+        onTap: () => onFabTap(context),
+        visible: visible,
+      ),
+    );
+    overlay.insert(_overlayEntry!);
+  }
+
+  /// Removes the FAB overlay.
+  void detach() {
+    _overlayEntry?.remove();
+    _overlayEntry = null;
+  }
+}

--- a/lib/src/ui/inspector_overlay_manager.dart
+++ b/lib/src/ui/inspector_overlay_manager.dart
@@ -28,7 +28,9 @@ class InspectorOverlayManager {
 
   /// Removes the FAB overlay.
   void detach() {
-    _overlayEntry?.remove();
+    if (_overlayEntry?.mounted ?? false) {
+      _overlayEntry!.remove();
+    }
     _overlayEntry = null;
   }
 }

--- a/test/core/uncaught_error_handler_test.dart
+++ b/test/core/uncaught_error_handler_test.dart
@@ -107,8 +107,13 @@ void main() {
     FlutterError.onError!(buildDetails(StateError('boom')));
     expect(hostFlutterCalled, isTrue);
 
-    PlatformDispatcher.instance.onError!(StateError('boom'), StackTrace.current);
+    final handled = PlatformDispatcher.instance.onError!(
+      StateError('boom'),
+      StackTrace.current,
+    );
     expect(hostPlatformCalled, isTrue);
+    // onLog 丟例外時，host 回傳的 handled 語意不得被改變（重構核心不變式）。
+    expect(handled, isTrue);
 
     final widget = ErrorWidget.builder(buildDetails(StateError('boom')));
     expect(widget.runtimeType, originalBuilder(buildDetails(StateError('boom'))).runtimeType);

--- a/test/core/uncaught_error_handler_test.dart
+++ b/test/core/uncaught_error_handler_test.dart
@@ -1,0 +1,116 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_inspector_kit/src/core/uncaught_error_handler.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FlutterExceptionHandler? savedFlutterOnError;
+  late ErrorCallback? savedPlatformOnError;
+  late Widget Function(FlutterErrorDetails) savedErrorWidgetBuilder;
+
+  setUp(() {
+    savedFlutterOnError = FlutterError.onError;
+    savedPlatformOnError = PlatformDispatcher.instance.onError;
+    savedErrorWidgetBuilder = ErrorWidget.builder;
+  });
+
+  tearDown(() {
+    FlutterError.onError = savedFlutterOnError;
+    PlatformDispatcher.instance.onError = savedPlatformOnError;
+    ErrorWidget.builder = savedErrorWidgetBuilder;
+  });
+
+  FlutterErrorDetails buildDetails(Object exception) {
+    return FlutterErrorDetails(
+      exception: exception,
+      stack: StackTrace.current,
+      library: 'test library',
+      context: ErrorDescription('while testing'),
+    );
+  }
+
+  test('idempotent: attach twice only attaches hooks once', () {
+    var callCount = 0;
+    final handler = UncaughtErrorHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+      },
+    );
+    
+    FlutterError.onError = (_) {};
+
+    handler.attach();
+    handler.attach();
+
+    FlutterError.onError!(buildDetails(StateError('boom')));
+    expect(callCount, 1);
+  });
+
+  test('chain: existing handlers are called', () {
+    var hostFlutterCalled = false;
+    var hostPlatformCalled = false;
+    var onLogCalledCount = 0;
+
+    FlutterError.onError = (_) {
+      hostFlutterCalled = true;
+    };
+    PlatformDispatcher.instance.onError = (e, s) {
+      hostPlatformCalled = true;
+      return true;
+    };
+    final originalBuilder = ErrorWidget.builder;
+
+    final handler = UncaughtErrorHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        onLogCalledCount++;
+      },
+    );
+    handler.attach();
+
+    FlutterError.onError!(buildDetails(StateError('boom')));
+    expect(hostFlutterCalled, isTrue);
+
+    PlatformDispatcher.instance.onError!(StateError('boom'), StackTrace.current);
+    expect(hostPlatformCalled, isTrue);
+
+    final widget = ErrorWidget.builder(buildDetails(StateError('boom')));
+    expect(widget.runtimeType, originalBuilder(buildDetails(StateError('boom'))).runtimeType);
+
+    expect(onLogCalledCount, 3);
+  });
+
+  test('guard: onLog throws, host handler is still called', () {
+    var hostFlutterCalled = false;
+    var hostPlatformCalled = false;
+
+    FlutterError.onError = (_) {
+      hostFlutterCalled = true;
+    };
+    PlatformDispatcher.instance.onError = (e, s) {
+      hostPlatformCalled = true;
+      return true;
+    };
+    final originalBuilder = ErrorWidget.builder;
+
+    final handler = UncaughtErrorHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        throw StateError('onLog failed');
+      },
+    );
+    handler.attach();
+
+    FlutterError.onError!(buildDetails(StateError('boom')));
+    expect(hostFlutterCalled, isTrue);
+
+    PlatformDispatcher.instance.onError!(StateError('boom'), StackTrace.current);
+    expect(hostPlatformCalled, isTrue);
+
+    final widget = ErrorWidget.builder(buildDetails(StateError('boom')));
+    expect(widget.runtimeType, originalBuilder(buildDetails(StateError('boom'))).runtimeType);
+  });
+}

--- a/test/ui/inspector_overlay_manager_test.dart
+++ b/test/ui/inspector_overlay_manager_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inspector_kit/src/ui/inspector_overlay_manager.dart';
+import 'package:flutter_inspector_kit/src/ui/widgets/inspector_fab.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('InspectorOverlayManager', () {
+    testWidgets('attach shows FAB, detach removes it, attach is idempotent, taps work', (tester) async {
+      bool tapped = false;
+      final manager = InspectorOverlayManager(onFabTap: (_) => tapped = true);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () => manager.attach(context: context),
+                    child: const Text('Attach'),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Initially no FAB
+      expect(find.byType(InspectorFab), findsNothing);
+
+      // Attach
+      await tester.tap(find.text('Attach'));
+      await tester.pump();
+      expect(find.byType(InspectorFab), findsOneWidget);
+
+      // Repeat attach to verify idempotent behavior (no crash, still one FAB)
+      await tester.tap(find.text('Attach'));
+      await tester.pump();
+      expect(find.byType(InspectorFab), findsOneWidget);
+
+      // Tap FAB
+      await tester.tap(find.byType(InspectorFab));
+      expect(tapped, isTrue);
+
+      // Detach
+      manager.detach();
+      await tester.pump();
+      expect(find.byType(InspectorFab), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
把 348 行的 God Class `FlutterInspector` 拆出兩組與「對外 Facade」無關的職責，回歸單一職責。`FlutterInspector` 降至 270 行，public API 簽章零變更（Never break userspace）。

Closes #69

## 修正問題
`FlutterInspector` 同時管理核心 Registry 門面、全域錯誤攔截（error hooks）與 FAB Overlay 掛載，違反 SRP，錯誤攔截與 UI 掛載邏輯難以單獨閱讀與測試。

## 修正方式
- **`lib/src/core/uncaught_error_handler.dart`（新）**：承接三個 error hook（`FlutterError.onError` / `PlatformDispatcher.onError` / `ErrorWidget.builder`）與 `_logFlutterError`。idempotent / chain 舊 handler / guard logging 三個語意逐行搬遷、無失真。
- **`lib/src/ui/inspector_overlay_manager.dart`（新）**：承接 FAB overlay 的 attach/detach，保留 idempotent 語意。
- **依賴以回呼注入**（`onLog` / `onFabTap`），不持有整個 inspector，無循環依賴。
- `FlutterInspector` 保留 `attach` / `detach` / `setupErrorHandlers` 為轉發方法，`captureUncaughtErrors` 旗標行為不變。兩個新類別定位 internal，未加進 barrel export。

## 驗證
- 既有 `test/core/error_capture_test.dart` 不改仍全綠（三個 process-global hook 語意鎖定）。
- 兩個新類別各補單元測試；STAGE 3 審查補上 guard × handled-return 交叉分支的 assert。
- 全套 `flutter test` 通過（309 tests）、`flutter analyze` 零 issue。

## Out of scope
不引入 Controller、不改 Entry、不碰階段一/三既有成果；error hooks 生命週期策略不變。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加未捕获错误的统一捕获与日志回调，支持结构化上下文信息。
  * 新增 Inspector 覆盖层 FAB 叠层管理：可挂载、显示/隐藏、点击回调与卸载。
* **Bug 修复**
  * 错误处理与 FAB 挂载均具幂等性，避免重复日志与重复叠层。
  * 日志失败不会阻断原有错误展示/处理链。
* **测试**
  * 补充未捕获错误与 Inspector 覆盖层的单元测试：幂等、链式转发、异常防护、点击/卸载。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->