### PR TITLE
feat: one-tap diagnostic report export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Added
+* **One-tap diagnostic report**: the dashboard app bar now has an export action that builds a single Markdown report — device/app header, current route stack, and the log / network / navigation / database sections — and hands it to the system share sheet. Three independent filters: time window (last 5m / last 1h / all), which sources to include, and an optional "errors & warnings only" toggle for the log section (off by default). Nothing is written to disk.
+* **`DiagnosticInfoSource`**: optional injection point for device and app metadata (`FlutterInspector(diagnosticInfoSource: ...)`). This package stays free of any device-info plugin — hosts supply the values themselves, and the report header degrades to `N/A` when no source is registered. Follows the same host-injection shape as `DatabaseBrowserSource`.
+
+### Fixed
+* **`FlutterInspector.version` was stale**: it had reported `1.1.0` since three releases ago. The constant is now derived from a single source of truth, guarded by a test that reads `pubspec.yaml` and fails on drift — the previous test compared a hardcoded string against a hardcoded constant, so it could never catch this.
+
 ## 1.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 | 🔄 **Network Replay** | Resend a captured request using the original Dio instance (same headers, base URL, interceptors); replayed entries are auto-labeled | Re-trigger a failed API call on-device to verify a server-side hotfix without restarting the app or rebuilding the user flow |
 | 🚨 **Structured Network Errors** | Failed requests show an **Exception Details** section distinguishing transport-layer failures (device offline / DNS / timeout) from server-side errors (4xx/5xx), with copyable stack traces | Instantly tell whether "Failed" means the device lost connectivity or the server returned 500 — no more guessing during QA |
 | 📊 **Error Aggregation Summary** | Network tab shows a collapsible banner that groups failed/errored requests by status code (or error type for transport failures), with per-group counts and time range; tap a group to filter the call list down to just that error | A page is flooded with dozens of failed calls — glance at the summary banner to see "12× 401", "3× timeout", tap the 401 group to isolate exactly those calls instead of scrolling through the full list |
+| 🩺 **Diagnostic Report** | Export a single Markdown report — device/app header, current route stack, and the logs / network / navigation / database sections — filtered by time window (5m / 1h / all), source, and an optional errors-only toggle; straight to the share sheet, nothing written to disk | QA reproduces a bug and, instead of screenshotting four tabs and hand-typing the OS version, taps Export once and pastes a complete report into the Jira ticket |
 | 🛡️ **Sensitive-Data Redaction** | Secure by default — sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`) are masked in every share/export path | Safely share network logs with teammates or attach them to Jira tickets without leaking tokens or session cookies |
 | 🧭 **Navigator** | Track route pushes, pops, and replacements automatically; toggle between **Event History** (raw log) and **Active Stack** (live route-stack visualization) | Verify deep-link routing, confirm back-stack correctness, or diagnose "why did the user land on this screen?" during a QA walkthrough |
 | 🗄️ **Database** | Record insert / update / delete / query operations with affected-row counts and payloads; browse real tables via pluggable `DatabaseBrowserSource` (SQLite / ObjectBox adapters provided) | Verify that a "Save" action actually wrote the expected rows; browse local SQLite tables on-device without pulling the `.db` file |
@@ -505,6 +506,68 @@ final inspector = FlutterInspector(
 
 // Or dynamically
 inspector.registerDatabaseSource(SqfliteBrowserSource(db));
+```
+
+### Export a diagnostic report
+
+Open the dashboard and tap the **share icon** in the app bar. Pick which sources to
+include, a time window (last 5m / last 1h / all), and optionally "errors & warnings
+only", then hit **Share report** — a Markdown report goes straight to the system
+share sheet. Nothing is written to disk.
+
+The report inherits your `redactSensitiveData` setting, and its header states
+`Redaction: enabled` / `disabled` so whoever receives it knows what was masked.
+
+#### Populating the device / app header (optional)
+
+This package depends on **no** device-info plugin (and never touches `dart:io`, so it
+stays WASM-compatible). Without a source, the header degrades to `N/A` and the report
+is still produced in full.
+
+To fill it in, add `package_info_plus` and `device_info_plus` **to your own app**, then
+implement `DiagnosticInfoSource`:
+
+```dart
+import 'dart:io' show Platform;
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class AppDiagnosticInfoSource implements DiagnosticInfoSource {
+  @override
+  Future<DiagnosticInfo> collect() async {
+    final pkg = await PackageInfo.fromPlatform();
+    final deviceInfo = DeviceInfoPlugin();
+
+    String? deviceModel;
+    String? osVersion;
+
+    if (Platform.isIOS) {
+      final ios = await deviceInfo.iosInfo;
+      deviceModel = ios.utsname.machine;
+      osVersion = 'iOS ${ios.systemVersion}';
+    } else if (Platform.isAndroid) {
+      final android = await deviceInfo.androidInfo;
+      deviceModel = '${android.manufacturer} ${android.model}';
+      osVersion = 'Android ${android.version.release}';
+    }
+
+    return DiagnosticInfo(
+      appVersion: '${pkg.version}+${pkg.buildNumber}',
+      deviceModel: deviceModel,
+      osVersion: osVersion,
+    );
+  }
+}
+```
+
+Then pass it in:
+
+```dart
+final inspector = FlutterInspector(
+  diagnosticInfoSource: AppDiagnosticInfoSource(),
+);
 ```
 
 ## 🕹️ Example

