### PR TITLE
Refactor: Clean up anti-patterns and code formatting

### DIFF
--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -151,25 +151,29 @@ class FlutterInspector {
     if (databaseSources != null) {
       _customDatabaseSources.addAll(databaseSources);
     }
+
     if (showNetworkNotification) {
-      final networkNotifier =
-          notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
-      // Wire onAdd only after init() resolves. init() never rejects (it catches
-      // and swallows platform errors internally), so this callback always runs.
-      // Requests that arrive before init completes are not forwarded to the
-      // notifier — which is correct, since _available isn't true until init
-      // succeeds, so showOrUpdate would no-op on them anyway. This just avoids
-      // holding a callback that fires into an uninitialised notifier.
-      () async {
-        await networkNotifier.init();
-        _registry.network.onAdd = (entry, total) {
-          networkNotifier.showOrUpdate(entry, total);
-        };
-        final entries = _registry.network.entries;
-        if (entries.isNotEmpty) {
-          networkNotifier.showOrUpdate(entries.first, entries.length);
-        }
-      }();
+      _initNetworkNotifier(notifier: notifier);
+    }
+  }
+
+  Future<void> _initNetworkNotifier({NetworkNotifier? notifier}) async {
+    final networkNotifier =
+        notifier ?? NetworkNotifier(onTap: _openNetworkFromNotification);
+    await networkNotifier.init();
+    // Wire onAdd only after init() resolves. init() never rejects (it catches
+    // and swallows platform errors internally), so this callback always runs.
+    // Requests that arrive before init completes are not forwarded to the
+    // notifier — which is correct, since _available isn't true until init
+    // succeeds, so showOrUpdate would no-op on them anyway. This just avoids
+    // holding a callback that fires into an uninitialised notifier.
+    _registry.network.onAdd = (entry, total) {
+      networkNotifier.showOrUpdate(entry, total);
+    };
+    final entries = _registry.network.entries;
+
+    if (entries.isNotEmpty) {
+      networkNotifier.showOrUpdate(entries.first, entries.length);
     }
   }
 

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -160,7 +160,8 @@ class FlutterInspector {
       // notifier — which is correct, since _available isn't true until init
       // succeeds, so showOrUpdate would no-op on them anyway. This just avoids
       // holding a callback that fires into an uninitialised notifier.
-      networkNotifier.init().then((_) {
+      () async {
+        await networkNotifier.init();
         _registry.network.onAdd = (entry, total) {
           networkNotifier.showOrUpdate(entry, total);
         };
@@ -168,7 +169,7 @@ class FlutterInspector {
         if (entries.isNotEmpty) {
           networkNotifier.showOrUpdate(entries.first, entries.length);
         }
-      });
+      }();
     }
   }
 

--- a/lib/src/core/inspector_overlay_manager.dart
+++ b/lib/src/core/inspector_overlay_manager.dart
@@ -15,10 +15,8 @@ class InspectorOverlayManager {
     final overlay = Overlay.maybeOf(context);
     if (overlay == null) return;
     _overlayEntry = OverlayEntry(
-      builder: (context) => InspectorFab(
-        onTap: () => onFabTap(context),
-        visible: visible,
-      ),
+      builder: (context) =>
+          InspectorFab(onTap: () => onFabTap(context), visible: visible),
     );
     overlay.insert(_overlayEntry!);
   }

--- a/lib/src/core/uncaught_error_handler.dart
+++ b/lib/src/core/uncaught_error_handler.dart
@@ -4,16 +4,16 @@ import 'package:flutter/widgets.dart';
 import '../models/log_level.dart';
 
 /// Signature for the function used to log an error.
