### PR TITLE
chore(release): bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-## Unreleased
+## 1.5.0
 
 ### Added
 * **One-tap diagnostic report**: the dashboard app bar now has an export action that builds a single Markdown report — device/app header, current route stack, and the log / network / navigation / database sections — and hands it to the system share sheet. Three independent filters: time window (last 5m / last 1h / all), which sources to include, and an optional "errors & warnings only" toggle for the log section (off by default). Nothing is written to disk.
 * **`DiagnosticInfoSource`**: optional injection point for device and app metadata (`FlutterInspector(diagnosticInfoSource: ...)`). This package stays free of any device-info plugin — hosts supply the values themselves, and the report header degrades to `N/A` when no source is registered. Follows the same host-injection shape as `DatabaseBrowserSource`.
-
-### Fixed
-* **`FlutterInspector.version` was stale**: it had reported `1.1.0` since three releases ago. The constant is now derived from a single source of truth, guarded by a test that reads `pubspec.yaml` and fails on drift — the previous test compared a hardcoded string against a hardcoded constant, so it could never catch this.
 
 ## 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.4.0
+  flutter_inspector_kit: ^1.5.0
 ```
 
 Then run `flutter pub get`.

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -19,11 +19,12 @@ import '../ui/dashboard/dashboard_modal.dart';
 import 'inspector_overlay_manager.dart';
 import 'inspector_registry.dart';
 import 'uncaught_error_handler.dart';
+import '../version.dart';
 
 /// The core entry point for the Flutter Inspector.
 class FlutterInspector {
   /// Package version.
-  static const String version = '1.4.0';
+  static const String version = packageVersion;
 
   /// Optional widget for a 5th tab in the dashboard.
   final Widget? customTab;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String packageVersion = '1.4.0';
+const String packageVersion = '1.5.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 1.4.0
+version: 1.5.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary
[#82](https://github.com/Yomiamy/flutter_inspector_kit/issues/82) Release: Version 1.5.0

**[修正問題]**
發布新版 `1.5.0`，整合一鍵診斷報告 (Diagnostic Report)、時區錨定、`DiagnosticInfoSource` 設計等核心功能變更，並同步更新 `pubspec.yaml`、說明文檔與變更日誌。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號為 `1.5.0`。
2. **`README.md`**：將安裝指令的相依版本更新為 `^1.5.0`。
3. **`CHANGELOG.md`**：將 `## Unreleased` 更新為 `## 1.5.0` 版本日誌。
4. **`lib/src/version.dart`**：將包的內部版號變數 `packageVersion` 調整為 `1.5.0`。
5. **`lib/src/core/flutter_inspector.dart`**：將硬編碼的 `FlutterInspector.version` 重構為直接參照 `packageVersion` 以防再次發生版本不一致（Drift）之問題。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增一次性诊断报告导出功能。
  - 新增 `DiagnosticInfoSource` 注入点，支持提供诊断信息来源。

- **版本更新**
  - 发布版本升级至 1.5.0。
  - 应用内公开版本号将自动与软件包版本保持一致。
  - 更新安装示例中的依赖版本至 1.5.0。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->