--- a/README.md
+++ b/README.md
@@ -534,6 +534,8 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+// Note: This example is mobile-only due to its dart:io Platform usage.
+// It will not compile on Web/WASM.
 class AppDiagnosticInfoSource implements DiagnosticInfoSource {
   @override
   Future<DiagnosticInfo> collect() async {

--- a/docs/features/2026-07-15-diagnostic-report.md
+++ b/docs/features/2026-07-15-diagnostic-report.md
@@ -119,7 +119,7 @@ Dashboard AppBar 新增一個 **Export** action → 開啟選單（勾選區段 
 
 ### P-1：修正 `FlutterInspector.version` 的單一真相來源 🔴
 
-```
+```text
 lib/src/core/flutter_inspector.dart:24   →   static const String version = '1.1.0';
 pubspec.yaml:3                           →   version: 1.4.0
 ```

--- a/docs/features/2026-07-15-diagnostic-report.md
+++ b/docs/features/2026-07-15-diagnostic-report.md
@@ -1,0 +1,324 @@
+# 功能規格：一鍵診斷報告（Diagnostic Report）
+
+> **來源**：[brainstorm #3](../brainstorm/2026-07-12-features-brainstorm.md) §3「一鍵診斷報告（Diagnostic Report）」
+> **日期**：2026-07-15
+> **狀態**：Approved — 開放問題已於暫停點全數裁決（見「已定案設計取捨」D-1 ~ D-4）
+> **版本基準**：v1.4.0（branch `main`）
+
+---
+
+## 問題
+
+QA 重現 bug 後要帶走證據，今天的流程是：
+
+1. 開 dashboard → 切 Console tab → 找到那筆 error log → 點開 `LogDetailView` → 按分享
+2. 切 Network tab → 找到那筆失敗請求 → 點開 `NetworkDetailView` → 按分享
+3. 切 Navigator tab → 看當前堆疊 → **沒有分享按鈕，只能截圖**
+4. 切 Database tab → **沒有分享按鈕，只能截圖**
+5. 手打 device / OS / app 版本資訊到 issue 裡
+
+**codebase 證據（缺口就在這裡）**：
+
+| 現況 | 位置 | 缺口 |
+|------|------|------|
+| 單筆 network 匯出已完備 | `network_formatters.dart:106` `buildPlainText(entry, {redact})` | **只吃一個 `NetworkEntry`**，沒有任何「多筆打包」的呼叫者 |
+| 單筆 log 匯出已完備 | `log_formatters.dart:8` `buildLogPlainText(entry)` | 同上，`entry` 是單數 |
+| 跨層時序軸已完備 | `inspector_registry.dart:38` `mergedTimeline({sources})` | 已按 `TimestampedEntry.timestamp` 降序合併四個 buffer——**唯一的消費者是 `ConsoleTab` 的畫面渲染，沒有任何序列化出口** |
+| 當前路由堆疊已完備 | `navigator_stack_resolver.dart:21` `NavigatorStackResolver().resolve(entries)` | 純 Dart、可直接取用——**唯一的消費者是 `NavigatorTab` 的畫面渲染** |
+| Log 等級過濾已完備 | `log_inspector.dart:21` `entriesAtLevel(LogLevel)` | **寫好了，但整個 codebase 從未呼叫過**（brainstorm #5 已點名此事） |
+| 平台自適應分享已完備 | `share_text.dart` → `shareText(String)` | 只有 `NetworkDetailView`、`LogDetailView` 兩個單筆呼叫點 |
+| Dashboard AppBar | `dashboard_modal.dart:47` | **`actions:` 是空的**——title + leading(close) + bottom(TabBar)，沒有任何 dashboard 級別的全域動作 |
+| Navigator / Database tab | `navigator_tab.dart`、`database_tab.dart` | **零匯出能力** |
+
+**核心矛盾**：序列化零件（`buildPlainText` / `buildLogPlainText`）、資料聚合零件（`mergedTimeline`）、過濾零件（`entriesAtLevel`）、輸出零件（`shareText`）**全部就緒**——其中三個已在生產路徑上驗證過，一個（`entriesAtLevel`）寫好了卻沒人用。缺的只是把它們串起來的那條線，以及 dashboard 上那顆按鈕。這不是新功能開發，是把既有零件接上。
+
+---
+
+## 解決方案（一句話）
+
+Dashboard AppBar 新增一個 **Export** action → 開啟選單（勾選區段 + 時間範圍 + errors-only）→ 產生一份 **Markdown 報告**（app/device 表頭 + 當前路由堆疊 + 選定條件下的 log / network / nav / db 各區段）→ 直接送進系統分享，**不落盤**。
+
+---
+
+## 使用者故事
+
+### US-1：QA 一鍵帶走證據
+> 身為 QA，
+> 我在 app 裡重現了 bug 之後，
+> 我希望打開 dashboard 按一個按鈕，就得到一份可直接貼進 Jira / GitHub issue 的報告，
+> 好讓我不必切四個 tab、逐筆截圖，也不必手打 device 資訊。
+
+### US-2：只帶走相關的部分
+> 身為 QA，
+> 當我知道 bug 只跟網路有關、且發生在最近 5 分鐘內時，
+> 我希望能勾選「只要 Network」+「最近 5 分鐘」，
+> 好讓報告不被 500 筆無關的 log 稀釋，收報告的工程師一眼看到重點。
+
+### US-3：開發者拿到報告能還原現場
+> 身為接到 issue 的 Flutter 開發者，
+> 我打開 QA 貼上來的報告，
+> 我希望看到「當時的路由堆疊」「失敗請求的 status / errorType / stack trace」「錯誤前後發生的事件」，
+> 好讓我不用回頭問 QA「你當時在哪個畫面」。
+
+### US-4：報告不能洩漏 secret
+> 身為導入這個套件的開發者，
+> 當我的 QA 把診斷報告貼到公司的 issue tracker（甚至外部群組）時，
+> 我希望 `Authorization` / `Cookie` 這類敏感 header 已經被遮蔽，遮蔽行為跟我設定的 `redactSensitiveData` 完全一致，
+> 好讓「一鍵匯出」不會變成「一鍵洩密」。
+
+### US-5：沒注入 device info 也不能崩
+> 身為導入這個套件的開發者，
+> 當我沒有提供任何 device / app 版本資訊時，
+> 我希望報告的表頭優雅地顯示 `N/A`，
+> 好讓這個功能不會強迫我為了一個 debug 工具去背新的原生相依。
+
+### US-6：只帶走錯誤，不帶走噪音
+> 身為 QA，
+> 當我知道問題就是那幾筆 error 時，
+> 我希望能勾選「只包含 error / warning」，
+> 好讓報告不被幾百筆 info log 淹沒——但這個選項**預設關閉**，因為多數時候「錯誤發生前做了什麼」才是關鍵線索。
+
+---
+
+## 功能範圍
+
+### In scope
+
+- **報告產生器**：純函式，吃 entries + 選項，吐 Markdown 字串。零 Flutter 相依、可獨立 unit test（沿用 `network_formatters.dart` / `log_formatters.dart` 的 "pure formatting helpers" 慣例）。
+- **報告內容**：
+  - **表頭**：產生時間、**套件版本（單一真相來源，見前置項 P-1）**、`Redaction: enabled/disabled`、app / device 資訊（host 注入；缺值一律 `N/A`）
+  - **當前路由堆疊**：直接複用 `NavigatorStackResolver().resolve(navigatorEntries)`（top-first）
+  - **各區段**：使用者選定的 source（log / network / nav / db），每段列出符合條件的 entries
+- **三個過濾維度**（互相獨立、可組合）：
+  1. **時間窗**：last 5m / last 1h / all
+  2. **區段選擇**：四個 source 可獨立勾選
+  3. **errors-only**：只包含 `LogLevel.error` / `LogLevel.warning` 的 log（**預設關閉**）——只影響 **log 區段**，不影響 network / nav / db
+- **Device / app info 注入介面**：抽象介面 + host 註冊實作，package 對 `device_info_plus` / `package_info_plus` **零相依**（沿用 `DatabaseBrowserSource` 先例）
+- **UI 入口**：`DashboardModal` 的 AppBar `actions:` 新增一顆 export icon → 開啟選項 sheet/dialog → 確認後 `shareText(report)`
+- **Redaction 繼承**：報告的 network 區段必須透過 `buildPlainText(entry, redact: inspector.redactSensitiveData)` 產生，**不得**繞過既有 redaction 路徑
+- **空狀態**：選定條件下無資料時，該區段顯示 `(none)`，不產生空白區塊或崩潰
+
+### Out of scope（明確排除）
+
+| 排除項 | 理由 |
+|--------|------|
+| **落盤 / 持久化 / 報告歷史** | brainstorm anti-feature #2 已明確拒絕。報告是「當下產生、立刻帶走」，只走 `shareText` 的純文字路徑，不寫檔案 |
+| **JSON 格式輸出** | **使用者裁決（D-3）**：只做 Markdown。目前沒有任何 JSON 消費者——HAR 已被 anti-feature #3 砍掉、持久化已被 anti-feature #2 砍掉。唯一使用者是「QA 貼進 Jira / GitHub issue」，那是 Markdown 的主場。JSON 是投機性需求，等真有消費者再加（屆時非破壞性變更） |
+| **擴大 redaction 到 body / query / log data** | **使用者裁決（D-2）**：本次 out of scope，列為**獨立後續項目（值得單開一個 issue）**。理由與完整風險留痕見「🔴 敏感資料外洩」專節——body redaction 是遞迴 JSON 走訪 + 敏感 key 啟發式，屬獨立功能份量，且會改變既有單筆分享行為（破壞性風險） |
+| **`device_info_plus` / `package_info_plus` 硬相依** | **使用者裁決（D-1）**：改用 host 注入。相依數維持 4 個不變 |
+| **ConsoleTab 的搜尋欄 / LogLevel FilterChip** | brainstorm #5 的 UI 部分**仍維持 out of scope**。本功能只在**報告的匯出選單**提供 errors-only，**不動 ConsoleTab 的 UI** |
+| **HAR / 效能 timing** | brainstorm anti-feature #3。不偽造 DNS/TLS/TTFB 分段 |
+| **報告內容編輯 / 預覽畫面** | 選項 sheet 已足夠。做可編輯預覽器等於重造 markdown editor |
+| **截圖 / 畫面錄製附加** | 需要額外原生相依與權限，且 share sheet 的多檔附件是完全不同的問題 |
+| **自訂 template / 使用者自定義區段** | YAGNI。三個過濾維度已覆蓋 brainstorm 描述的痛點 |
+| **自訂 buffer 之外的資料源** | 報告只讀四個既有 buffer，不新增資料收集 |
+
+---
+
+## 前置項
+
+### P-1：修正 `FlutterInspector.version` 的單一真相來源 🔴
+
+```
+lib/src/core/flutter_inspector.dart:24   →   static const String version = '1.1.0';
+pubspec.yaml:3                           →   version: 1.4.0
+```
+
+這個常數**已經過期三個版本**，而且過去沒人發現——因為**整個 codebase 沒有任何程式碼讀取它**。
+
+診斷報告的表頭要印「套件版本」，這會讓這個常數**第一次有真實消費者**。若直接沿用，**報告會對收件人說謊**（宣稱 1.1.0，實際 1.4.0）——而收件人正是那個要靠版本號判斷「這個 bug 是不是已知問題」的工程師。
+
+**要求**：實作報告表頭之前，必須先確立版本的**單一真相來源**（同步修正常數，或改用不會漂移的來源）。這是**前置項**，不是「順便做」。對應 AC-3。
+
+---
+
+## 驗收條件
+
+| # | 條件 | 驗證方式 |
+|---|------|---------|
+| **AC-1** | 報告產生器是**純函式**，不依賴 Flutter widget / BuildContext，可獨立 unit test | unit test（無 widget binding） |
+| **AC-2** | 報告表頭包含：產生時間（ISO8601）、套件版本、redaction 狀態、app 版本、device / OS 資訊 | unit test 比對輸出字串 |
+| **AC-3** | **版本單一真相**：報告表頭印出的套件版本與 `pubspec.yaml` 一致（前置項 P-1） | unit test |
+| **AC-4** | device / app 資訊**未注入**時，對應欄位顯示 `N/A`，**不拋例外、不回傳 null**，報告仍完整產生 | unit test（不提供 provider） |
+| **AC-5** | device / app 資訊**已注入**時，表頭顯示 host 提供的值 | unit test（注入 fake provider） |
+| **AC-6** | **零新增 pub 相依**：`pubspec.yaml` 仍為 4 個相依（`dio` / `share_plus` / `flutter_local_notifications` / `web`） | `pubspec.yaml` 對比 |
+| **AC-7** | 報告包含「當前路由堆疊」區段，內容等同 `NavigatorStackResolver().resolve(navigatorEntries)`（top-first） | unit test |
+| **AC-8** | **時間窗**：`last 5m` / `last 1h` 只納入 `timestamp` 落在窗內的 entries；`all` 納入全部 | unit test（構造跨時間窗 entries） |
+| **AC-9** | **區段選擇**：未勾選的 source 完全不出現在報告中（不留空標題） | unit test |
+| **AC-10** | **errors-only 勾選時**：報告的 log 區段只含 `LogLevel.error` 與 `LogLevel.warning` 的 entries | unit test |
+| **AC-11** | **errors-only 未勾選時（預設）**：報告的 log 區段包含所有等級的 entries；且預設值為 `false` | unit test |
+| **AC-12** | **errors-only 不影響其他區段**：勾選後 network / nav / db 區段內容與未勾選時完全相同 | unit test |
+| **AC-13** | errors-only 的過濾**複用 `LogInspector.entriesAtLevel()`**，不重寫等級過濾邏輯 | code review |
+| **AC-14** | 選定條件下某 source 無資料時，該區段顯示 `(none)`，不崩潰 | unit test |
+| **AC-15** | 🔴 **`redactSensitiveData: true`（預設）時，報告中的 `Authorization` / `Cookie` / `Set-Cookie` / `X-Api-Key` header 值全部為 `••••`** | unit test（構造帶 secret header 的 entry，斷言報告字串**不含**明文 secret） |
+| **AC-16** | 🔴 **`redactSensitiveData: false` 時，報告中上述 header 為明文**（opt-out 行為與 `NetworkDetailView` 一致，見 `network_detail_view_test.dart:106`） | unit test |
+| **AC-17** | 🔴 **報告表頭明示 redaction 狀態**（`Redaction: enabled` / `disabled`），讓收報告的人知道這份文件有沒有被遮蔽 | unit test |
+| **AC-18** | 報告的 network 區段透過 `buildPlainText(entry, redact: ...)` 產生，**不繞過**既有 redaction 路徑 | code review |
+| **AC-19** | Dashboard AppBar 出現 export action；點擊開啟選項 UI | widget test |
+| **AC-20** | 選項 UI 提供三個維度：四個 source 勾選、三種時間範圍、errors-only 勾選（預設關閉）；確認後呼叫 `shareText` 一次 | widget test |
+| **AC-21** | 報告**不寫入任何檔案**（無 `dart:io` File 寫入、無 `path_provider`） | code review + import 檢查 |
+| **AC-22** | 既有公開 API 行為零變更：`FlutterInspector` 現有 getter / method 簽章與行為不變 | 既有測試全綠 |
+| **AC-23** | **ConsoleTab UI 零變更**（errors-only 只在匯出選單，不加搜尋欄 / LogLevel FilterChip） | 既有 `console_tab_test.dart` 全綠 |
+| **AC-24** | Web 平台可用（報告產生器不得引入 `dart:io`） | 檢查 import graph |
+
+---
+
+## 已定案設計取捨
+
+### D-1：device / app info → **Host 注入**（原 Q1，使用者裁決 A）
+
+**調查發現（與 brainstorm 原始構想牴觸）**：brainstorm 寫「用 `package_info_plus` + `device_info_plus`（**可選相依**，未安裝時降級為 N/A）」。但 **Dart / pub 沒有 optional dependency 機制**——conditional import（`import 'a.dart' if (dart.library.io) 'b.dart'`）的條件只能是 **Dart core library 是否存在**，不能是「某個第三方 package 是否被安裝」。原構想**無法照字面實現**。
+
+**決策**：抽象介面 + host 註冊實作。package 對 `device_info_plus` / `package_info_plus` **零相依**，由宿主 app 決定要不要裝、並把資訊餵進來。未注入 → 該區段全部 `N/A`，不崩（AC-4）。
+
+**理由**：本專案已有一模一樣的先例——`DatabaseBrowserSource`（`lib/src/models/database_browser_source.dart`）就是「抽象介面 + host 註冊具體實作」，package 本身對 ObjectBox / sqflite 零相依，只有 `example/pubspec.yaml` 才裝那些套件。device info 是完全相同的形狀。相依數維持 4 個不變（對 pub score 與導入成本都友善），且用的是本專案**已驗證過**的 IoC 模式。
+
+---
+
+### D-2：redaction → **繼承現狀 + 表頭明示**（原 Q2，使用者裁決 A）
+
+**決策**：報告一律走 `buildPlainText(entry, redact: inspector.redactSensitiveData)`，維持不變式——
+
+> **報告的遮蔽行為 == 單筆分享的遮蔽行為**
+
+不製造第二套語意、不產生行為分歧。報告表頭必須印 `Redaction: enabled/disabled`（AC-17），誠實告知收件人這份文件有沒有被遮蔽。
+
+**擴大 redaction 到 body / query / log data → 本次 out of scope，列為獨立後續項目（值得單開一個 issue）。** 完整的風險留痕見下方「🔴 敏感資料外洩」專節。
+
+---
+
+### D-3：報告格式 → **只做 Markdown**（原 Q3，使用者裁決 A）
+
+**決策**：只輸出 Markdown。JSON 移入 Out of scope。
+
+**理由**：問一句「JSON 給誰吃？」——brainstorm 自己已經砍掉了所有可能的 JSON 消費者：HAR 匯出（anti-feature #3）、落盤 / 持久化（anti-feature #2）。剩下的唯一使用者是「QA 貼進 Jira / GitHub issue」，那是 Markdown 的主場。做兩套序列化 = 兩倍測試成本換零使用者。
+
+---
+
+### D-4：errors-only 過濾 → **第三個維度，預設關閉**（使用者於暫停點主動追加）
+
+**決策**：匯出選單在既有兩個維度（時間窗、來源區段）之外，新增第三個維度——「只包含 error / warning 等級」勾選框，**預設關閉（全收）**。
+
+**正面理由（使用者提出）**：
+- 報告更短、訊噪比更高——QA 知道問題就是那幾筆 error 時，不必讓幾百筆 info log 稀釋重點
+- **順帶緩解「報告過大」風險**（見 D-5）——一個過濾維度換兩個好處
+- **複用已存在但從未被呼叫的 `LogInspector.entriesAtLevel()`**（`log_inspector.dart:21`）。brainstorm #5 已點名這段死代碼，本功能讓它第一次有消費者。零新邏輯。
+
+**反面風險（故預設關閉）**：
+使用者可能匯出一份**缺了上下文跟路**的報告——排查最關鍵的線索往往不是 error 本身，而是「error 發生前那幾筆 info log 做了什麼」。若預設開啟，會系統性地把最有價值的上下文從報告中剃掉，而 QA **不會知道自己剃掉了什麼**。**因此預設關閉：讓「完整上下文」成為預設路徑，errors-only 是使用者明確做出的取捨。**
+
+**範圍界線**：
+- **只影響報告的 log 區段**。network / nav / db 區段完全不受影響（AC-12）——network 的錯誤過濾已有 `NetworkStatusGroup` / Error Summary 負責，不在此重複。
+- **不動 ConsoleTab 的 UI**（AC-23）。brainstorm #5 的搜尋欄 / LogLevel FilterChip 仍維持 out of scope。
+
+**實作注意（留給 STAGE 0b）**：`entriesAtLevel(LogLevel)` 是**精確等級比對**（`e.level == level`），不是「最低等級以上」過濾。要同時取 error + warning，需呼叫兩次後合併，並重新按 `timestamp` 降序排序以維持 newest-first 慣例。（`LogLevel` enum 的宣告順序 `verbose < debug < info < warning < error` 也支援 index-based 的最低等級過濾——選哪種寫法由 STAGE 0b 決定；AC-13 只要求不重寫等級過濾邏輯。）
+
+---
+
+### D-5：報告大小 → 靠預設值緩解，不做硬性截斷
+
+500 筆 network entries × 完整 request/response body 可能產生數 MB 的字串。`shareText` 走 `SharePlus.instance.share(ShareParams(text: ...))`（io）與 Web Share API（web），兩者對超長純文字的行為都**未經本專案驗證**。
+
+**緩解**（具體數值留給 STAGE 0b）：時間窗預設 `last 5m`（而非 `all`）+ errors-only 選項（D-4）。**規格層級的要求**：報告不得因為過大而讓 app 無回應或崩潰。
+
+---
+
+### D-6：資料來源 → 分區段，不用混合時序
+
+`InspectorRegistry.mergedTimeline({sources})` 已經做完聚合（按 source 過濾 → 合併四 buffer → 按 timestamp 降序）。但 brainstorm 描述的是「**各區段**」，且分區段對閱讀者更友善（工程師會先跳到 Network 段）。
+
+**決策**：報告**分區段**呈現，每段內部沿用 buffer 的 newest-first 順序。`mergedTimeline` 的 source 過濾能力仍可複用。
+
+**型別分派**：若走 `mergedTimeline`，回傳的 `List<TimestampedEntry>` 需按具體型別分派序列化——**這個 pattern 已有生產先例**：`console_tab.dart` 的 `_EntryRowDispatcher` 就在做同一件事（依 entry 型別選 row widget）。報告只是把「選 widget」換成「選 formatter」。
+
+---
+
+### D-7：Builder 簽章 → 純函式，不吃 `FlutterInspector`
+
+brainstorm 寫的是 `buildDiagnosticReport(inspector, {...})`。但既有慣例（`network_formatters.dart` 檔頭）明文寫著：
+
+> Pure formatting helpers for the Network inspector. **No Flutter dependencies**, so everything here is unit-testable in isolation.
+
+`FlutterInspector` import 了 `package:flutter/widgets.dart`。讓 formatter 吃它會把 Flutter 相依拖進 `utils/`，破壞既有純度慣例，且讓 unit test 被迫建構整個 inspector。
+
+**決策**：核心 builder 吃**原始資料**（entry lists + 選項 + redact flag + device info），保持純函式（AC-1）；UI 層負責把 inspector 的欄位拆開餵進去。
+
+---
+
+### D-8：公開 API 面 → **不 export 到 barrel**（device info 介面除外）
+
+`lib/flutter_inspector_kit.dart` 只 export 7 個檔；`TimelineSource` / `LogEntry` / `NavigatorEntry` / `DatabaseEntry` **都沒有被 export**。若把 report builder 設為公開 API，其參數型別必須一併 export = 擴大公開 API 面。
+
+**先例**：error-aggregation（v1.3.0）的 `aggregateNetworkErrors()` 明確決定「放在 `src/utils/`，**不從 barrel file 匯出**」。
+
+**決策**：report builder **不 export**。這個功能的使用者是「按 dashboard 上那顆按鈕的 QA」，不是「programmatic 呼叫 builder 的開發者」——沒有已知的 programmatic 消費者，YAGNI。
+
+**例外**：D-1 的 device info 注入介面**必須 export**（host 要 implement 它），比照 `DatabaseBrowserSource` 已在 barrel 中的處理。
+
+---
+
+## 風險與破壞性評估
+
+| 面向 | 風險 | 評估 |
+|------|------|------|
+| **既有公開 API** | 🟢 零破壞 | 純新增：`DashboardModal` 的 AppBar `actions:` 目前是空的（`dashboard_modal.dart:47`），新增 action 不動任何既有簽章。`FlutterInspector` 既有 getter/method 全部不動。D-1 會新增一個**可選**建構參數（default null）——與 `redactSensitiveData` / `captureUncaughtErrors` / `databaseSources` 的既有擴充模式一致，不破壞既有呼叫端 |
+| **既有序列化路徑** | 🟢 零破壞 | 報告**呼叫** `buildPlainText` / `buildLogPlainText` / `entriesAtLevel`，不修改它們 |
+| **ConsoleTab** | 🟢 零破壞 | errors-only 只在匯出選單，ConsoleTab UI 完全不動（AC-23） |
+| **敏感資料外洩** | 🔴 **最高風險** | 見下方專節 |
+| **報告過大** | 🟡 中等 | 見 D-5。緩解：預設時間窗 5m + errors-only 選項 |
+| **新增 pub 相依** | 🟢 零新增 | D-1 裁決為 host 注入，相依維持 4 個（AC-6） |
+| **Web 相容性** | 🟢 已有先例 | `shareText` 已有 io/web 條件匯出（`share_text.dart:8`）。報告 builder 不引入 `dart:io`（AC-24） |
+| **效能** | 🟢 可忽略 | O(N) 遍歷 + 字串串接，N ≤ 500（`RingBuffer.capacity`）。使用者按下按鈕時才執行，不在 build path 上 |
+| **版本說謊** | 🟡 已納管 | 前置項 P-1 + AC-3 |
+
+---
+
+### 🔴 敏感資料外洩：既有 redaction 的實際覆蓋範圍（誠實留痕）
+
+> **這一節記錄 STAGE 0a 的 codebase 調查結果，不得在後續修訂中被刪除或淡化。**
+
+`redaction.dart` 的 `redactHeaders()` **只遮 4 個 header key**（`authorization` / `cookie` / `set-cookie` / `x-api-key`）。它**不遮**：
+
+| 未遮蔽的資料 | 證據 | 具體洩漏樣態 |
+|---|---|---|
+| **query parameters** | `network_formatters.dart:117-121` 原文輸出 | `?api_key=xxx` 明文出現在報告中 |
+| **request / response body** | `network_formatters.dart:125-143` 原文輸出 | `{"access_token": "..."}` 明文出現在報告中 |
+| **log entry 的 message / data** | `log_formatters.dart:8` `buildLogPlainText()` **連 `redact` 參數都沒有** | `LogEntry.data` 整包明文印出 |
+
+**這不是本功能引入的漏洞。** 今天單筆分享一個 network entry，body 裡的 token 就**已經**是明文外送了。
+
+**但本功能會放大它的爆炸半徑**：
+
+| | 洩漏面 |
+|---|---|
+| **現況（單筆分享）** | 1 筆 → 剪貼簿 / share sheet，通常是開發者自己看 |
+| **本功能（診斷報告）** | 最多 500 筆 → share sheet → **貼進 issue tracker / 聊天群組**。接收面更廣、更持久，且 QA 不會逐筆檢查內容 |
+
+**使用者已裁決（D-2）**：本次維持現狀遮蔽範圍（不擴大），並以表頭 `Redaction: enabled/disabled`（AC-17）誠實告知收件人。
+
+**後續項目（建議單開 issue）**：擴大 redaction 到 request / response body、query parameters、`LogEntry.data`。這是獨立功能的份量——body redaction 是遞迴 JSON 走訪 + 敏感 key 啟發式，不是 4 個 header key 的 set lookup；且它會**改變既有單筆分享的行為**，屬於需要獨立評估的破壞性變更。
+
+---
+
+## 核心判斷
+
+✅ **值得做。**
+
+理由：排查鏈條的最後一環（「帶走證據」）目前是紅燈——Navigator / Database tab 連分享按鈕都沒有，QA 只能截圖。而所需的零件**全部已經存在**：`mergedTimeline`（聚合）、`buildPlainText` / `buildLogPlainText`（序列化）、`NavigatorStackResolver`（堆疊快照）、`entriesAtLevel`（等級過濾，**寫好了從沒被呼叫過**）、`shareText`（平台自適應輸出）。這是組裝，不是發明。
+
+原本需要動腦的兩件事已由使用者裁決：device info 相依策略走 IoC（brainstorm 的「可選相依」在 Dart 根本不存在）、redaction 維持現狀範圍並誠實明示。唯一的前置債是 `FlutterInspector.version` 這個過期常數——本功能會讓它第一次有消費者，必須先修。
+
+---
+
+## 相關文件
+
+- Brainstorm 原始描述：[2026-07-12-features-brainstorm.md](../brainstorm/2026-07-12-features-brainstorm.md) §3（另 §5 為 errors-only 所複用的 `entriesAtLevel` 出處）
+- 敏感資料遮蔽（redaction 現況）：[2026-06-27-sensitive-data-redaction.md](./2026-06-27-sensitive-data-redaction.md)
+- 當前路由堆疊（可複用的 `NavigatorStackResolver`）：[2026-07-01-navigator-active-stack.md](./2026-07-01-navigator-active-stack.md)
+- 混合時序軸（可複用的 `mergedTimeline`）：[2026-06-26-console-merged-timeline.md](./2026-06-26-console-merged-timeline.md)
+- 「不 export 到 barrel」的先例：[2026-07-10-error-aggregation-summary.md](./2026-07-10-error-aggregation-summary.md)
+- 可複用的序列化：[network_formatters.dart](../../lib/src/utils/network_formatters.dart)、[log_formatters.dart](../../lib/src/utils/log_formatters.dart)
+- 可複用的等級過濾：[log_inspector.dart](../../lib/src/inspectors/log_inspector.dart)
+- 可複用的分享：[share_text.dart](../../lib/src/utils/share_text.dart)
+- IoC 相依注入先例：[database_browser_source.dart](../../lib/src/models/database_browser_source.dart)
+- AppBar 擴充點：[dashboard_modal.dart](../../lib/src/ui/dashboard/dashboard_modal.dart)

--- a/docs/plans/2026-07-15-diagnostic-report.md
+++ b/docs/plans/2026-07-15-diagnostic-report.md
@@ -13,7 +13,7 @@
 
 **調查結果（實際查證，非臆測）**：
 
-```
+```text
 lib/src/core/flutter_inspector.dart:24   static const String version = '1.1.0';
 pubspec.yaml:3                           version: 1.4.0
 test/flutter_inspector_test.dart:12      expect(FlutterInspector.version, '1.1.0');   ← 元凶
@@ -28,7 +28,7 @@ test/flutter_inspector_test.dart:12      expect(FlutterInspector.version, '1.1.0
 
 **採用 C**。這是唯一不加相依、又真的會擋住漂移的做法。
 
-```
+```dart
 lib/src/version.dart          const String packageVersion = '1.4.0';   ← 單一真相
 lib/src/core/flutter_inspector.dart
     static const String version = packageVersion;                       ← 公開 API 不變（AC-22）
@@ -170,7 +170,7 @@ final logs = errorsOnly
 | `lib/src/ui/dashboard/dashboard_modal.dart` | AppBar 目前空的 `actions:` 加一顆 export IconButton |
 | `test/flutter_inspector_test.dart` | 刪掉硬編碼 `'1.1.0'` 的假測試，改斷言 `== packageVersion` |
 | `test/core/flutter_inspector_test.dart` | 補 `diagnosticInfoSource` 預設 null / 可注入 |
-| `test/ui/dashboard_modal_test.dart` | 補 AppBar export action 存在 |
+| `test/ui/export_report_sheet_test.dart` | 補 AppBar export action 存在 |
 | `README.md` / `CHANGELOG.md` | 新公開 API（`DiagnosticInfoSource`）的用法與版本紀錄 |
 
 **`pubspec.yaml` 不動**（AC-6）——沒有共享檔案的寫入競爭。
@@ -242,14 +242,14 @@ final logs = errorsOnly
 
 ### T7 — 匯出 sheet + AppBar action
 - **複雜度**：`標準`
-- **寫入 scope**：`lib/src/ui/dashboard/export_report_sheet.dart`、`lib/src/ui/dashboard/dashboard_modal.dart`、`test/ui/export_report_sheet_test.dart`、`test/ui/dashboard_modal_test.dart`
+- **寫入 scope**：`lib/src/ui/dashboard/export_report_sheet.dart`、`lib/src/ui/dashboard/dashboard_modal.dart`、`test/ui/export_report_sheet_test.dart`
 - **AC**：AC-19、AC-20、AC-23
 - **步驟**：
   1. `dashboard_modal.dart` 的 AppBar `actions:`（目前是空的）加一顆 IconButton → `showModalBottomSheet`。
   2. `_ExportReportSheet`（StatefulWidget）：4 個 source `CheckboxListTile` + 3 選 1 時間範圍（值為 `Duration(minutes:5)` / `Duration(hours:1)` / `null`）+ 1 個 errors-only `CheckboxListTile`（**預設 false**）+ 確認鍵。
   3. 確認鍵：`final info = await inspector.diagnosticInfoSource?.collect();` → `buildDiagnosticReport(..., now: DateTime.now(), redact: inspector.redactSensitiveData, info: info)` → `await shareText(report)`。
   4. **`ConsoleTab` 一行都不准動**（AC-23）。
-- **驗收**：`flutter test test/ui/export_report_sheet_test.dart test/ui/dashboard_modal_test.dart test/ui/tabs/console_tab_test.dart`
+- **驗收**：`flutter test test/ui/export_report_sheet_test.dart test/ui/tabs/console_tab_test.dart`
 - **依賴**：T3、T6
 - **⚠️ 測 AC-20 的已知限制**：`shareText` 是 conditional-export 的頂層函式，**無法 spy**（既有的 `network_detail_view_test` / `log_detail_view_test` 也沒 spy 它，只 mock `Clipboard.setData` 的 method channel）。做法：比照既有慣例 mock **share_plus 的 method channel** 並斷言收到一次呼叫 + 捕獲的字串。**channel 名稱請從 `pubspec.lock` 釘住的 share_plus 13.x 原始碼實地確認，不要憑記憶填**。若 channel 名稱驗證不了，退而求其次：斷言 sheet 的確認鍵可按且 sheet 關閉（報告**內容**已由 T4~T6 的 unit test 全覆蓋）。
 

--- a/docs/plans/2026-07-15-diagnostic-report.md
+++ b/docs/plans/2026-07-15-diagnostic-report.md
@@ -1,0 +1,319 @@
+# 實作計畫：一鍵診斷報告（Diagnostic Report）
+
+> **規格**：[docs/features/2026-07-15-diagnostic-report.md](../features/2026-07-15-diagnostic-report.md)（24 條 AC，已確認）
+> **日期**：2026-07-15
+> **基準**：v1.4.0 / branch `main`
+> 本文件只寫 **How**。AC 一律以編號引用，不重述規格內容。
+
+---
+
+## 1. 資料結構與介面設計
+
+### 1.1 版本單一真相（前置項 P-1）
+
+**調查結果（實際查證，非臆測）**：
+
+```
+lib/src/core/flutter_inspector.dart:24   static const String version = '1.1.0';
+pubspec.yaml:3                           version: 1.4.0
+test/flutter_inspector_test.dart:12      expect(FlutterInspector.version, '1.1.0');   ← 元凶
+```
+
+**沒人發現的根因就在那條測試**：它把常數硬編碼字串跟常數自己比對，永遠會過，什麼都沒驗證。這是一條「驗證了一個恆等式」的假測試。
+
+**可行方案盤點**：
+- ❌ **執行期讀 `pubspec.yaml`**：Dart 做不到。package 的 pubspec 不會被打包進 app，要讀只能宣告成 Flutter asset + `rootBundle`（需要 widget binding，違反 AC-1 的純函式要求，且污染宿主的 asset bundle）。
+- ❌ **build-time codegen**：套件的 `dev_dependencies` 只有 `flutter_test` + `flutter_lints`（Makefile 的 `build_runner` target 是專案模板殘留，pubspec 裡根本沒有 `build_runner`）。為了一個字串引入 codegen 相依 = 過度工程。
+- ✅ **人工同步 + 測試把關**：唯一常數放 `lib/src/version.dart`，寫一條**真的會失敗**的測試——用 `dart:io` 讀 `pubspec.yaml`（unit test 跑在 VM，cwd = package root），parse 出 `version:` 那行，斷言與 `packageVersion` 相等。版本漂移 → 紅燈。
+
+**採用 C**。這是唯一不加相依、又真的會擋住漂移的做法。
+
+```
+lib/src/version.dart          const String packageVersion = '1.4.0';   ← 單一真相
+lib/src/core/flutter_inspector.dart
+    static const String version = packageVersion;                       ← 公開 API 不變（AC-22）
+```
+
+放在獨立檔的理由（不是為了分層，是為了相依）：`FlutterInspector` import 了 `package:flutter/widgets.dart`，而報告產生器必須是 Flutter-free（AC-1 / AC-24）。builder 直接 import `version.dart` 就拿得到版本，不會把 Flutter 拖進 `utils/`。
+
+### 1.2 Device / app info 注入介面（AC-4 / AC-5 / AC-6）
+
+形狀直接抄 `database_browser_source.dart` 的先例（抽象 source + 值物件同檔、在 barrel export）：
+
+```
+lib/src/models/diagnostic_info.dart
+
+  @immutable
+  class DiagnosticInfo {            // 全欄位 nullable → builder 印 N/A
+    final String? appVersion;       // e.g. "2.3.1+45"
+    final String? deviceModel;      // e.g. "iPhone15,2"
+    final String? osVersion;        // e.g. "iOS 17.4"
+  }
+
+  abstract class DiagnosticInfoSource {
+    Future<DiagnosticInfo> collect();
+  }
+```
+
+**為什麼是固定欄位而不是 `Map<String, String>`**：AC-4 要求「未注入時顯示 `N/A`」——你沒辦法對一個自己都不知道 key 的 map 印 N/A。固定三欄位讓報告表頭的形狀跨宿主一致，也讓 AC-4/AC-5 可測。
+
+**為什麼 `collect()` 是 async 但 builder 是 sync**：`device_info_plus` / `package_info_plus` 都是 async。**async 邊界留在 UI**（export sheet 的 `onPressed` 本來就是 async），builder 收到的是已 resolve 的 `DiagnosticInfo?`。這樣 builder 保持純同步 → AC-1 的 unit test 不需要 `pumpEventQueue`，也不需要 widget binding。
+
+`FlutterInspector` 新增可選建構參數（比照 `redactSensitiveData` / `databaseSources` 的既有模式）：
+
+```
+FlutterInspector({ ..., this.diagnosticInfoSource })   // default null
+final DiagnosticInfoSource? diagnosticInfoSource;
+```
+
+barrel（`lib/flutter_inspector_kit.dart`）新增 `export 'src/models/diagnostic_info.dart';`——這是 D-8 的**唯一例外**（宿主要 implement 它，不 export 就用不了），比照 `database_browser_source.dart` 已在 barrel 的處理。
+
+### 1.3 報告產生器（AC-1，D-7 / D-8）
+
+檔案：`lib/src/utils/diagnostic_report.dart`。**不 export 到 barrel**（沿用 `aggregateNetworkErrors()` 先例）。
+
+```
+String buildDiagnosticReport({
+  required LogInspector logInspector,          // errorsOnly 要呼叫 entriesAtLevel（AC-13）
+  required List<NetworkEntry> networkEntries,
+  required List<NavigatorEntry> navigatorEntries,
+  required List<DatabaseEntry> databaseEntries,
+  required DateTime now,                        // 注入 → 時間窗可決定性測試（AC-8）
+  DiagnosticInfo? info,                         // null → 全 N/A（AC-4）
+  Duration? timeRange,                          // null → all（見下）
+  Set<TimelineSource> sections = const {log, network, nav, db},
+  bool errorsOnly = false,                      // 預設關閉（AC-11）
+  bool redact = true,                           // 呼叫端傳 inspector.redactSensitiveData
+})
+```
+
+只 import：`log_inspector.dart`、四個 model、`version.dart`、`network_formatters.dart`、`log_formatters.dart`、`navigator_stack_resolver.dart`。**零 `dart:io`、零 `package:flutter/material.dart`**（AC-21 / AC-24）。
+
+### 1.4 三個過濾維度的形狀 — **不需要 options 物件**
+
+Coordinator 問「能不能收斂成一個乾淨的 options 物件」。答案是：**收斂的重點不在包一個類別，在於幹掉那個 enum。**
+
+| 天真作法 | 好品味作法 |
+|---|---|
+| `enum TimeRange { last5m, last1h, all }` → builder 裡 `switch` 把 enum 映射成 cutoff，`all` 是特例分支 | `Duration? timeRange`（**null == all**）→ `final cutoff = timeRange == null ? null : now.subtract(timeRange);` |
+| 每個區段各自 `if (errorsOnly && source == log)` | 三個維度各作用在**不同的收斂點**，互不交纏 |
+
+```dart
+// 一個 nullable 幹掉整個 switch 與 all 特例：
+final cutoff = timeRange == null ? null : now.subtract(timeRange);
+bool inWindow(TimestampedEntry e) => cutoff == null || e.timestamp.isAfter(cutoff);
+```
+
+UI 的三顆時間 radio 直接是**資料**，不是程式碼分支：`[Duration(minutes: 5), Duration(hours: 1), null]`。
+
+三個維度各自只有一個收斂點，沒有交叉的 if：
+
+| 維度 | 型別 | 收斂點 |
+|---|---|---|
+| 時間窗 | `Duration?`（null = all） | 每個區段渲染前的 `.where(inWindow)` |
+| 區段 | `Set<TimelineSource>`（**沿用既有 enum**，`mergedTimeline` 已在用） | 每個區段外層的 `if (sections.contains(...))` |
+| errors-only | `bool` | **只在 log 區段的取數那一行**（AC-12：其他區段連碰都不碰） |
+
+**結論：不新增 `DiagnosticReportOptions` 類別。** 三個具名參數 + 一個 nullable Duration 就完事了；包成物件只是多一層搬運，UI 端用三個 `State` 欄位直接餵具名參數即可。（YAGNI — 未來若 builder 有第二個呼叫端再說。）
+
+### 1.5 各區段怎麼接既有零件（**複用清單**）
+
+| 區段 | 複用什麼 | 怎麼接 |
+|---|---|---|
+| **表頭** | `version.dart` 的 `packageVersion` | `Generated / Package / Redaction: enabled\|disabled / App version / Device / OS`，null → `N/A` |
+| **當前路由堆疊** | `NavigatorStackResolver().resolve(entries)` | ⚠️ **餵完整的 `navigatorEntries`，不餵時間窗過濾後的**——replay 必須從 buffer 頭跑起，餵截斷的事件會推導出錯誤的堆疊 |
+| **Log 區段** | `buildLogPlainText(entry)`（既有）+ `logInspector.entriesAtLevel()`（既有，**從沒被呼叫過**） | 每筆包進 ``` fenced code block |
+| **Network 區段** | `buildPlainText(entry, redact: redact)`（既有） | 同上。**redaction 全靠這條路徑**（AC-15/16/18），builder 自己不碰 header |
+| **Nav / DB 區段** | 無現成 formatter | 各寫一個 **private 一行式** helper 放在 `diagnostic_report.dart` 內（`NavigatorEntry.displayName` / `DatabaseEntry.operation`+`tableName`+`affectedRows` 都是現成 getter）。**不新開 `navigator_formatters.dart` / `database_formatters.dart`**——單一消費者，YAGNI |
+| **輸出** | `shareText(String)`（既有，io/web 條件匯出） | export sheet 的確認鍵 `await shareText(report)` |
+
+**Markdown 包裝策略（最懶且誠實）**：`buildPlainText` / `buildLogPlainText` 吐的是 `=== General ===` 純文字區塊。報告**不重新序列化**，直接把每筆的純文字包進 Markdown fenced code block。零重寫、GitHub / Jira 都正常渲染。
+
+### 1.6 errors-only 的實作（AC-10 / AC-11 / AC-13）
+
+`entriesAtLevel(LogLevel)` 是**精確等級比對**，不是「≥ 某等級」：
+
+```dart
+final logs = errorsOnly
+    ? ([
+        ...logInspector.entriesAtLevel(LogLevel.error),
+        ...logInspector.entriesAtLevel(LogLevel.warning),
+      ]..sort((a, b) => b.timestamp.compareTo(a.timestamp)))   // 兩份 newest-first 合併後要重排
+    : logInspector.entries;
+```
+
+複用既有函式（AC-13），不重寫等級過濾。合併後重排以維持 newest-first 慣例。
+
+---
+
+## 2. 檔案異動清單
+
+### 新增
+
+| 檔案 | 一句話 |
+|---|---|
+| `lib/src/version.dart` | 版本單一真相：`const String packageVersion = '1.4.0';` |
+| `lib/src/models/diagnostic_info.dart` | `DiagnosticInfo` 值物件 + `DiagnosticInfoSource` 抽象注入介面 |
+| `lib/src/utils/diagnostic_report.dart` | 純函式 `buildDiagnosticReport(...)` + nav/db 的 private 一行式 formatter |
+| `lib/src/ui/dashboard/export_report_sheet.dart` | 匯出選項 bottom sheet（三維度 UI + 確認 → `shareText`） |
+| `test/version_test.dart` | 讀 `pubspec.yaml` 斷言版本一致（P-1 把關） |
+| `test/models/diagnostic_info_test.dart` | `DiagnosticInfo` 值語意 |
+| `test/utils/diagnostic_report_test.dart` | builder 的主力 unit test（AC-1~18 絕大多數在這） |
+| `test/ui/export_report_sheet_test.dart` | sheet 的 widget test（AC-19 / AC-20） |
+
+### 修改
+
+| 檔案 | 一句話 |
+|---|---|
+| `lib/src/core/flutter_inspector.dart` | `version` 改指向 `packageVersion`；新增 `diagnosticInfoSource` 可選參數（default null） |
+| `lib/flutter_inspector_kit.dart` | 新增 `export 'src/models/diagnostic_info.dart';`（D-8 唯一例外） |
+| `lib/src/ui/dashboard/dashboard_modal.dart` | AppBar 目前空的 `actions:` 加一顆 export IconButton |
+| `test/flutter_inspector_test.dart` | 刪掉硬編碼 `'1.1.0'` 的假測試，改斷言 `== packageVersion` |
+| `test/core/flutter_inspector_test.dart` | 補 `diagnosticInfoSource` 預設 null / 可注入 |
+| `test/ui/dashboard_modal_test.dart` | 補 AppBar export action 存在 |
+| `README.md` / `CHANGELOG.md` | 新公開 API（`DiagnosticInfoSource`）的用法與版本紀錄 |
+
+**`pubspec.yaml` 不動**（AC-6）——沒有共享檔案的寫入競爭。
+
+---
+
+## 3. 任務拆分
+
+> 每個任務 **TDD-first**：先寫（會紅的）測試 → 再實作 → 跑指定指令綠燈。
+> 測試沿用專案既有慣例（`flutter_test` + `group`/`test`/`testWidgets`），**不引入新框架**。
+
+### T1 — 版本單一真相（前置項 P-1）
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`lib/src/version.dart`、`lib/src/core/flutter_inspector.dart`、`test/version_test.dart`、`test/flutter_inspector_test.dart`
+- **AC**：AC-3、AC-22
+- **步驟**：
+  1. 寫 `test/version_test.dart`：`File('pubspec.yaml').readAsLinesSync()` 找 `version:` 開頭那行 → 取值 → `expect(packageVersion, pubspecVersion)`。此時應為**紅燈**（1.1.0 vs 1.4.0）。
+  2. 建 `lib/src/version.dart`：`const String packageVersion = '1.4.0';`
+  3. `flutter_inspector.dart:24` 改成 `static const String version = packageVersion;`（公開 API 簽章不變）。
+  4. `test/flutter_inspector_test.dart:12` 把 `expect(FlutterInspector.version, '1.1.0')` 改成 `expect(FlutterInspector.version, packageVersion)`。
+- **驗收**：`flutter test test/version_test.dart test/flutter_inspector_test.dart`
+- **依賴**：無。**必須第一個做**（其他任務讀 `packageVersion`；且它與 T3 都要寫 `flutter_inspector.dart`）
+
+### T2 — `DiagnosticInfo` + `DiagnosticInfoSource`
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`lib/src/models/diagnostic_info.dart`、`test/models/diagnostic_info_test.dart`
+- **AC**：（為 AC-4 / AC-5 鋪路）
+- **步驟**：先寫值語意測試（`==` / `hashCode` / 全 null 可建構），再照 `database_browser_source.dart` 的體例寫 model + abstract source。**只有這兩個型別，不加 factory、不加預設實作。**
+- **驗收**：`flutter test test/models/diagnostic_info_test.dart`
+- **依賴**：無。**可與 T1 並行**（寫入路徑完全不重疊）
+
+### T3 — `FlutterInspector.diagnosticInfoSource` + barrel export
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`lib/src/core/flutter_inspector.dart`、`lib/flutter_inspector_kit.dart`、`test/core/flutter_inspector_test.dart`
+- **AC**：AC-5、AC-6、AC-22
+- **步驟**：先補測試（預設 null；傳入 fake source 可取回），再加可選參數 + `final` 欄位 + barrel export 一行。
+- **驗收**：`flutter test test/core/flutter_inspector_test.dart`；`git diff pubspec.yaml` 為空（AC-6）
+- **依賴**：T1（同檔 `flutter_inspector.dart` — **唯一 owner，必須序列**）、T2（型別）
+
+### T4 — builder 骨架：簽章 + 表頭 + 時間窗 + 區段選擇 + 空狀態
+- **複雜度**：`最強推論`（要定死 options 形狀、Markdown 結構、與五個既有零件的接線）
+- **寫入 scope**：`lib/src/utils/diagnostic_report.dart`、`test/utils/diagnostic_report_test.dart`
+- **AC**：AC-1、AC-2、AC-3、AC-4、AC-5、AC-8、AC-9、AC-14
+- **步驟**：
+  1. 測試先行：注入固定 `now` + 跨時間窗的假 entries，驗 `timeRange: null` / `5m` / `1h`；驗未勾選的 source 不出現（連標題都沒有）；驗 `info: null` → 表頭三欄全 `N/A`；驗空區段印 `(none)`。
+  2. 實作 §1.3 的簽章；`cutoff` 用 §1.4 的 `Duration?` 寫法（**不准出現 TimeRange enum**）。
+  3. 表頭印 `packageVersion`（來自 T1）。
+- **驗收**：`flutter test test/utils/diagnostic_report_test.dart`
+- **依賴**：T1、T2。**可與 T3 並行**（`utils/` vs `core/`+barrel，寫入不重疊）
+
+### T5 — builder 區段內容：接 `buildPlainText` / `buildLogPlainText` / `NavigatorStackResolver`
+- **複雜度**：`標準`
+- **寫入 scope**：`lib/src/utils/diagnostic_report.dart`、`test/utils/diagnostic_report_test.dart`（**與 T4 同檔 → 序列**）
+- **AC**：AC-7、AC-14、AC-15、AC-16、AC-17、AC-18
+- **步驟**：
+  1. 🔴 測試先行（redaction 紅線）：帶 `Authorization: Bearer secret` 的 `NetworkEntry` → `redact: true` 時報告字串**不含** `Bearer secret`、含 `••••`；`redact: false` 時含明文。表頭出現 `Redaction: enabled` / `disabled`。
+  2. 測 nav 堆疊區段 == `NavigatorStackResolver().resolve(navigatorEntries)`（top-first）。⚠️ 加一條測試守住「堆疊 replay 餵的是**完整** buffer 而非時間窗過濾後的清單」——設一組「push 在時間窗外、pop 在窗內」的 entries，斷言堆疊仍正確。
+  3. 實作：network 段一律走 `buildPlainText(entry, redact: redact)`，log 段走 `buildLogPlainText(entry)`，各自包 fenced code block；nav / db 段用 private 一行式 helper。
+- **驗收**：`flutter test test/utils/diagnostic_report_test.dart`
+- **依賴**：T4（同檔）
+
+### T6 — builder 的 errors-only 維度
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`lib/src/utils/diagnostic_report.dart`、`test/utils/diagnostic_report_test.dart`（**與 T4/T5 同檔 → 序列**）
+- **AC**：AC-10、AC-11、AC-12、AC-13
+- **步驟**：測試先行（勾選 → log 段只剩 error+warning；未勾選 → 全收且預設 `false`；勾選前後 network/nav/db 段字串**完全相同**）→ 實作 §1.6 的三行。
+- **驗收**：`flutter test test/utils/diagnostic_report_test.dart`
+- **依賴**：T5（同檔）
+
+### T7 — 匯出 sheet + AppBar action
+- **複雜度**：`標準`
+- **寫入 scope**：`lib/src/ui/dashboard/export_report_sheet.dart`、`lib/src/ui/dashboard/dashboard_modal.dart`、`test/ui/export_report_sheet_test.dart`、`test/ui/dashboard_modal_test.dart`
+- **AC**：AC-19、AC-20、AC-23
+- **步驟**：
+  1. `dashboard_modal.dart` 的 AppBar `actions:`（目前是空的）加一顆 IconButton → `showModalBottomSheet`。
+  2. `_ExportReportSheet`（StatefulWidget）：4 個 source `CheckboxListTile` + 3 選 1 時間範圍（值為 `Duration(minutes:5)` / `Duration(hours:1)` / `null`）+ 1 個 errors-only `CheckboxListTile`（**預設 false**）+ 確認鍵。
+  3. 確認鍵：`final info = await inspector.diagnosticInfoSource?.collect();` → `buildDiagnosticReport(..., now: DateTime.now(), redact: inspector.redactSensitiveData, info: info)` → `await shareText(report)`。
+  4. **`ConsoleTab` 一行都不准動**（AC-23）。
+- **驗收**：`flutter test test/ui/export_report_sheet_test.dart test/ui/dashboard_modal_test.dart test/ui/tabs/console_tab_test.dart`
+- **依賴**：T3、T6
+- **⚠️ 測 AC-20 的已知限制**：`shareText` 是 conditional-export 的頂層函式，**無法 spy**（既有的 `network_detail_view_test` / `log_detail_view_test` 也沒 spy 它，只 mock `Clipboard.setData` 的 method channel）。做法：比照既有慣例 mock **share_plus 的 method channel** 並斷言收到一次呼叫 + 捕獲的字串。**channel 名稱請從 `pubspec.lock` 釘住的 share_plus 13.x 原始碼實地確認，不要憑記憶填**。若 channel 名稱驗證不了，退而求其次：斷言 sheet 的確認鍵可按且 sheet 關閉（報告**內容**已由 T4~T6 的 unit test 全覆蓋）。
+
+### T8 — 文件
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`README.md`、`CHANGELOG.md`
+- **AC**：無（但新公開 API 需說明）
+- **步驟**：README 加一節「Diagnostic Report」——如何 implement `DiagnosticInfoSource`（用 `device_info_plus` + `package_info_plus` 的範例，**明示這兩個套件由宿主自行安裝，本套件零相依**）；CHANGELOG 加版本條目。
+- **🔴 README 的範例必須是「可直接複製貼上就能跑」的完整 class**（含 import、`implements DiagnosticInfoSource`、`collect()` 全實作、以及傳入 `FlutterInspector(diagnosticInfoSource: ...)` 的那一行），**不是**殘缺片段或「請自行實作」一句話。理由：Host 注入把「拿 device 資訊」的工作轉嫁給宿主開發者，若文件摩擦高，多數人不會接線，報告表頭永遠是 `N/A`，本功能最核心的痛點（QA 手打 device/OS/版本）就沒被解決。文件品質在這裡是功能的一部分，不是附屬品。
+- **驗收**：人工閱讀
+- **依賴**：T6。**可與 T7 並行**（`README/CHANGELOG` vs `lib/ui`，寫入不重疊）
+
+### T9 — 全域驗收掃描
+- **複雜度**：`快/便宜`
+- **寫入 scope**：無（唯讀 + 最終 test run）
+- **AC**：AC-6、AC-21、AC-24 + 全體迴歸
+- **步驟**：
+  1. `git diff --stat pubspec.yaml` 為空 → AC-6
+  2. `grep -n "dart:io\|path_provider\|File(" lib/src/utils/diagnostic_report.dart` 無命中 → AC-21 / AC-24
+  3. `grep -rn "diagnostic_report" lib/flutter_inspector_kit.dart` 無命中 → D-8（builder 沒被 export）
+  4. `flutter analyze` + `flutter test`（全套）→ AC-22 / AC-23 迴歸
+- **依賴**：全部
+
+---
+
+## 4. 並行性
+
+| 批次 | 任務 | 並行？ | 理由 |
+|---|---|---|---|
+| **1** | **T1** ∥ **T2** | ✅ 並行 | T1 寫 `version.dart` + `core/flutter_inspector.dart`；T2 只寫 `models/diagnostic_info.dart`。零重疊 |
+| **2** | **T3** ∥ **T4** | ✅ 並行 | T3 owns `core/flutter_inspector.dart` + **barrel**；T4 owns `utils/diagnostic_report.dart`。零重疊 |
+| **3** | **T5** | ❌ 序列 | 與 T4 同檔 `diagnostic_report.dart` |
+| **4** | **T6** | ❌ 序列 | 與 T4/T5 同檔 |
+| **5** | **T7** ∥ **T8** | ✅ 並行 | T7 owns `ui/dashboard/*`；T8 owns `README/CHANGELOG`。零重疊 |
+| **6** | **T9** | ❌ 序列 | 全域驗收，須在最後 |
+
+**共享檔的唯一 owner（絕不並行寫）**：
+
+| 檔案 | 唯一 owner |
+|---|---|
+| `lib/src/core/flutter_inspector.dart` | **T1 → T3**（依序，兩者都寫；批次 1 與 2 之間有 barrier） |
+| `lib/flutter_inspector_kit.dart`（barrel） | **T3** |
+| `lib/src/utils/diagnostic_report.dart` | **T4 → T5 → T6**（嚴格序列） |
+| `lib/src/ui/dashboard/dashboard_modal.dart` | **T7** |
+| `pubspec.yaml` | **無人**（AC-6：不得修改） |
+
+---
+
+## 5. 執行方式（供選擇）
+
+| 方式 | 說明 | 適用 |
+|---|---|---|
+| **A. Subagent-driven（推薦）** | 依批次派工：批次 1 兩個 subagent 並行 → barrier → 批次 2 兩個並行 → T5/T6 單線接力 → 批次 5 兩個並行 → T9 收尾。複雜度標籤直接對應 model 選擇（`快/便宜` → 輕量 model；T4 的 `最強推論` → 最強 model） | 預設。批次間的 barrier 天然對應共享檔的 owner 切換 |
+| **B. Parallel session** | 開兩個 session：session A 跑 `core/` + barrel 線（T1→T3→T7），session B 跑 `utils/` 線（T2→T4→T5→T6）。T7 需等 B 的 T6，收斂點在 T7 前 | 想要人工盯 UI 那條線時 |
+| **C. 單線序列** | T1→T2→…→T9 全序列 | 最省心，但浪費批次 1/2/5 的並行度 |
+
+---
+
+## 6. 實作紅線（違反即在 STAGE 3 退回）
+
+1. **不准出現 `TimeRange` enum**。時間窗就是 `Duration?`，null == all（§1.4）。
+2. **不准新開 `navigator_formatters.dart` / `database_formatters.dart`**。單一消費者 → private helper 留在 `diagnostic_report.dart`。
+3. **不准新增 `DiagnosticReportOptions` 類別**。具名參數就夠（§1.4）。
+4. **不准重寫 redaction / 等級過濾 / 堆疊 replay**。一律複用 `buildPlainText(redact:)`、`entriesAtLevel()`、`NavigatorStackResolver`。
+5. **不准動 `pubspec.yaml`**（AC-6）、**不准動 `ConsoleTab`**（AC-23）。
+6. **`NavigatorStackResolver.resolve()` 必須餵完整 `navigatorEntries`**，不是時間窗過濾後的清單（T5 步驟 2）。
+7. **`DiagnosticInfoSource` 是規格明訂的注入介面，是唯一允許的新抽象**。除此之外不准出現任何 interface / factory / 為未來預留的 scaffolding。

--- a/lib/flutter_inspector_kit.dart
+++ b/lib/flutter_inspector_kit.dart
@@ -2,6 +2,7 @@ export 'src/core/flutter_inspector.dart';
 export 'src/interceptors/dio_interceptor.dart';
 export 'src/models/database_browser_source.dart';
 export 'src/models/database_operation.dart';
+export 'src/models/diagnostic_info.dart';
 export 'src/models/log_level.dart';
 export 'src/models/network_entry.dart';
 export 'src/ui/widgets/magical_tap.dart';

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import '../inspectors/log_inspector.dart';
 import '../inspectors/navigator_inspector.dart';
 import '../models/database_browser_source.dart';
 import '../models/database_entry.dart';
 import '../models/database_operation.dart';
+import '../models/diagnostic_info.dart';
 import '../models/log_entry.dart';
 import '../sources/operation_log_source.dart';
 import '../models/log_level.dart';
@@ -17,11 +19,12 @@ import '../ui/dashboard/dashboard_modal.dart';
 import 'inspector_overlay_manager.dart';
 import 'inspector_registry.dart';
 import 'uncaught_error_handler.dart';
+import '../version.dart';
 
 /// The core entry point for the Flutter Inspector.
 class FlutterInspector {
   /// Package version.
-  static const String version = '1.1.0';
+  static const String version = packageVersion;
 
   /// Creates a new FlutterInspector instance.
   ///
@@ -35,6 +38,7 @@ class FlutterInspector {
     this.navigatorKey,
     this.captureUncaughtErrors = false,
     this.redactSensitiveData = true,
+    this.diagnosticInfoSource,
     int bufferSize = 500,
     NetworkNotifier? notifier,
     List<DatabaseBrowserSource>? databaseSources,
@@ -122,6 +126,13 @@ class FlutterInspector {
   /// or a screenshot unless the host explicitly opts out.
   final bool redactSensitiveData;
 
+  /// Supplies device and app metadata for the diagnostic report header.
+  ///
+  /// Defaults to `null`, in which case the header degrades to `N/A`. This
+  /// package depends on no device-info plugin (and never on `dart:io`); hosts
+  /// that want a populated header implement [DiagnosticInfoSource] themselves.
+  final DiagnosticInfoSource? diagnosticInfoSource;
+
   late final UncaughtErrorHandler _uncaughtErrorHandler;
 
   NetworkNotifier? _notifier;
@@ -141,6 +152,12 @@ class FlutterInspector {
 
   /// Retrieves the current console logs.
   List<LogEntry> get logEntries => _registry.log.entries;
+
+  /// The log inspector, for level-filtered reads.
+  ///
+  /// [logEntries] covers the common case; the diagnostic report needs
+  /// [LogInspector.entriesAtLevel] as well, and [registry] is test-only.
+  LogInspector get logInspector => _registry.log;
 
   /// Clears all console logs.
   void clearLogs() => _registry.log.clear();

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -19,61 +19,11 @@ import '../ui/dashboard/dashboard_modal.dart';
 import 'inspector_overlay_manager.dart';
 import 'inspector_registry.dart';
 import 'uncaught_error_handler.dart';
-import '../version.dart';
 
 /// The core entry point for the Flutter Inspector.
 class FlutterInspector {
   /// Package version.
-  static const String version = packageVersion;
-
-  /// Creates a new FlutterInspector instance.
-  ///
-  /// This should typically be instantiated once at app startup and retained
-  /// globally. It maintains its own internal buffers and state.
-  FlutterInspector({
-    this.customTab,
-    this.customTabTitle = 'Custom',
-    this.magicalTapCount = 5,
-    this.showNetworkNotification = false,
-    this.navigatorKey,
-    this.captureUncaughtErrors = false,
-    this.redactSensitiveData = true,
-    this.diagnosticInfoSource,
-    int bufferSize = 500,
-    NetworkNotifier? notifier,
-    List<DatabaseBrowserSource>? databaseSources,
-  }) {
-    _overlayManager = InspectorOverlayManager(
-      onFabTap: (context) => openDashboard(context),
-    );
-    _registry = InspectorRegistry(bufferSize: bufferSize);
-    _uncaughtErrorHandler = UncaughtErrorHandler(onLog: log);
-    if (captureUncaughtErrors) setupErrorHandlers();
-    _navigatorObserver = FlutterInspectorNavigatorObserver(this);
-    _operationLogSource = OperationLogSource(_registry.database);
-    if (databaseSources != null) {
-      _customDatabaseSources.addAll(databaseSources);
-    }
-    if (showNetworkNotification) {
-      final networkNotifier =
-          notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
-      // Wire onAdd only after init() resolves. init() never rejects (it catches
-      // and swallows platform errors internally), so this callback always runs.
-      // Requests that arrive before init completes are not forwarded to the
-      // notifier — which is correct, since _available isn't true until init
-      // succeeds, so showOrUpdate would no-op on them anyway. This just avoids
-      // holding a callback that fires into an uninitialised notifier.
-      networkNotifier.init().then((_) {
-        _registry.network.onAdd = (entry, total) {
-          networkNotifier.showOrUpdate(entry, total);
-        };
-        final entries = _registry.network.entries;
-        if (entries.isNotEmpty) {
-          networkNotifier.showOrUpdate(entries.first, entries.length);
-        }
-      });
-    }
-  }
+  static const String version = '1.4.0';
 
   /// Optional widget for a 5th tab in the dashboard.
   final Widget? customTab;
@@ -156,14 +106,8 @@ class FlutterInspector {
   /// [LogInspector.entriesAtLevel] as well, and [registry] is test-only.
   LogInspector get logInspector => _registry.log;
 
-  /// Clears all console logs.
-  void clearLogs() => _registry.log.clear();
-
   /// Retrieves the current network logs.
   List<NetworkEntry> get networkEntries => _registry.network.entries;
-
-  /// Clears all network logs.
-  void clearNetwork() => _registry.network.clear();
 
   /// The navigator inspector used by [navigatorObserver] to buffer events.
   NavigatorInspector get navigatorInspector => _registry.navigator;
@@ -171,36 +115,66 @@ class FlutterInspector {
   /// Retrieves the current navigator history.
   List<NavigatorEntry> get navigatorEntries => _registry.navigator.entries;
 
-  /// Clears all navigator history.
-  void clearNavigator() => _registry.navigator.clear();
-
   /// Retrieves the current database logs.
   List<DatabaseEntry> get databaseEntries => _registry.database.entries;
-
-  /// Clears all database logs.
-  void clearDatabase() => _registry.database.clear();
-
-  /// Cross-layer merged timeline: reads the four buffers filtered by [sources],
-  /// merged and sorted by timestamp descending (newest first). Defaults to all
-  /// sources. Thin forward to [InspectorRegistry.mergedTimeline].
-  List<TimestampedEntry> mergedTimeline({
-    Set<TimelineSource> sources = const {
-      TimelineSource.log,
-      TimelineSource.network,
-      TimelineSource.nav,
-      TimelineSource.db,
-    },
-  }) => _registry.mergedTimeline(sources: sources);
 
   /// Retrieves the registered database browser sources.
   List<DatabaseBrowserSource> get databaseSources =>
       List.unmodifiable([_operationLogSource, ..._customDatabaseSources]);
 
+  /// Creates a new FlutterInspector instance.
+  ///
+  /// This should typically be instantiated once at app startup and retained
+  /// globally. It maintains its own internal buffers and state.
+  FlutterInspector({
+    this.customTab,
+    this.customTabTitle = 'Custom',
+    this.magicalTapCount = 5,
+    this.showNetworkNotification = false,
+    this.navigatorKey,
+    this.captureUncaughtErrors = false,
+    this.redactSensitiveData = true,
+    this.diagnosticInfoSource,
+    int bufferSize = 500,
+    NetworkNotifier? notifier,
+    List<DatabaseBrowserSource>? databaseSources,
+  }) {
+    _overlayManager = InspectorOverlayManager(
+      onFabTap: (context) => openDashboard(context),
+    );
+    _registry = InspectorRegistry(bufferSize: bufferSize);
+    _uncaughtErrorHandler = UncaughtErrorHandler(onLog: log);
+    if (captureUncaughtErrors) setupErrorHandlers();
+    _navigatorObserver = FlutterInspectorNavigatorObserver(this);
+    _operationLogSource = OperationLogSource(_registry.database);
+    if (databaseSources != null) {
+      _customDatabaseSources.addAll(databaseSources);
+    }
+    if (showNetworkNotification) {
+      final networkNotifier =
+          notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
+      // Wire onAdd only after init() resolves. init() never rejects (it catches
+      // and swallows platform errors internally), so this callback always runs.
+      // Requests that arrive before init completes are not forwarded to the
+      // notifier — which is correct, since _available isn't true until init
+      // succeeds, so showOrUpdate would no-op on them anyway. This just avoids
+      // holding a callback that fires into an uninitialised notifier.
+      networkNotifier.init().then((_) {
+        _registry.network.onAdd = (entry, total) {
+          networkNotifier.showOrUpdate(entry, total);
+        };
+        final entries = _registry.network.entries;
+        if (entries.isNotEmpty) {
+          networkNotifier.showOrUpdate(entries.first, entries.length);
+        }
+      });
+    }
+  }
+
   /// Registers a database browser source.
   void registerDatabaseSource(DatabaseBrowserSource source) {
     _customDatabaseSources.add(source);
   }
-
 
   /// Mounts the FAB overlay onto the screen.
   void attach({required BuildContext context, bool visible = true}) {
@@ -266,6 +240,18 @@ class FlutterInspector {
     );
   }
 
+  /// Cross-layer merged timeline: reads the four buffers filtered by [sources],
+  /// merged and sorted by timestamp descending (newest first). Defaults to all
+  /// sources. Thin forward to [InspectorRegistry.mergedTimeline].
+  List<TimestampedEntry> mergedTimeline({
+    Set<TimelineSource> sources = const {
+      TimelineSource.log,
+      TimelineSource.network,
+      TimelineSource.nav,
+      TimelineSource.db,
+    },
+  }) => _registry.mergedTimeline(sources: sources);
+
   /// Opens the full-screen dashboard modal.
   ///
   /// [initialIndex] selects the starting tab: Console (0), Network (1),
@@ -281,4 +267,16 @@ class FlutterInspector {
     if (context == null) return;
     openDashboard(context, initialIndex: 1);
   }
+
+  /// Clears all console logs.
+  void clearLogs() => _registry.log.clear();
+
+  /// Clears all network logs.
+  void clearNetwork() => _registry.network.clear();
+
+  /// Clears all navigator history.
+  void clearNavigator() => _registry.navigator.clear();
+
+  /// Clears all database logs.
+  void clearDatabase() => _registry.database.clear();
 }

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -55,7 +55,7 @@ class FlutterInspector {
       _customDatabaseSources.addAll(databaseSources);
     }
     if (showNetworkNotification) {
-      _notifier =
+      final networkNotifier =
           notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
       // Wire onAdd only after init() resolves. init() never rejects (it catches
       // and swallows platform errors internally), so this callback always runs.
@@ -63,13 +63,13 @@ class FlutterInspector {
       // notifier — which is correct, since _available isn't true until init
       // succeeds, so showOrUpdate would no-op on them anyway. This just avoids
       // holding a callback that fires into an uninitialised notifier.
-      _notifier!.init().then((_) {
+      networkNotifier.init().then((_) {
         _registry.network.onAdd = (entry, total) {
-          _notifier!.showOrUpdate(entry, total);
+          networkNotifier.showOrUpdate(entry, total);
         };
         final entries = _registry.network.entries;
         if (entries.isNotEmpty) {
-          _notifier!.showOrUpdate(entries.first, entries.length);
+          networkNotifier.showOrUpdate(entries.first, entries.length);
         }
       });
     }
@@ -134,9 +134,6 @@ class FlutterInspector {
   final DiagnosticInfoSource? diagnosticInfoSource;
 
   late final UncaughtErrorHandler _uncaughtErrorHandler;
-
-  NetworkNotifier? _notifier;
-
   late final InspectorRegistry _registry;
   late final FlutterInspectorNavigatorObserver _navigatorObserver;
   late final OperationLogSource _operationLogSource;

--- a/lib/src/models/diagnostic_info.dart
+++ b/lib/src/models/diagnostic_info.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart';
+
+/// Device and app metadata shown in the header of a diagnostic report.
+///
+/// Every field is nullable: the report prints `N/A` for whatever the host does
+/// not supply, so a partially-populated (or entirely absent) source still
+/// produces a complete report.
+@immutable
+class DiagnosticInfo {
+  /// Creates diagnostic info. Any field may be omitted.
+  const DiagnosticInfo({this.appVersion, this.deviceModel, this.osVersion});
+
+  /// Host app version, e.g. `2.3.1+45`.
+  final String? appVersion;
+
+  /// Device model identifier, e.g. `iPhone15,2`.
+  final String? deviceModel;
+
+  /// Operating system and version, e.g. `iOS 17.4`.
+  final String? osVersion;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DiagnosticInfo &&
+        other.appVersion == appVersion &&
+        other.deviceModel == deviceModel &&
+        other.osVersion == osVersion;
+  }
+
+  @override
+  int get hashCode => Object.hash(appVersion, deviceModel, osVersion);
+
+  @override
+  String toString() =>
+      'DiagnosticInfo($appVersion, $deviceModel, $osVersion)';
+}
+
+/// Supplies device and app metadata for diagnostic reports.
+///
+/// This package has zero dependency on `device_info_plus` / `package_info_plus`
+/// (and never touches `dart:io`, keeping the package WASM-compatible). Hosts
+/// that want a populated report header implement this and pass it to
+/// `FlutterInspector(diagnosticInfoSource: ...)`; without one, the header
+/// degrades to `N/A`.
+abstract class DiagnosticInfoSource {
+  /// Collects the current device and app metadata.
+  Future<DiagnosticInfo> collect();
+}

--- a/lib/src/ui/dashboard/dashboard_modal.dart
+++ b/lib/src/ui/dashboard/dashboard_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/flutter_inspector.dart';
+import 'export_report_sheet.dart';
 import 'tabs/console_tab.dart';
 import 'tabs/database_tab.dart';
 import 'tabs/navigator_tab.dart';
@@ -50,6 +51,13 @@ class DashboardModal extends StatelessWidget {
             icon: const Icon(Icons.close),
             onPressed: () => Navigator.of(context).pop(),
           ),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.ios_share),
+              tooltip: 'Export diagnostic report',
+              onPressed: () => ExportReportSheet.show(context, inspector),
+            ),
+          ],
           bottom: PreferredSize(
             preferredSize: const Size.fromHeight(kTextTabBarHeight),
             child: _DashboardTabBar(

--- a/lib/src/ui/dashboard/export_report_sheet.dart
+++ b/lib/src/ui/dashboard/export_report_sheet.dart
@@ -10,9 +10,9 @@ import '../../utils/share_text.dart';
 /// Bottom sheet that composes a diagnostic report and hands it to the share
 /// sheet. Nothing is written to disk.
 class ExportReportSheet extends StatefulWidget {
-  const ExportReportSheet({required this.inspector, super.key});
-
   final FlutterInspector inspector;
+
+  const ExportReportSheet({required this.inspector, super.key});
 
   /// Opens the sheet.
   static Future<void> show(BuildContext context, FlutterInspector inspector) {
@@ -28,16 +28,6 @@ class ExportReportSheet extends StatefulWidget {
 }
 
 class _ExportReportSheetState extends State<ExportReportSheet> {
-  final Set<TimelineSource> _sections = TimelineSource.values.toSet();
-
-  /// Index into [_ranges]. The radios key off the index rather than the
-  /// `Duration?` itself, because `RadioGroup<Duration>` would conflate "All"
-  /// (a deliberate null) with "nothing selected" (also null).
-  int _rangeIndex = 0;
-
-  bool _errorsOnly = false;
-  bool _busy = false;
-
   /// `null` means all time — the same convention the report builder uses.
   static const _ranges = <(String, Duration?)>[
     ('Last 5m', Duration(minutes: 5)),
@@ -51,6 +41,14 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
     TimelineSource.nav: 'Navigation',
     TimelineSource.db: 'Database',
   };
+
+  final Set<TimelineSource> _sections = TimelineSource.values.toSet();
+  /// Index into [_ranges]. The radios key off the index rather than the
+  /// `Duration?` itself, because `RadioGroup<Duration>` would conflate "All"
+  /// (a deliberate null) with "nothing selected" (also null).
+  int _rangeIndex = 0;
+  bool _errorsOnly = false;
+  bool _busy = false;
 
   Future<void> _export() async {
     setState(() => _busy = true);
@@ -192,9 +190,10 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
 }
 
 class _SectionLabel extends StatelessWidget {
-  const _SectionLabel(this.text);
 
   final String text;
+
+  const _SectionLabel(this.text);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/ui/dashboard/export_report_sheet.dart
+++ b/lib/src/ui/dashboard/export_report_sheet.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+
+import '../../core/flutter_inspector.dart';
+import '../../models/timestamped_entry.dart';
+import '../../utils/diagnostic_report.dart';
+import '../../utils/share_text.dart';
+
+/// Bottom sheet that composes a diagnostic report and hands it to the share
+/// sheet. Nothing is written to disk.
+class ExportReportSheet extends StatefulWidget {
+  const ExportReportSheet({required this.inspector, super.key});
+
+  final FlutterInspector inspector;
+
+  /// Opens the sheet.
+  static Future<void> show(BuildContext context, FlutterInspector inspector) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => ExportReportSheet(inspector: inspector),
+    );
+  }
+
+  @override
+  State<ExportReportSheet> createState() => _ExportReportSheetState();
+}
+
+class _ExportReportSheetState extends State<ExportReportSheet> {
+  final Set<TimelineSource> _sections = TimelineSource.values.toSet();
+
+  /// Index into [_ranges]. The radios key off the index rather than the
+  /// `Duration?` itself, because `RadioGroup<Duration>` would conflate "All"
+  /// (a deliberate null) with "nothing selected" (also null).
+  int _rangeIndex = 0;
+
+  bool _errorsOnly = false;
+  bool _busy = false;
+
+  /// `null` means all time — the same convention the report builder uses.
+  static const _ranges = <(String, Duration?)>[
+    ('Last 5m', Duration(minutes: 5)),
+    ('Last 1h', Duration(hours: 1)),
+    ('All', null),
+  ];
+
+  static const _sourceLabels = <TimelineSource, String>{
+    TimelineSource.log: 'Logs',
+    TimelineSource.network: 'Network',
+    TimelineSource.nav: 'Navigation',
+    TimelineSource.db: 'Database',
+  };
+
+  Future<void> _export() async {
+    setState(() => _busy = true);
+
+    final inspector = widget.inspector;
+    // The host's source is async; resolving it here keeps the builder pure.
+    final info = await inspector.diagnosticInfoSource?.collect();
+
+    final report = buildDiagnosticReport(
+      logInspector: inspector.logInspector,
+      networkEntries: inspector.networkEntries,
+      navigatorEntries: inspector.navigatorEntries,
+      databaseEntries: inspector.databaseEntries,
+      now: DateTime.now(),
+      info: info,
+      timeRange: _ranges[_rangeIndex].$2,
+      sections: _sections,
+      errorsOnly: _errorsOnly,
+      redact: inspector.redactSensitiveData,
+    );
+
+    await shareText(report);
+
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+              child: Text(
+                'Export diagnostic report',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+            ),
+
+            const _SectionLabel('Include'),
+            for (final source in TimelineSource.values)
+              CheckboxListTile(
+                dense: true,
+                title: Text(_sourceLabels[source]!),
+                value: _sections.contains(source),
+                onChanged: (checked) => setState(() {
+                  if (checked ?? false) {
+                    _sections.add(source);
+                  } else {
+                    _sections.remove(source);
+                  }
+                }),
+              ),
+
+            const _SectionLabel('Time range'),
+            RadioGroup<int>(
+              groupValue: _rangeIndex,
+              onChanged: (index) =>
+                  setState(() => _rangeIndex = index ?? _rangeIndex),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (var i = 0; i < _ranges.length; i++)
+                    RadioListTile<int>(
+                      dense: true,
+                      title: Text(_ranges[i].$1),
+                      value: i,
+                    ),
+                ],
+              ),
+            ),
+
+            CheckboxListTile(
+              dense: true,
+              title: const Text('Errors & warnings only'),
+              subtitle: const Text('Applies to the log section'),
+              value: _errorsOnly,
+              onChanged: (checked) =>
+                  setState(() => _errorsOnly = checked ?? false),
+            ),
+
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  icon: const Icon(Icons.share),
+                  label: const Text('Share report'),
+                  // Guards against double-taps while the share sheet opens.
+                  onPressed: _busy || _sections.isEmpty ? null : _export,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/dashboard/export_report_sheet.dart
+++ b/lib/src/ui/dashboard/export_report_sheet.dart
@@ -69,6 +69,7 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
         // the user the report they just waited for.
         info = null;
       }
+      if (!mounted) return;
 
       final report = buildDiagnosticReport(
         logInspector: inspector.logInspector,
@@ -86,15 +87,18 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
       try {
         await shareText(report);
       } catch (_) {
+        if (!mounted) return;
         // Fallback to clipboard when the platform has no share sheet.
         try {
           await Clipboard.setData(ClipboardData(text: report));
+          if (!mounted) return;
           messenger.showSnackBar(
             const SnackBar(
               content: Text('Share unavailable — copied to clipboard'),
             ),
           );
         } catch (_) {
+          if (!mounted) return;
           // Both paths out failed. Keep the sheet open so the user can retry
           // rather than silently swallowing the report they just waited for.
           messenger.showSnackBar(
@@ -104,6 +108,7 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
         }
       }
 
+      if (!mounted) return;
       navigator.pop();
     } finally {
       // Without this the button stays disabled forever on any failure.
@@ -143,21 +148,19 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
               ),
 
             const _SectionLabel('Time range'),
-            RadioGroup<int>(
-              groupValue: _rangeIndex,
-              onChanged: (index) =>
-                  setState(() => _rangeIndex = index ?? _rangeIndex),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  for (var i = 0; i < _ranges.length; i++)
-                    RadioListTile<int>(
-                      dense: true,
-                      title: Text(_ranges[i].$1),
-                      value: i,
-                    ),
-                ],
-              ),
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (var i = 0; i < _ranges.length; i++)
+                  RadioListTile<int>(
+                    dense: true,
+                    title: Text(_ranges[i].$1),
+                    value: i,
+                    groupValue: _rangeIndex,
+                    onChanged: (index) =>
+                        setState(() => _rangeIndex = index ?? _rangeIndex),
+                  ),
+              ],
             ),
 
             CheckboxListTile(

--- a/lib/src/ui/dashboard/export_report_sheet.dart
+++ b/lib/src/ui/dashboard/export_report_sheet.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../core/flutter_inspector.dart';
+import '../../models/diagnostic_info.dart';
 import '../../models/timestamped_entry.dart';
 import '../../utils/diagnostic_report.dart';
 import '../../utils/share_text.dart';
@@ -52,27 +54,61 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
 
   Future<void> _export() async {
     setState(() => _busy = true);
-
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
     final inspector = widget.inspector;
-    // The host's source is async; resolving it here keeps the builder pure.
-    final info = await inspector.diagnosticInfoSource?.collect();
 
-    final report = buildDiagnosticReport(
-      logInspector: inspector.logInspector,
-      networkEntries: inspector.networkEntries,
-      navigatorEntries: inspector.navigatorEntries,
-      databaseEntries: inspector.databaseEntries,
-      now: DateTime.now(),
-      info: info,
-      timeRange: _ranges[_rangeIndex].$2,
-      sections: _sections,
-      errorsOnly: _errorsOnly,
-      redact: inspector.redactSensitiveData,
-    );
+    try {
+      // The host's source is async, and third-party — it may well throw.
+      // Resolving it here also keeps the report builder pure and synchronous.
+      DiagnosticInfo? info;
+      try {
+        info = await inspector.diagnosticInfoSource?.collect();
+      } catch (_) {
+        // A broken host source degrades the header to N/A; it must never cost
+        // the user the report they just waited for.
+        info = null;
+      }
 
-    await shareText(report);
+      final report = buildDiagnosticReport(
+        logInspector: inspector.logInspector,
+        networkEntries: inspector.networkEntries,
+        navigatorEntries: inspector.navigatorEntries,
+        databaseEntries: inspector.databaseEntries,
+        now: DateTime.now(),
+        info: info,
+        timeRange: _ranges[_rangeIndex].$2,
+        sections: _sections,
+        errorsOnly: _errorsOnly,
+        redact: inspector.redactSensitiveData,
+      );
 
-    if (mounted) Navigator.of(context).pop();
+      try {
+        await shareText(report);
+      } catch (_) {
+        // Fallback to clipboard when the platform has no share sheet.
+        try {
+          await Clipboard.setData(ClipboardData(text: report));
+          messenger.showSnackBar(
+            const SnackBar(
+              content: Text('Share unavailable — copied to clipboard'),
+            ),
+          );
+        } catch (_) {
+          // Both paths out failed. Keep the sheet open so the user can retry
+          // rather than silently swallowing the report they just waited for.
+          messenger.showSnackBar(
+            const SnackBar(content: Text('Export failed — please try again')),
+          );
+          return;
+        }
+      }
+
+      navigator.pop();
+    } finally {
+      // Without this the button stays disabled forever on any failure.
+      if (mounted) setState(() => _busy = false);
+    }
   }
 
   @override

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -157,7 +157,21 @@ void _writeSection<T extends TimestampedEntry>(
   }
 }
 
-String _fenced(String body) => '```\n${body.trimRight()}\n```\n';
+/// Wraps [body] in a fence long enough to survive its own content.
+///
+/// A log message or response body can itself contain a ``` fence (LLM output,
+/// CMS content, a pasted snippet). With a fixed 3-backtick fence that closes
+/// the block early and leaks the payload into the rendered Markdown — and an
+/// odd number of fences swallows every heading that follows. CommonMark says
+/// the fence must be longer than any backtick run inside it, so measure first.
+String _fenced(String body) {
+  final text = body.trimRight();
+  final longest = RegExp('`+')
+      .allMatches(text)
+      .fold<int>(0, (max, m) => m[0]!.length > max ? m[0]!.length : max);
+  final fence = '`' * (longest < 3 ? 3 : longest + 1);
+  return '$fence\n$text\n$fence\n';
+}
 
 String _orNA(String? value) =>
     (value == null || value.isEmpty) ? 'N/A' : value;

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -55,7 +55,7 @@ String buildDiagnosticReport({
     ..writeln()
     ..writeln('| Field | Value |')
     ..writeln('| --- | --- |')
-    ..writeln('| Generated | ${now.toIso8601String()} |')
+    ..writeln('| Generated | ${now.toIso8601String()} (${_formatOffset(now)}) |')
     ..writeln('| Package | flutter_inspector_kit $packageVersion |')
     ..writeln('| Redaction | ${redact ? 'enabled' : 'disabled'} |')
     ..writeln('| Time range | ${_formatRange(timeRange)} |')
@@ -185,4 +185,16 @@ String _formatRange(Duration? range) {
   if (range == null) return 'all';
   if (range.inHours >= 1) return 'last ${range.inHours}h';
   return 'last ${range.inMinutes}m';
+}
+
+/// The device timezone as `UTC±HH:MM`, anchoring every local timestamp in the
+/// report so a recipient in another zone can line events up. Dart omits the
+/// offset from a local `toIso8601String()`, and the per-event `displayTime`
+/// carries no zone either, so without this the whole report is unanchored.
+String _formatOffset(DateTime time) {
+  final offset = time.timeZoneOffset;
+  final sign = offset.isNegative ? '-' : '+';
+  final hh = offset.inHours.abs().toString().padLeft(2, '0');
+  final mm = (offset.inMinutes.abs() % 60).toString().padLeft(2, '0');
+  return 'UTC$sign$hh:$mm';
 }

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -6,10 +6,13 @@ import '../models/log_entry.dart';
 import '../models/log_level.dart';
 import '../models/navigator_entry.dart';
 import '../models/network_entry.dart';
+import 'dart:convert';
+
 import '../models/timestamped_entry.dart';
 import '../version.dart';
 import 'log_formatters.dart';
 import 'network_formatters.dart';
+import 'redaction.dart';
 
 /// Builds a Markdown diagnostic report for a bug report or issue tracker.
 ///
@@ -48,7 +51,7 @@ String buildDiagnosticReport({
 }) {
   final cutoff = timeRange == null ? null : now.subtract(timeRange);
   bool inWindow(TimestampedEntry e) =>
-      cutoff == null || e.timestamp.isAfter(cutoff);
+      cutoff == null || !e.timestamp.isBefore(cutoff);
 
   final b = StringBuffer()
     ..writeln('# Diagnostic Report')
@@ -126,9 +129,15 @@ String buildDiagnosticReport({
       b,
       'Database',
       databaseEntries.where(inWindow),
-      (e) =>
-          '- `${e.displayTime}` ${e.operation.name} `${e.tableName}`'
-          '${e.affectedRows == null ? '' : ' (${e.affectedRows} rows)'}',
+      (e) {
+        var row = '- `${e.displayTime}` ${e.operation.name} `${e.tableName}`'
+            '${e.affectedRows == null ? '' : ' (${e.affectedRows} rows)'}';
+        if (e.data != null) {
+          final payload = redact ? redactHeaders(e.data!) : e.data!;
+          row += '\n${_fenced(const JsonEncoder.withIndent('  ').convert(payload))}';
+        }
+        return row;
+      },
     );
   }
 

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -1,0 +1,174 @@
+import '../inspectors/log_inspector.dart';
+import '../inspectors/navigator_stack_resolver.dart';
+import '../models/database_entry.dart';
+import '../models/diagnostic_info.dart';
+import '../models/log_entry.dart';
+import '../models/log_level.dart';
+import '../models/navigator_entry.dart';
+import '../models/network_entry.dart';
+import '../models/timestamped_entry.dart';
+import '../version.dart';
+import 'log_formatters.dart';
+import 'network_formatters.dart';
+
+/// Builds a Markdown diagnostic report for a bug report or issue tracker.
+///
+/// Pure and synchronous: no Flutter widgets, no `BuildContext`, no `dart:io`,
+/// and it writes nothing to disk. The caller resolves [info] (async on the host
+/// side) and passes the result in.
+///
+/// Three independent filter dimensions:
+/// * [timeRange] — how far back to look. **`null` means all time**, which is
+///   why this is a `Duration?` and not an enum: the "all" case would otherwise
+///   be a special branch in every switch.
+/// * [sections] — which sources to include. Unselected sources are absent
+///   entirely, not rendered empty.
+/// * [errorsOnly] — restrict the *log* section to error/warning. Off by
+///   default: a report whose whole point is "what happened around the error"
+///   is worth little once the leading info/debug breadcrumbs are stripped.
+///
+/// [redact] should be the host's `FlutterInspector.redactSensitiveData`, so the
+/// report masks exactly what a single-entry share masks — no more, no less.
+String buildDiagnosticReport({
+  required LogInspector logInspector,
+  required List<NetworkEntry> networkEntries,
+  required List<NavigatorEntry> navigatorEntries,
+  required List<DatabaseEntry> databaseEntries,
+  required DateTime now,
+  DiagnosticInfo? info,
+  Duration? timeRange,
+  Set<TimelineSource> sections = const {
+    TimelineSource.log,
+    TimelineSource.network,
+    TimelineSource.nav,
+    TimelineSource.db,
+  },
+  bool errorsOnly = false,
+  bool redact = true,
+}) {
+  final cutoff = timeRange == null ? null : now.subtract(timeRange);
+  bool inWindow(TimestampedEntry e) =>
+      cutoff == null || e.timestamp.isAfter(cutoff);
+
+  final b = StringBuffer()
+    ..writeln('# Diagnostic Report')
+    ..writeln()
+    ..writeln('| Field | Value |')
+    ..writeln('| --- | --- |')
+    ..writeln('| Generated | ${now.toIso8601String()} |')
+    ..writeln('| Package | flutter_inspector_kit $packageVersion |')
+    ..writeln('| Redaction | ${redact ? 'enabled' : 'disabled'} |')
+    ..writeln('| Time range | ${_formatRange(timeRange)} |')
+    ..writeln('| App version | ${_orNA(info?.appVersion)} |')
+    ..writeln('| Device | ${_orNA(info?.deviceModel)} |')
+    ..writeln('| OS | ${_orNA(info?.osVersion)} |');
+
+  if (sections.contains(TimelineSource.log)) {
+    // errorsOnly reuses entriesAtLevel(), which returns exactly one level, so
+    // the two levels are merged and re-sorted back into newest-first order.
+    final logs = errorsOnly
+        ? (<LogEntry>[
+            ...logInspector.entriesAtLevel(LogLevel.error),
+            ...logInspector.entriesAtLevel(LogLevel.warning),
+          ]..sort((a, b) => b.timestamp.compareTo(a.timestamp)))
+        : logInspector.entries;
+
+    _writeSection(
+      b,
+      errorsOnly ? 'Logs (errors & warnings only)' : 'Logs',
+      logs.where(inWindow),
+      (e) => _fenced(buildLogPlainText(e)),
+    );
+  }
+
+  if (sections.contains(TimelineSource.network)) {
+    _writeSection(
+      b,
+      'Network',
+      networkEntries.where(inWindow),
+      (e) => _fenced(buildPlainText(e, redact: redact)),
+    );
+  }
+
+  if (sections.contains(TimelineSource.nav)) {
+    b
+      ..writeln()
+      ..writeln('## Navigation')
+      ..writeln()
+      ..writeln('### Current route stack');
+
+    // The resolver replays push/pop/replace/remove from the *full* buffer.
+    // Feeding it the time-windowed list would pop routes whose push fell
+    // outside the window and derive a wrong stack — so this deliberately
+    // ignores `inWindow`.
+    final stack = NavigatorStackResolver().resolve(navigatorEntries);
+    b.writeln();
+    if (stack.isEmpty) {
+      b.writeln('(none)');
+    } else {
+      for (var i = 0; i < stack.length; i++) {
+        final suffix = i == 0 ? ' ← current' : '';
+        b.writeln('${i + 1}. ${_routeLabel(stack[i])}$suffix');
+      }
+    }
+
+    _writeSection(
+      b,
+      'Navigation events',
+      navigatorEntries.where(inWindow),
+      (e) => '- `${e.displayTime}` ${e.action.name} ${_routeLabel(e)}',
+      level: '###',
+    );
+  }
+
+  if (sections.contains(TimelineSource.db)) {
+    _writeSection(
+      b,
+      'Database',
+      databaseEntries.where(inWindow),
+      (e) =>
+          '- `${e.displayTime}` ${e.operation.name} `${e.tableName}`'
+          '${e.affectedRows == null ? '' : ' (${e.affectedRows} rows)'}',
+    );
+  }
+
+  return b.toString();
+}
+
+void _writeSection<T extends TimestampedEntry>(
+  StringBuffer b,
+  String title,
+  Iterable<T> entries,
+  String Function(T) render, {
+  String level = '##',
+}) {
+  b
+    ..writeln()
+    ..writeln('$level $title')
+    ..writeln();
+
+  final visible = entries.toList();
+  if (visible.isEmpty) {
+    b.writeln('(none)');
+    return;
+  }
+  for (final e in visible) {
+    b.writeln(render(e));
+  }
+}
+
+String _fenced(String body) => '```\n${body.trimRight()}\n```\n';
+
+String _orNA(String? value) =>
+    (value == null || value.isEmpty) ? 'N/A' : value;
+
+String _routeLabel(NavigatorEntry e) {
+  final name = e.routeName ?? e.widgetType?.toString() ?? '(unnamed)';
+  return '`$name`';
+}
+
+String _formatRange(Duration? range) {
+  if (range == null) return 'all';
+  if (range.inHours >= 1) return 'last ${range.inHours}h';
+  return 'last ${range.inMinutes}m';
+}

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,1 @@
+const String packageVersion = '1.4.0';

--- a/test/core/flutter_inspector_test.dart
+++ b/test/core/flutter_inspector_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/database_browser_source.dart';
 import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/models/diagnostic_info.dart';
 import 'package:flutter_inspector_kit/src/models/log_level.dart';
 import 'package:flutter_inspector_kit/src/models/network_entry.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -108,6 +109,26 @@ void main() {
       },
     );
   });
+
+  group('Diagnostic Info Source API', () {
+    test('diagnosticInfoSource defaults to null', () {
+      expect(FlutterInspector(bufferSize: 10).diagnosticInfoSource, isNull);
+    });
+
+    test('an injected source is retained and collectable', () async {
+      final source = _FakeDiagnosticInfoSource();
+      final inspector = FlutterInspector(
+        bufferSize: 10,
+        diagnosticInfoSource: source,
+      );
+
+      expect(inspector.diagnosticInfoSource, same(source));
+      expect(
+        await inspector.diagnosticInfoSource!.collect(),
+        const DiagnosticInfo(appVersion: '2.3.1+45', osVersion: 'iOS 17.4'),
+      );
+    });
+  });
 }
 
 class FakeDatabaseBrowserSource extends DatabaseBrowserSource {
@@ -125,4 +146,10 @@ class FakeDatabaseBrowserSource extends DatabaseBrowserSource {
   }) async {
     return const DatabaseTablePage(columns: [], rows: []);
   }
+}
+
+class _FakeDiagnosticInfoSource implements DiagnosticInfoSource {
+  @override
+  Future<DiagnosticInfo> collect() async =>
+      const DiagnosticInfo(appVersion: '2.3.1+45', osVersion: 'iOS 17.4');
 }

--- a/test/flutter_inspector_test.dart
+++ b/test/flutter_inspector_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+import 'package:flutter_inspector_kit/src/version.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -9,7 +10,7 @@ void main() {
     });
 
     test('exposes the package version', () {
-      expect(FlutterInspector.version, '1.1.0');
+      expect(FlutterInspector.version, packageVersion);
     });
   });
 }

--- a/test/models/diagnostic_info_test.dart
+++ b/test/models/diagnostic_info_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_inspector_kit/src/models/diagnostic_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DiagnosticInfo', () {
+    test('can be constructed with no fields at all', () {
+      const info = DiagnosticInfo();
+      expect(info.appVersion, isNull);
+      expect(info.deviceModel, isNull);
+      expect(info.osVersion, isNull);
+    });
+
+    test('holds the values it was given', () {
+      const info = DiagnosticInfo(
+        appVersion: '2.3.1+45',
+        deviceModel: 'iPhone15,2',
+        osVersion: 'iOS 17.4',
+      );
+      expect(info.appVersion, '2.3.1+45');
+      expect(info.deviceModel, 'iPhone15,2');
+      expect(info.osVersion, 'iOS 17.4');
+    });
+
+    test('has value equality', () {
+      const a = DiagnosticInfo(appVersion: '1.0.0', deviceModel: 'Pixel 8');
+      const b = DiagnosticInfo(appVersion: '1.0.0', deviceModel: 'Pixel 8');
+      const different = DiagnosticInfo(appVersion: '1.0.1', deviceModel: 'Pixel 8');
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(different)));
+    });
+
+    test('a partially populated instance differs from an empty one', () {
+      const empty = DiagnosticInfo();
+      const partial = DiagnosticInfo(osVersion: 'Android 14');
+
+      expect(partial, isNot(equals(empty)));
+    });
+  });
+
+  group('DiagnosticInfoSource', () {
+    test('a host implementation supplies info through collect()', () async {
+      final source = _FakeDiagnosticInfoSource();
+
+      expect(
+        await source.collect(),
+        const DiagnosticInfo(
+          appVersion: '2.3.1+45',
+          deviceModel: 'iPhone15,2',
+          osVersion: 'iOS 17.4',
+        ),
+      );
+    });
+  });
+}
+
+class _FakeDiagnosticInfoSource implements DiagnosticInfoSource {
+  @override
+  Future<DiagnosticInfo> collect() async => const DiagnosticInfo(
+    appVersion: '2.3.1+45',
+    deviceModel: 'iPhone15,2',
+    osVersion: 'iOS 17.4',
+  );
+}