-typedef LogCallback = void Function(
-  String message, {
-  LogLevel level,
-  String? stackTrace,
-  Map<String, dynamic>? data,
-});
+typedef LogCallback =
+    void Function(
+      String message, {
+      LogLevel level,
+      String? stackTrace,
+      Map<String, dynamic>? data,
+    });
 
 /// Handles attaching error hooks and forwarding to a log function.
 class UncaughtErrorHandler {
-
   /// The function called to log an error.
   final LogCallback onLog;
 
@@ -23,6 +23,7 @@ class UncaughtErrorHandler {
 
   /// Creates a new UncaughtErrorHandler instance.
   UncaughtErrorHandler({required this.onLog});
+
   /// Attaches the three standard Flutter error hooks, chaining/wrapping any
   /// existing host handler so errors are always forwarded downstream.
   ///

--- a/lib/src/core/uncaught_error_handler.dart
+++ b/lib/src/core/uncaught_error_handler.dart
@@ -7,7 +7,7 @@ import '../models/log_level.dart';
 typedef LogCallback =
     void Function(
       String message, {
-      LogLevel level,
+      required LogLevel level,
       String? stackTrace,
       Map<String, dynamic>? data,
     });

--- a/lib/src/models/diagnostic_info.dart
+++ b/lib/src/models/diagnostic_info.dart
@@ -32,8 +32,7 @@ class DiagnosticInfo {
   int get hashCode => Object.hash(appVersion, deviceModel, osVersion);
 
   @override
-  String toString() =>
-      'DiagnosticInfo($appVersion, $deviceModel, $osVersion)';
+  String toString() => 'DiagnosticInfo($appVersion, $deviceModel, $osVersion)';
 }
 
 /// Supplies device and app metadata for diagnostic reports.

--- a/lib/src/models/network_entry.dart
+++ b/lib/src/models/network_entry.dart
@@ -201,8 +201,7 @@ class NetworkEntry implements TimestampedEntry {
 
   /// Whether either body was truncated to fit [kNetworkBodyMaxLength].
   bool get isTruncated =>
-      isRequestTruncated ||
-      (responseBody?.endsWith(kTruncatedMarker) ?? false);
+      isRequestTruncated || (responseBody?.endsWith(kTruncatedMarker) ?? false);
 
   /// Whether the request body was truncated to fit [kNetworkBodyMaxLength].
   bool get isRequestTruncated =>

--- a/lib/src/ui/dashboard/dashboard_modal.dart
+++ b/lib/src/ui/dashboard/dashboard_modal.dart
@@ -81,10 +81,7 @@ class DashboardModal extends StatelessWidget {
 }
 
 class _DashboardTabBar extends StatelessWidget {
-  const _DashboardTabBar({
-    required this.hasCustomTab,
-    this.customTabTitle,
-  });
+  const _DashboardTabBar({required this.hasCustomTab, this.customTabTitle});
 
   final bool hasCustomTab;
   final String? customTabTitle;

--- a/lib/src/ui/dashboard/export_report_sheet.dart
+++ b/lib/src/ui/dashboard/export_report_sheet.dart
@@ -43,6 +43,7 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
   };
 
   final Set<TimelineSource> _sections = TimelineSource.values.toSet();
+
   /// Index into [_ranges]. The radios key off the index rather than the
   /// `Duration?` itself, because `RadioGroup<Duration>` would conflate "All"
   /// (a deliberate null) with "nothing selected" (also null).
@@ -134,7 +135,7 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
             for (final source in TimelineSource.values)
               CheckboxListTile(
                 dense: true,
-                title: Text(_sourceLabels[source]!),
+                title: Text(_sourceLabels[source] ?? ''),
                 value: _sections.contains(source),
                 onChanged: (checked) => setState(() {
                   if (checked ?? false) {
@@ -190,7 +191,6 @@ class _ExportReportSheetState extends State<ExportReportSheet> {
 }
 
 class _SectionLabel extends StatelessWidget {
-
   final String text;
 
   const _SectionLabel(this.text);

--- a/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
+++ b/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
@@ -374,4 +374,3 @@ class _TableRowsBody extends StatelessWidget {
     );
   }
 }
-

--- a/lib/src/ui/dashboard/tabs/network_tab.dart
+++ b/lib/src/ui/dashboard/tabs/network_tab.dart
@@ -49,8 +49,7 @@ class _NetworkTabState extends State<NetworkTab> {
         : filteredEntries
               .where(
                 (e) =>
-                    e.error != null ||
-                    (e.statusCode != null && e.statusCode! >= 400),
+                    e.error != null || (e.statusCode ?? 0) >= 400,
               )
               .where(
                 (e) => group.statusCode != null

--- a/lib/src/ui/dashboard/tabs/network_tab.dart
+++ b/lib/src/ui/dashboard/tabs/network_tab.dart
@@ -47,13 +47,17 @@ class _NetworkTabState extends State<NetworkTab> {
     final entries = group == null
         ? filteredEntries
         : filteredEntries
-            .where((e) =>
-                e.error != null ||
-                (e.statusCode != null && e.statusCode! >= 400))
-            .where((e) => group.statusCode != null
-                ? e.statusCode == group.statusCode
-                : e.errorType == group.errorType)
-            .toList(growable: false);
+              .where(
+                (e) =>
+                    e.error != null ||
+                    (e.statusCode != null && e.statusCode! >= 400),
+              )
+              .where(
+                (e) => group.statusCode != null
+                    ? e.statusCode == group.statusCode
+                    : e.errorType == group.errorType,
+              )
+              .toList(growable: false);
 
     return Column(
       children: [
@@ -74,8 +78,7 @@ class _NetworkTabState extends State<NetworkTab> {
           selectedGroup: _selectedErrorGroup,
           expanded: _errorSummaryExpanded,
           onGroupTap: (group) => setState(() {
-            _selectedErrorGroup =
-                _selectedErrorGroup == group ? null : group;
+            _selectedErrorGroup = _selectedErrorGroup == group ? null : group;
           }),
           onExpandToggle: () => setState(() {
             _errorSummaryExpanded = !_errorSummaryExpanded;
@@ -144,8 +147,12 @@ class _SearchBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(ThemeSpacing.spacing8,
-          ThemeSpacing.spacing8, ThemeSpacing.spacing4, ThemeSpacing.spacing4),
+      padding: const EdgeInsets.fromLTRB(
+        ThemeSpacing.spacing8,
+        ThemeSpacing.spacing8,
+        ThemeSpacing.spacing4,
+        ThemeSpacing.spacing4,
+      ),
       child: Row(
         children: [
           Expanded(
@@ -222,7 +229,7 @@ class _FilterChips extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(right: ThemeSpacing.spacing8),
               child: FilterChip(
-                label: Text(statusLabels[group]!),
+                label: Text(statusLabels[group] ?? ''),
                 selected: selectedStatusGroups.contains(group),
                 onSelected: (selected) =>
                     onStatusGroupSelected(group, selected),
@@ -332,8 +339,11 @@ class _ErrorSummaryBanner extends StatelessWidget {
           padding: ThemePadding.paddingAll8,
           child: Row(
             children: [
-              const Icon(Icons.warning_amber_rounded,
-                  size: ThemeSize.size16, color: ThemeColor.colorFF9800),
+              const Icon(
+                Icons.warning_amber_rounded,
+                size: ThemeSize.size16,
+                color: ThemeColor.colorFF9800,
+              ),
               const SizedBox(width: ThemeSpacing.spacing8),
               Text(
                 '⚠ ${groups.fold(0, (sum, g) => sum + g.count)} errors '
@@ -354,12 +364,18 @@ class _ErrorSummaryBanner extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(
-              ThemeSpacing.spacing12, ThemeSpacing.spacing8, ThemeSpacing.spacing12, 0),
+            ThemeSpacing.spacing12,
+            ThemeSpacing.spacing8,
+            ThemeSpacing.spacing12,
+            0,
+          ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text('Error Summary',
-                  style: Theme.of(context).textTheme.labelSmall),
+              Text(
+                'Error Summary',
+                style: Theme.of(context).textTheme.labelSmall,
+              ),
               InkWell(
                 onTap: onExpandToggle,
                 child: const Icon(Icons.expand_less, size: ThemeSize.size16),
@@ -446,10 +462,11 @@ class _ErrorGroupCard extends StatelessWidget {
                           Expanded(
                             child: Text(
                               group.label,
-                              style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: color,
-                              ),
+                              style: Theme.of(context).textTheme.labelMedium
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: color,
+                                  ),
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),

--- a/lib/src/ui/dashboard/tabs/network_tab.dart
+++ b/lib/src/ui/dashboard/tabs/network_tab.dart
@@ -54,7 +54,7 @@ class _NetworkTabState extends State<NetworkTab> {
               .where(
                 (e) => group.statusCode != null
                     ? e.statusCode == group.statusCode
-                    : e.errorType == group.errorType,
+                    : e.statusCode == null && e.errorType == group.errorType,
               )
               .toList(growable: false);
 

--- a/lib/src/ui/theme/theme_padding.dart
+++ b/lib/src/ui/theme/theme_padding.dart
@@ -7,8 +7,9 @@ class ThemePadding {
   static const EdgeInsets paddingAll8 = EdgeInsets.all(ThemeSpacing.spacing8);
   static const EdgeInsets paddingAll12 = EdgeInsets.all(ThemeSpacing.spacing12);
   static const EdgeInsets paddingAll16 = EdgeInsets.all(ThemeSpacing.spacing16);
-  static const EdgeInsets paddingH8 =
-      EdgeInsets.symmetric(horizontal: ThemeSpacing.spacing8);
+  static const EdgeInsets paddingH8 = EdgeInsets.symmetric(
+    horizontal: ThemeSpacing.spacing8,
+  );
   static const EdgeInsets paddingH16V8 = EdgeInsets.symmetric(
     horizontal: ThemeSpacing.spacing16,
     vertical: ThemeSpacing.spacing8,

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -58,7 +58,9 @@ String buildDiagnosticReport({
     ..writeln()
     ..writeln('| Field | Value |')
     ..writeln('| --- | --- |')
-    ..writeln('| Generated | ${now.toIso8601String()} (${_formatOffset(now)}) |')
+    ..writeln(
+      '| Generated | ${now.toIso8601String()} (${_formatOffset(now)}) |',
+    )
     ..writeln('| Package | flutter_inspector_kit $packageVersion |')
     ..writeln('| Redaction | ${redact ? 'enabled' : 'disabled'} |')
     ..writeln('| Time range | ${_formatRange(timeRange)} |')
@@ -125,20 +127,17 @@ String buildDiagnosticReport({
   }
 
   if (sections.contains(TimelineSource.db)) {
-    _writeSection(
-      b,
-      'Database',
-      databaseEntries.where(inWindow),
-      (e) {
-        var row = '- `${e.displayTime}` ${e.operation.name} `${e.tableName}`'
-            '${e.affectedRows == null ? '' : ' (${e.affectedRows} rows)'}';
-        if (e.data != null) {
-          final payload = redact ? redactHeaders(e.data!) : e.data!;
-          row += '\n${_fenced(const JsonEncoder.withIndent('  ').convert(payload))}';
-        }
-        return row;
-      },
-    );
+    _writeSection(b, 'Database', databaseEntries.where(inWindow), (e) {
+      var row =
+          '- `${e.displayTime}` ${e.operation.name} `${e.tableName}`'
+          '${e.affectedRows == null ? '' : ' (${e.affectedRows} rows)'}';
+      if (e.data != null) {
+        final payload = redact ? redactHeaders(e.data!) : e.data!;
+        row +=
+            '\n${_fenced(const JsonEncoder.withIndent('  ').convert(payload))}';
+      }
+      return row;
+    });
   }
 
   return b.toString();
@@ -177,13 +176,15 @@ String _fenced(String body) {
   final text = body.trimRight();
   final longest = RegExp('`+')
       .allMatches(text)
-      .fold<int>(0, (max, m) => m[0]!.length > max ? m[0]!.length : max);
+      .fold<int>(
+        0,
+        (max, m) => (m[0]?.length ?? 0) > max ? (m[0]?.length ?? 0) : max,
+      );
   final fence = '`' * (longest < 3 ? 3 : longest + 1);
   return '$fence\n$text\n$fence\n';
 }
 
-String _orNA(String? value) =>
-    (value == null || value.isEmpty) ? 'N/A' : value;
+String _orNA(String? value) => (value == null || value.isEmpty) ? 'N/A' : value;
 
 String _routeLabel(NavigatorEntry e) {
   final name = e.routeName ?? e.widgetType?.toString() ?? '(unnamed)';

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -131,8 +131,9 @@ String buildDiagnosticReport({
       var row =
           '- `${e.displayTime}` ${e.operation.name} `${e.tableName}`'
           '${e.affectedRows == null ? '' : ' (${e.affectedRows} rows)'}';
-      if (e.data != null) {
-        final payload = redact ? redactHeaders(e.data!) : e.data!;
+      final data = e.data;
+      if (data != null) {
+        final payload = redact ? redactHeaders(data) : data;
         row +=
             '\n${_fenced(const JsonEncoder.withIndent('  ').convert(payload))}';
       }

--- a/lib/src/utils/network_utils.dart
+++ b/lib/src/utils/network_utils.dart
@@ -182,8 +182,7 @@ List<NetworkErrorGroup> aggregateNetworkErrors(List<NetworkEntry> entries) {
     // 1. Filter out non-error entries: only requests with an error or a
     // >=400 status code count. Pending requests (both null) are excluded.
     final isError =
-        entry.error != null ||
-        (entry.statusCode != null && entry.statusCode! >= 400);
+        entry.error != null || (entry.statusCode ?? 0) >= 400;
     if (!isError) continue;
 
     // 2. Group by statusCode when present; only transport failures

--- a/lib/src/utils/network_utils.dart
+++ b/lib/src/utils/network_utils.dart
@@ -181,8 +181,9 @@ List<NetworkErrorGroup> aggregateNetworkErrors(List<NetworkEntry> entries) {
   for (final entry in entries) {
     // 1. Filter out non-error entries: only requests with an error or a
     // >=400 status code count. Pending requests (both null) are excluded.
+    final statusCode = entry.statusCode;
     final isError =
-        entry.error != null || (entry.statusCode ?? 0) >= 400;
+        entry.error != null || (statusCode != null && statusCode >= 400);
     if (!isError) continue;
 
     // 2. Group by statusCode when present; only transport failures
@@ -200,12 +201,12 @@ List<NetworkErrorGroup> aggregateNetworkErrors(List<NetworkEntry> entries) {
     );
 
     builder.count++;
-    if (builder.firstSeen == null ||
-        entry.timestamp.isBefore(builder.firstSeen!)) {
+    final firstSeen = builder.firstSeen;
+    if (firstSeen == null || entry.timestamp.isBefore(firstSeen)) {
       builder.firstSeen = entry.timestamp;
     }
-    if (builder.lastSeen == null ||
-        entry.timestamp.isAfter(builder.lastSeen!)) {
+    final lastSeen = builder.lastSeen;
+    if (lastSeen == null || entry.timestamp.isAfter(lastSeen)) {
       builder.lastSeen = entry.timestamp;
     }
   }

--- a/lib/src/utils/network_utils.dart
+++ b/lib/src/utils/network_utils.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
 import '../models/network_entry.dart';
+
 /// Formats [t] as a zero-padded `HH:mm:ss` local-time string.
 String timeOf(DateTime t) =>
     '${t.hour.toString().padLeft(2, '0')}:'
@@ -180,7 +181,9 @@ List<NetworkErrorGroup> aggregateNetworkErrors(List<NetworkEntry> entries) {
   for (final entry in entries) {
     // 1. Filter out non-error entries: only requests with an error or a
     // >=400 status code count. Pending requests (both null) are excluded.
-    final isError = entry.error != null || (entry.statusCode != null && entry.statusCode! >= 400);
+    final isError =
+        entry.error != null ||
+        (entry.statusCode != null && entry.statusCode! >= 400);
     if (!isError) continue;
 
     // 2. Group by statusCode when present; only transport failures
@@ -189,16 +192,21 @@ List<NetworkErrorGroup> aggregateNetworkErrors(List<NetworkEntry> entries) {
     final key = entry.statusCode != null
         ? (entry.statusCode, null)
         : (null, entry.errorType);
-    final builder = builders.putIfAbsent(key, () => _ErrorGroupBuilder(
-      statusCode: entry.statusCode,
-      errorType: entry.statusCode != null ? null : entry.errorType,
-    ));
+    final builder = builders.putIfAbsent(
+      key,
+      () => _ErrorGroupBuilder(
+        statusCode: entry.statusCode,
+        errorType: entry.statusCode != null ? null : entry.errorType,
+      ),
+    );
 
     builder.count++;
-    if (builder.firstSeen == null || entry.timestamp.isBefore(builder.firstSeen!)) {
+    if (builder.firstSeen == null ||
+        entry.timestamp.isBefore(builder.firstSeen!)) {
       builder.firstSeen = entry.timestamp;
     }
-    if (builder.lastSeen == null || entry.timestamp.isAfter(builder.lastSeen!)) {
+    if (builder.lastSeen == null ||
+        entry.timestamp.isAfter(builder.lastSeen!)) {
       builder.lastSeen = entry.timestamp;
     }
   }
@@ -211,14 +219,11 @@ List<NetworkErrorGroup> aggregateNetworkErrors(List<NetworkEntry> entries) {
 }
 
 class _ErrorGroupBuilder {
-  _ErrorGroupBuilder({
-    this.statusCode,
-    this.errorType,
-  });
+  _ErrorGroupBuilder({this.statusCode, this.errorType});
 
   final int? statusCode;
   final DioExceptionType? errorType;
-  
+
   int count = 0;
   DateTime? firstSeen;
   DateTime? lastSeen;


### PR DESCRIPTION
### Summary
[#84](https://github.com/Yomiamy/flutter_inspector_kit/issues/84) 清理程式碼庫違反 flutter-styles.md 的反模式與格式問題

**[修正問題]**

本次 PR 旨在清理程式碼庫中違反 `flutter-styles.md` 規範的寫法，主要針對以下兩個面向進行改善：
1. **反模式 (Anti-patterns)**：發現多處使用了強制解包（force unwrap `!`）與舊式非同步處理（`.then()`），這些寫法會增加預期外的崩潰風險，並降低程式碼可讀性。
2. **程式碼格式 (Code Formatting)**：多個檔案的格式未與 `dart format` 官方標準保持一致。

**[修正方式]**

- **消除強制解包 (`!`) 替換為安全處理 (`??`)**
  - 在 `lib/src/utils/diagnostic_report.dart` 中，移除正則表達式匹配時不安全的 `m[0]!.length` 寫法，改為安全的 `(m[0]?.length ?? 0)`。
  - 在 `lib/src/ui/dashboard/export_report_sheet.dart` 及 `lib/src/ui/dashboard/tabs/network_tab.dart` 中，移除了不安全的 Map lookup 強制解包，改採防禦性設計以防範空值異常。
- **非同步寫法升級**
  - 在 `lib/src/core/flutter_inspector.dart` 中，將舊式的 Promise 鏈式寫法 (`.then()`) 重構為 `async/await`，提升邏輯的清晰度與標準化。
- **全域排版統一**
  - 執行 `dart format`，將包含 `ThemePadding`, `NetworkUtils`, `_ErrorSummaryBanner` 等多個元件中的排版補齊 trailing commas，並對齊官方格式標準。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复导出报表“来源标题”映射缺失导致的运行时异常。
  * 修复网络筛选/错误组标签映射缺失时的断言错误，改为安全回退显示空字符串。
  * 调整网络错误组归类：当所选错误组不带状态码时，额外要求仅匹配无状态码的条目，避免误归类。
  * 优化网络通知初始化时序：初始化完成后再注册展示逻辑，并在已有记录存在时触发更新。
* **Refactor**
  * 多处格式、空安全与输出细节优化，提升稳定性与可维护性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->