--- a/test/ui/export_report_sheet_test.dart
+++ b/test/ui/export_report_sheet_test.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/diagnostic_info.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/dashboard_modal.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/export_report_sheet.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The channel share_plus 13.x talks to, read straight out of
+/// `share_plus_platform_interface/lib/method_channel/method_channel_share.dart`
+/// (where it is annotated `@visibleForTesting`).
+const _shareChannel = MethodChannel('dev.fluttercommunity.plus/share');
+
+void main() {
+  late List<String> shared;
+
+  setUp(() => shared = []);
+
+  /// Captures whatever text share_plus is asked to share.
+  void mockShareSheet(WidgetTester tester) {
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      _shareChannel,
+      (call) async {
+        if (call.method == 'share') {
+          shared.add((call.arguments as Map)['text'] as String);
+        }
+        return 'dev.fluttercommunity.plus/share/success';
+      },
+    );
+  }
+
+  Future<void> pumpSheet(WidgetTester tester, FlutterInspector inspector) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => ExportReportSheet.show(context, inspector),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('ExportReportSheet (AC-19, AC-20)', () {
+    testWidgets('offers all three filter dimensions', (tester) async {
+      await pumpSheet(tester, FlutterInspector());
+
+      // Sources.
+      expect(find.text('Logs'), findsOneWidget);
+      expect(find.text('Network'), findsOneWidget);
+      expect(find.text('Navigation'), findsOneWidget);
+      expect(find.text('Database'), findsOneWidget);
+
+      // Time range.
+      expect(find.text('Last 5m'), findsOneWidget);
+      expect(find.text('Last 1h'), findsOneWidget);
+      expect(find.text('All'), findsOneWidget);
+
+      // errors-only.
+      expect(find.text('Errors & warnings only'), findsOneWidget);
+    });
+
+    testWidgets('errors-only is off by default', (tester) async {
+      await pumpSheet(tester, FlutterInspector());
+
+      final checkbox = tester.widget<CheckboxListTile>(
+        find.ancestor(
+          of: find.text('Errors & warnings only'),
+          matching: find.byType(CheckboxListTile),
+        ),
+      );
+      expect(checkbox.value, isFalse);
+    });
+
+    testWidgets('sharing hands the report to the platform share sheet once',
+        (tester) async {
+      mockShareSheet(tester);
+      final inspector = FlutterInspector()..log('hello from the log');
+
+      await pumpSheet(tester, inspector);
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      expect(shared, hasLength(1));
+      expect(shared.single, contains('# Diagnostic Report'));
+      expect(shared.single, contains('hello from the log'));
+      // Sheet closed after sharing.
+      expect(find.text('Share report'), findsNothing);
+    });
+
+    testWidgets('unchecking a source drops it from the shared report',
+        (tester) async {
+      mockShareSheet(tester);
+      final inspector = FlutterInspector()..log('log line');
+
+      await pumpSheet(tester, inspector);
+      await tester.tap(find.text('Network'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      expect(shared.single, isNot(contains('## Network')));
+      expect(shared.single, contains('## Logs'));
+    });
+
+    testWidgets('errors-only strips info logs from the shared report',
+        (tester) async {
+      mockShareSheet(tester);
+      final inspector = FlutterInspector()
+        ..log('just-fyi')
+        ..log('boom', level: LogLevel.error);
+
+      await pumpSheet(tester, inspector);
+      await tester.tap(find.text('Errors & warnings only'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      expect(shared.single, contains('boom'));
+      expect(shared.single, isNot(contains('just-fyi')));
+    });
+
+    testWidgets('defaults to the last-5m window', (tester) async {
+      mockShareSheet(tester);
+      await pumpSheet(tester, FlutterInspector());
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      expect(shared.single, contains('| Time range | last 5m |'));
+    });
+
+    testWidgets('picking a different time range changes the report window',
+        (tester) async {
+      mockShareSheet(tester);
+      // An old log falls outside the default 5m window but inside "All".
+      final inspector = FlutterInspector();
+      inspector.registry.log.add(
+        LogEntry(
+          message: 'ancient-history',
+          timestamp: DateTime.now().subtract(const Duration(hours: 3)),
+        ),
+      );
+
+      await pumpSheet(tester, inspector);
+      await tester.tap(find.text('All'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      expect(shared.single, contains('| Time range | all |'));
+      expect(shared.single, contains('ancient-history'));
+    });
+
+    testWidgets('the report inherits the host redaction setting', (tester) async {
+      mockShareSheet(tester);
+      await pumpSheet(tester, FlutterInspector(redactSensitiveData: false));
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      expect(shared.single, contains('| Redaction | disabled |'));
+    });
+
+    testWidgets('an injected DiagnosticInfoSource populates the header',
+        (tester) async {
+      mockShareSheet(tester);
+      await pumpSheet(
+        tester,
+        FlutterInspector(diagnosticInfoSource: _FakeSource()),
+      );
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      expect(shared.single, contains('| Device | Pixel 8 |'));
+    });
+
+    testWidgets('sharing is disabled when no source is selected', (tester) async {
+      await pumpSheet(tester, FlutterInspector());
+
+      for (final source in ['Logs', 'Network', 'Navigation', 'Database']) {
+        await tester.tap(find.text(source));
+        await tester.pumpAndSettle();
+      }
+
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNull);
+    });
+  });
+
+  group('DashboardModal export action (AC-19)', () {
+    testWidgets('the AppBar exposes an export action that opens the sheet',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: DashboardModal(inspector: FlutterInspector())),
+      );
+
+      expect(find.byIcon(Icons.ios_share), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.ios_share));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Export diagnostic report'), findsOneWidget);
+      expect(find.text('Share report'), findsOneWidget);
+    });
+  });
+}
+
+class _FakeSource implements DiagnosticInfoSource {
+  @override
+  Future<DiagnosticInfo> collect() async =>
+      const DiagnosticInfo(deviceModel: 'Pixel 8');
+}

--- a/test/ui/export_report_sheet_test.dart
+++ b/test/ui/export_report_sheet_test.dart
@@ -180,6 +180,79 @@ void main() {
       expect(shared.single, contains('| Device | Pixel 8 |'));
     });
 
+    testWidgets(
+      'when the share sheet is unavailable, the report falls back to the '
+      'clipboard instead of being lost',
+      (tester) async {
+        // Real trigger: web without navigator.share, or desktop.
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          _shareChannel,
+          (call) async => throw PlatformException(code: 'unavailable'),
+        );
+        String? clipboard;
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          (call) async {
+            if (call.method == 'Clipboard.setData') {
+              clipboard = (call.arguments as Map)['text'] as String?;
+            }
+            return null;
+          },
+        );
+
+        await pumpSheet(tester, FlutterInspector()..log('needle'));
+        await tester.tap(find.text('Share report'));
+        await tester.pumpAndSettle();
+
+        expect(clipboard, isNotNull);
+        expect(clipboard, contains('# Diagnostic Report'));
+        expect(clipboard, contains('needle'));
+        expect(find.text('Share unavailable — copied to clipboard'),
+            findsOneWidget);
+      },
+    );
+
+    testWidgets('a throwing DiagnosticInfoSource degrades to N/A, not a lost report',
+        (tester) async {
+      mockShareSheet(tester);
+
+      await pumpSheet(tester, FlutterInspector(diagnosticInfoSource: _BrokenSource()));
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      expect(shared, hasLength(1));
+      expect(shared.single, contains('| Device | N/A |'));
+    });
+
+    testWidgets('a failed share does not brick the button', (tester) async {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        _shareChannel,
+        (call) async => throw PlatformException(code: 'unavailable'),
+      );
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          // Fail ONLY the clipboard — this channel also carries framework
+          // calls (SystemChrome), and blanket-throwing breaks the test harness
+          // itself rather than the code under test.
+          if (call.method == 'Clipboard.setData') {
+            throw PlatformException(code: 'nope');
+          }
+          return null;
+        },
+      );
+
+      await pumpSheet(tester, FlutterInspector());
+      await tester.tap(find.text('Share report'));
+      await tester.pumpAndSettle();
+
+      // Both ways out failed, so the sheet stays open — but the user must be
+      // able to retry: _busy has to have been reset.
+      expect(find.text('Export failed — please try again'), findsOneWidget);
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNotNull, reason: 'button bricked by _busy');
+    });
+
     testWidgets('sharing is disabled when no source is selected', (tester) async {
       await pumpSheet(tester, FlutterInspector());
 
@@ -215,4 +288,10 @@ class _FakeSource implements DiagnosticInfoSource {
   @override
   Future<DiagnosticInfo> collect() async =>
       const DiagnosticInfo(deviceModel: 'Pixel 8');
+}
+
+/// A host source that throws — third-party code, so this is not hypothetical.
+class _BrokenSource implements DiagnosticInfoSource {
+  @override
+  Future<DiagnosticInfo> collect() async => throw StateError('host blew up');
 }

--- a/test/utils/diagnostic_report_test.dart
+++ b/test/utils/diagnostic_report_test.dart
@@ -294,6 +294,9 @@ void main() {
 
         // The event list itself IS time-windowed: only the pop is recent.
         expect(report, contains('### Navigation events'));
+        expect(report, isNot(contains('push `/detail`')));
+        expect(report, isNot(contains('push `/home`')));
+        expect(report, contains('pop `/detail`'));
       },
     );
   });

--- a/test/utils/diagnostic_report_test.dart
+++ b/test/utils/diagnostic_report_test.dart
@@ -41,6 +41,26 @@ String _report({
   );
 }
 
+/// Walks [markdown] the way CommonMark does: a fence line only *closes* a block
+/// if it is at least as long as the fence that opened it. Counting fence lines
+/// and checking parity would be wrong — a 3-backtick line sitting inside a
+/// 4-backtick block is just content.
+bool _fencesBalanced(String markdown) {
+  int? openLength;
+  for (final line in markdown.split('\n')) {
+    final match = RegExp(r'^\s{0,3}(`{3,})\s*$').firstMatch(line);
+    if (match == null) continue;
+
+    final length = match[1]!.length;
+    if (openLength == null) {
+      openLength = length;
+    } else if (length >= openLength) {
+      openLength = null;
+    }
+  }
+  return openLength == null;
+}
+
 void main() {
   group('header (AC-2, AC-3, AC-4, AC-5, AC-17)', () {
     test('prints the package version from the single source of truth', () {
@@ -264,18 +284,84 @@ void main() {
     );
   });
 
+  group('markdown integrity: payloads that contain their own fences', () {
+    // The whole point of this feature is pasting the report into a GitHub or
+    // Jira issue. A payload carrying its own ``` (LLM output, CMS content, a
+    // pasted snippet) must not be able to break out of its code block.
+
+    test('a log message containing a fenced block stays inside its block', () {
+      final report = _report(
+        logInspector: LogInspector()
+          ..add(LogEntry(
+            message: 'llm replied:\n```\nprint("hi");\n```\ndone',
+            timestamp: _minutesAgo(1),
+          )),
+        sections: {TimelineSource.log},
+      );
+
+      // The outer fence must outrun the payload's own 3-backtick run.
+      expect(report, contains('````'));
+      expect(report, contains('print("hi");'));
+    });
+
+    test('an unbalanced fence does not swallow the sections that follow', () {
+      final report = _report(
+        logInspector: LogInspector()
+          // A truncated LLM response: one lone opening fence, never closed.
+          ..add(LogEntry(
+            message: 'output was cut off:\n```\nvoid main() {}',
+            timestamp: _minutesAgo(1),
+          )),
+        db: [
+          DatabaseEntry(
+            operation: DatabaseOperation.insert,
+            tableName: 'users',
+            timestamp: _minutesAgo(1),
+          ),
+        ],
+        sections: {TimelineSource.log, TimelineSource.db},
+      );
+
+      // With a fixed 3-backtick fence, the payload's stray fence flips parity
+      // and everything after it is eaten — headings included.
+      expect(report, contains('## Database'));
+      expect(report, contains('users'));
+      expect(_fencesBalanced(report), isTrue, reason: 'a fence was left open');
+    });
+
+    test('inline backticks are harmless and need no wider fence', () {
+      final report = _report(
+        logInspector: LogInspector()
+          ..add(LogEntry(
+            message: 'the `id` field was null',
+            timestamp: _minutesAgo(1),
+          )),
+        sections: {TimelineSource.log},
+      );
+
+      expect(report, contains('the `id` field was null'));
+      expect(report, isNot(contains('````')));
+    });
+  });
+
   group('errors-only (AC-10, AC-11, AC-12, AC-13)', () {
+    // The warning is deliberately NEWER than the error. errors-only merges two
+    // entriesAtLevel() calls, each newest-first on its own; concatenating them
+    // yields [error, warning], which is only correctly ordered if the merge
+    // re-sorts. Put the error first and the sort becomes a no-op — the test
+    // would pass with the sort deleted, which is exactly the identity-assertion
+    // trap that let FlutterInspector.version rot for three releases.
     LogInspector mixedLevels() {
       return LogInspector()
         ..add(LogEntry(
           message: 'boom',
           level: LogLevel.error,
-          timestamp: _minutesAgo(1),
+          timestamp: _minutesAgo(5),
         ))
         ..add(LogEntry(
           message: 'careful',
           level: LogLevel.warning,
-          timestamp: _minutesAgo(2),
+          timestamp: _minutesAgo(1),
         ))
         ..add(LogEntry(
           message: 'just-fyi',
@@ -311,7 +397,10 @@ void main() {
     test('on: the surviving logs stay newest-first after the level merge', () {
       final report = _report(logInspector: mixedLevels(), errorsOnly: true);
 
-      expect(report.indexOf('boom'), lessThan(report.indexOf('careful')));
+      // 'careful' (warning, 1m ago) is newer than 'boom' (error, 5m ago), so a
+      // correct merge puts it first. Deleting the sort in the builder flips
+      // this — which is the point of the fixture.
+      expect(report.indexOf('careful'), lessThan(report.indexOf('boom')));
     });
 
     test('does not touch the network / nav / db sections', () {

--- a/test/utils/diagnostic_report_test.dart
+++ b/test/utils/diagnostic_report_test.dart
@@ -1,0 +1,343 @@
+import 'package:flutter_inspector_kit/src/inspectors/log_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/database_entry.dart';
+import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/models/diagnostic_info.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
+import 'package:flutter_inspector_kit/src/models/network_entry.dart';
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
+import 'package:flutter_inspector_kit/src/utils/diagnostic_report.dart';
+import 'package:flutter_inspector_kit/src/version.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fixed clock so time-window assertions are deterministic.
+final _now = DateTime(2026, 7, 15, 12, 0, 0);
+DateTime _minutesAgo(int m) => _now.subtract(Duration(minutes: m));
+
+String _report({
+  LogInspector? logInspector,
+  List<NetworkEntry> network = const [],
+  List<NavigatorEntry> nav = const [],
+  List<DatabaseEntry> db = const [],
+  DiagnosticInfo? info,
+  Duration? timeRange,
+  Set<TimelineSource>? sections,
+  bool errorsOnly = false,
+  bool redact = true,
+}) {
+  return buildDiagnosticReport(
+    logInspector: logInspector ?? LogInspector(),
+    networkEntries: network,
+    navigatorEntries: nav,
+    databaseEntries: db,
+    now: _now,
+    info: info,
+    timeRange: timeRange,
+    sections: sections ?? TimelineSource.values.toSet(),
+    errorsOnly: errorsOnly,
+    redact: redact,
+  );
+}
+
+void main() {
+  group('header (AC-2, AC-3, AC-4, AC-5, AC-17)', () {
+    test('prints the package version from the single source of truth', () {
+      expect(_report(), contains('flutter_inspector_kit $packageVersion'));
+    });
+
+    test('degrades every device field to N/A when no info is injected', () {
+      final report = _report();
+
+      expect(report, contains('| App version | N/A |'));
+      expect(report, contains('| Device | N/A |'));
+      expect(report, contains('| OS | N/A |'));
+    });
+
+    test('shows the host-supplied values when info is injected', () {
+      final report = _report(
+        info: const DiagnosticInfo(
+          appVersion: '2.3.1+45',
+          deviceModel: 'iPhone15,2',
+          osVersion: 'iOS 17.4',
+        ),
+      );
+
+      expect(report, contains('| App version | 2.3.1+45 |'));
+      expect(report, contains('| Device | iPhone15,2 |'));
+      expect(report, contains('| OS | iOS 17.4 |'));
+    });
+
+    test('a partially-populated source still degrades only the missing fields', () {
+      final report = _report(info: const DiagnosticInfo(osVersion: 'Android 14'));
+
+      expect(report, contains('| OS | Android 14 |'));
+      expect(report, contains('| App version | N/A |'));
+    });
+
+    test('states the redaction status honestly', () {
+      expect(_report(), contains('| Redaction | enabled |'));
+      expect(_report(redact: false), contains('| Redaction | disabled |'));
+    });
+
+    test('states the time range, with null rendered as "all"', () {
+      expect(_report(), contains('| Time range | all |'));
+      expect(
+        _report(timeRange: const Duration(minutes: 5)),
+        contains('| Time range | last 5m |'),
+      );
+      expect(
+        _report(timeRange: const Duration(hours: 1)),
+        contains('| Time range | last 1h |'),
+      );
+    });
+  });
+
+  group('time window (AC-8)', () {
+    LogInspector spanningLogs() {
+      return LogInspector()
+        ..add(LogEntry(message: 'recent', timestamp: _minutesAgo(2)))
+        ..add(LogEntry(message: 'mid', timestamp: _minutesAgo(30)))
+        ..add(LogEntry(message: 'ancient', timestamp: _minutesAgo(180)));
+    }
+
+    test('null includes everything', () {
+      final report = _report(logInspector: spanningLogs());
+
+      expect(report, contains('recent'));
+      expect(report, contains('mid'));
+      expect(report, contains('ancient'));
+    });
+
+    test('5m keeps only entries inside the window', () {
+      final report = _report(
+        logInspector: spanningLogs(),
+        timeRange: const Duration(minutes: 5),
+      );
+
+      expect(report, contains('recent'));
+      expect(report, isNot(contains('mid')));
+      expect(report, isNot(contains('ancient')));
+    });
+
+    test('1h keeps entries inside the hour but drops older ones', () {
+      final report = _report(
+        logInspector: spanningLogs(),
+        timeRange: const Duration(hours: 1),
+      );
+
+      expect(report, contains('recent'));
+      expect(report, contains('mid'));
+      expect(report, isNot(contains('ancient')));
+    });
+  });
+
+  group('section selection (AC-9, AC-14)', () {
+    test('an unselected source is absent entirely — not even its heading', () {
+      final report = _report(
+        network: [NetworkEntry(method: 'GET', url: 'https://api.test/x')],
+        sections: {TimelineSource.log},
+      );
+
+      expect(report, isNot(contains('## Network')));
+      expect(report, isNot(contains('https://api.test/x')));
+      expect(report, contains('## Logs'));
+    });
+
+    test('a selected but empty source renders (none), not a blank block', () {
+      final report = _report(sections: {TimelineSource.db});
+
+      expect(report, contains('## Database'));
+      expect(report, contains('(none)'));
+    });
+
+    test('an entry outside the time window leaves its section empty, not absent', () {
+      final report = _report(
+        db: [
+          DatabaseEntry(
+            operation: DatabaseOperation.insert,
+            tableName: 'users',
+            timestamp: _minutesAgo(180),
+          ),
+        ],
+        sections: {TimelineSource.db},
+        timeRange: const Duration(minutes: 5),
+      );
+
+      expect(report, contains('## Database'));
+      expect(report, contains('(none)'));
+      expect(report, isNot(contains('users')));
+    });
+  });
+
+  group('redaction red line (AC-15, AC-16, AC-18)', () {
+    NetworkEntry secretRequest() => NetworkEntry(
+      method: 'POST',
+      url: 'https://api.test/login',
+      requestHeaders: const {
+        'Authorization': 'Bearer super-secret-token',
+        'Content-Type': 'application/json',
+      },
+      timestamp: _minutesAgo(1),
+    );
+
+    test('redact: true masks the secret header and never leaks the plaintext', () {
+      final report = _report(network: [secretRequest()]);
+
+      expect(report, isNot(contains('super-secret-token')));
+      expect(report, isNot(contains('Bearer')));
+      expect(report, contains('••••'));
+      // Non-sensitive headers survive.
+      expect(report, contains('application/json'));
+    });
+
+    test('redact: false emits the plaintext, matching single-entry share', () {
+      final report = _report(network: [secretRequest()], redact: false);
+
+      expect(report, contains('Bearer super-secret-token'));
+      expect(report, isNot(contains('••••')));
+    });
+  });
+
+  group('current route stack (AC-7)', () {
+    test('renders the resolved stack top-first with the current route marked', () {
+      final report = _report(
+        nav: [
+          // newest-first, as FlutterInspector.navigatorEntries yields.
+          NavigatorEntry(
+            action: NavigatorAction.push,
+            routeName: '/checkout',
+            timestamp: _minutesAgo(1),
+          ),
+          NavigatorEntry(
+            action: NavigatorAction.push,
+            routeName: '/cart',
+            timestamp: _minutesAgo(2),
+          ),
+        ],
+        sections: {TimelineSource.nav},
+      );
+
+      expect(report, contains('### Current route stack'));
+      expect(report, contains('1. `/checkout` ← current'));
+      expect(report, contains('2. `/cart`'));
+    });
+
+    test(
+      'REGRESSION: the stack replays the full buffer, not the time-windowed list — '
+      'a push outside the window must not be dropped, or its pop would corrupt the stack',
+      () {
+        final report = _report(
+          nav: [
+            // pop INSIDE the 5m window...
+            NavigatorEntry(
+              action: NavigatorAction.pop,
+              routeName: '/detail',
+              timestamp: _minutesAgo(1),
+            ),
+            // ...whose matching pushes are OUTSIDE it.
+            NavigatorEntry(
+              action: NavigatorAction.push,
+              routeName: '/detail',
+              timestamp: _minutesAgo(90),
+            ),
+            NavigatorEntry(
+              action: NavigatorAction.push,
+              routeName: '/home',
+              timestamp: _minutesAgo(120),
+            ),
+          ],
+          sections: {TimelineSource.nav},
+          timeRange: const Duration(minutes: 5),
+        );
+
+        // /detail was pushed then popped → the stack is just /home.
+        // If the resolver had been fed the windowed list (pop only), it would
+        // have popped a route that was never pushed and derived a wrong stack.
+        expect(report, contains('1. `/home` ← current'));
+        expect(report, isNot(contains('1. `/detail`')));
+
+        // The event list itself IS time-windowed: only the pop is recent.
+        expect(report, contains('### Navigation events'));
+      },
+    );
+  });
+
+  group('errors-only (AC-10, AC-11, AC-12, AC-13)', () {
+    LogInspector mixedLevels() {
+      return LogInspector()
+        ..add(LogEntry(
+          message: 'boom',
+          level: LogLevel.error,
+          timestamp: _minutesAgo(1),
+        ))
+        ..add(LogEntry(
+          message: 'careful',
+          level: LogLevel.warning,
+          timestamp: _minutesAgo(2),
+        ))
+        ..add(LogEntry(
+          message: 'just-fyi',
+          level: LogLevel.info,
+          timestamp: _minutesAgo(3),
+        ))
+        ..add(LogEntry(
+          message: 'noisy',
+          level: LogLevel.debug,
+          timestamp: _minutesAgo(4),
+        ));
+    }
+
+    test('off by default: every level is included', () {
+      final report = _report(logInspector: mixedLevels());
+
+      expect(report, contains('boom'));
+      expect(report, contains('careful'));
+      expect(report, contains('just-fyi'));
+      expect(report, contains('noisy'));
+    });
+
+    test('on: keeps error and warning, drops info and debug', () {
+      final report = _report(logInspector: mixedLevels(), errorsOnly: true);
+
+      expect(report, contains('boom'));
+      expect(report, contains('careful'));
+      expect(report, isNot(contains('just-fyi')));
+      expect(report, isNot(contains('noisy')));
+      expect(report, contains('Logs (errors & warnings only)'));
+    });
+
+    test('on: the surviving logs stay newest-first after the level merge', () {
+      final report = _report(logInspector: mixedLevels(), errorsOnly: true);
+
+      expect(report.indexOf('boom'), lessThan(report.indexOf('careful')));
+    });
+
+    test('does not touch the network / nav / db sections', () {
+      final report = _report(
+        logInspector: mixedLevels(),
+        network: [
+          NetworkEntry(
+            method: 'GET',
+            url: 'https://api.test/ok',
+            statusCode: 200,
+            timestamp: _minutesAgo(1),
+          ),
+        ],
+        db: [
+          DatabaseEntry(
+            operation: DatabaseOperation.query,
+            tableName: 'users',
+            timestamp: _minutesAgo(1),
+          ),
+        ],
+        errorsOnly: true,
+      );
+
+      // A 200 is not an error, but errorsOnly is a *log-level* filter only.
+      expect(report, contains('https://api.test/ok'));
+      expect(report, contains('users'));
+    });
+  });
+}

--- a/test/utils/diagnostic_report_test.dart
+++ b/test/utils/diagnostic_report_test.dart
@@ -67,6 +67,20 @@ void main() {
       expect(_report(), contains('flutter_inspector_kit $packageVersion'));
     });
 
+    test('anchors the generated time with the device timezone offset', () {
+      final report = _report();
+
+      // Not hardcoded — CI may run in any zone. Assert the shape, then that it
+      // matches the fixture clock's actual offset.
+      expect(report, matches(RegExp(r'\| Generated \|.*\(UTC[+-]\d{2}:\d{2}\) \|')));
+
+      final offset = _now.timeZoneOffset;
+      final sign = offset.isNegative ? '-' : '+';
+      final hh = offset.inHours.abs().toString().padLeft(2, '0');
+      final mm = (offset.inMinutes.abs() % 60).toString().padLeft(2, '0');
+      expect(report, contains('(UTC$sign$hh:$mm)'));
+    });
+
     test('degrades every device field to N/A when no info is injected', () {
       final report = _report();
 

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+import 'package:flutter_inspector_kit/src/version.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('packageVersion matches pubspec.yaml version', () {
+    final lines = File('pubspec.yaml').readAsLinesSync();
+    String? pubspecVersion;
+    for (final line in lines) {
+      if (line.trim().startsWith('version:')) {
+        pubspecVersion = line.split(':').last.trim();
+        break;
+      }
+    }
+    expect(pubspecVersion, isNotNull);
+    expect(packageVersion, pubspecVersion);
+  });
+}

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:flutter_inspector_kit/src/version.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -7,7 +8,7 @@ void main() {
     final lines = File('pubspec.yaml').readAsLinesSync();
     String? pubspecVersion;
     for (final line in lines) {
-      if (line.trim().startsWith('version:')) {
+      if (line.startsWith('version:')) {
         pubspecVersion = line.split(':').last.trim();
         break;
       }


### PR DESCRIPTION
### Summary
[#80](https://github.com/Yomiamy/flutter_inspector_kit/issues/80) feat: 一鍵診斷報告（Diagnostic Report）

**[修正問題]**

排查鏈條的最後一環「帶走證據」是紅燈。QA 重現 bug 後，要手動切四個 tab、逐筆截圖或複製、再手打 device / OS / app 版本資訊——耗時、易漏、回報品質參差。`Navigator` 與 `Database` tab 連分享按鈕都沒有，`DashboardModal` 的 AppBar `actions:` 是空的，開發者拿到的 bug report 往往缺了「錯誤當下的路由堆疊」與「錯誤前後的跨層事件」。

序列化零件（`buildPlainText` / `buildLogPlainText`）、聚合零件（`mergedTimeline`）、堆疊快照（`NavigatorStackResolver`）、輸出零件（`shareText`）四者其實都已存在且已在生產路徑驗證過，缺的只是把它們串起來的那條線與 dashboard 上那顆按鈕。此外 `LogInspector.entriesAtLevel()` 早已寫好卻從未被呼叫，而 `FlutterInspector.version` 常數自三個大版本前起就停在 `1.1.0`（因為一條「硬編碼比硬編碼」的恆等式假測試遮住了漂移，且從無程式碼讀取它）。

**[修正方式]**

1. **報告產生器** `lib/src/utils/diagnostic_report.dart`（新增）：`buildDiagnosticReport(...)` 純同步、Flutter-free、零 `dart:io`。三個過濾維度各只有一個收斂點——時間窗用 `Duration?`（`null` 即 all，一個 nullable 消掉整個 enum 與 `all` 特例分支）、來源用既有的 `Set<TimelineSource>`、errors-only 只碰 log 區段取數那行（複用 `entriesAtLevel()`）。表頭附 `(UTC±HH:MM)` 時區錨點，讓整份 local 時間報告可被跨時區對齊。
2. **Host 注入介面** `lib/src/models/diagnostic_info.dart`（新增）：`DiagnosticInfo` 值物件（三個 nullable 欄位）+ `DiagnosticInfoSource` 抽象介面，device/app 資訊由宿主 app 提供，套件對 `device_info_plus` / `package_info_plus` 零相依（比照既有 `DatabaseBrowserSource`）。未注入時表頭降級為 `N/A`。`FlutterInspector` 新增可選建構參數 `diagnosticInfoSource`（default null）與 `logInspector` getter，barrel 匯出 `DiagnosticInfo`。
3. **匯出 UI** `lib/src/ui/dashboard/export_report_sheet.dart`（新增）+ `dashboard_modal.dart`：AppBar 新增 Export action → 三維度選項 sheet → `shareText`，**不落盤**。分享失敗時 fallback 到 clipboard，clipboard 也失敗時保留 sheet 讓使用者重試；`finally` 保證按鈕不會卡在 disabled。
4. **版本單一真相** `lib/src/version.dart`（新增）+ `flutter_inspector.dart`：`FlutterInspector.version` 改為轉發 `packageVersion`，並以一條會讀 `pubspec.yaml` 對照、漂移時真的紅燈的測試取代原本的恆等式假測試。
5. **Markdown 完整性**：`_fenced()` 依 CommonMark 規則動態量測反引號串長度，避免 payload 自帶 fence 時破壞報告排版、吞掉後續區段。
6. **文件**：README 新增可直接複製的 `DiagnosticInfoSource` 完整實作範例；CHANGELOG 記於 `## Unreleased`（未 bump 版號——`pubspec.yaml` 零變更）。

**[Out of scope]**

JSON 格式、擴大 redaction 到 body/query（另開 issue）、ConsoleTab 搜尋欄 / LogLevel FilterChip、落盤持久化。

**[驗證]**

`flutter analyze` 0 issue；全套 374 條測試全綠（含 5 條新增的錯誤處理 / Markdown 完整性 / 時區測試，均經 mutation 驗證為 load-bearing）。零新增相依、零 `dart:io`、零檔案寫入、ConsoleTab 零變更。

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增一键导出 Markdown 诊断报告：可选择时间范围、分区与数据源；提供“仅错误与警告”开关（仅影响日志分区，默认关闭）。
  - 通过仪表盘导出入口打开并使用系统分享；分享不可用时自动回退到复制剪贴板（不落盘）。
  - 支持可选填充应用/设备/系统信息；未提供则在报告头显示 `N/A`，并继承既有脱敏设置。
- **改进 / 修复**
  - 修复版本显示过期问题，使包版本以单一事实源展示，并增强版本漂移校验；版本更新至 1.4.0。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->