### PR TITLE
feat(report): replace diagnostic Logs section with chronological Timeline (#86)

### DIFF
--- a/docs/plans/2026-07-16-diagnostic-report-timeline-design.md
+++ b/docs/plans/2026-07-16-diagnostic-report-timeline-design.md
@@ -1,0 +1,38 @@
+# Diagnostic Report Timeline Redesign
+
+## 1. Context & Problem
+In `v1.5.0`, the diagnostic report exports `LogEntry`, `NetworkEntry`, `NavigatorEntry`, and `DatabaseEntry` into four isolated sections. When troubleshooting, the causal relationship across layers (e.g., a button tap leading to an API call, which fails and produces an error log) is lost because events are grouped by type rather than interleaved by time.
+
+The `## Logs` section in particular takes up excessive vertical space (formatting every log with `General`, `StackTrace`, and `Data` blocks) even when 90% of the entries have no stack trace or data.
+
+## 2. Goal
+Replace the isolated `## Logs` section with a single `## Timeline` section that chronologically interleaves events from all four layers, matching the visual mental model of `ConsoleTab`'s `mergedTimeline()`. 
+
+## 3. Design: The Timeline Mixed Stream (方案 A)
+
+### 3.1 Data Flow
+Instead of just rendering `logInspector.entries`, the report builder will merge all selected buffers based on the `sections` filter, sort them descendingly by `timestamp` (newest first), and apply the `timeRange` cutoff.
+
+No new data models will be introduced. It reuses the existing `TimestampedEntry` interface.
+
+### 3.2 Single-Line Format
+Each entry will be rendered as a dense, single-line tag to maximize information density. 
+
+| Type | Format | Example |
+|------|--------|---------|
+| **LogEntry** | `[HH:mm:ss] [LOG/{level}] {message}` | `[10:30:06] [LOG/error] Fetch failed` |
+| **LogEntry** (with StackTrace) | *Message line* + 3 lines of indented stack trace | `  │ #0 UserRepo.fetch (repo.dart:42)` |
+| **NetworkEntry** | `[HH:mm:ss] [NET] {method} {path} → {status} ({duration}ms)` | `[10:30:05] [NET] GET /api/data → 502 (1200ms)` |
+| **NetworkEntry** (Error, no status) | `[HH:mm:ss] [NET] {method} {path} ✗ {errorType}` | `[10:30:05] [NET] POST /api ✗ connectionTimeout` |
+| **NavigatorEntry** | `[HH:mm:ss] [NAV] {action} {routeName}` | `[10:30:01] [NAV] push /home` |
+| **DatabaseEntry** | `[HH:mm:ss] [DB] {operation} {tableName} ({rows} rows)` | `[10:30:06] [DB] query users (3 rows)` |
+
+### 3.3 Semantic Updates
+1. **Section Renaming**: The report's `## Logs` header becomes `## Timeline`.
+2. **`errorsOnly` Flag**: The `errorsOnly` filter on `ExportReportSheet` previously only affected logs. Now, it will filter the Timeline stream to show **only** error/warning logs AND error network entries (`statusCode >= 400` or `errorType != null`). 
+3. **Detail Sections Unchanged**: The independent `## Network`, `## Navigation`, and `## Database` sections remain at the bottom of the report to preserve full request/response payloads.
+
+## 4. Implementation Details
+* **`lib/src/utils/log_formatters.dart`**: Add one-liner formatters for each entry type.
+* **`lib/src/utils/diagnostic_report.dart`**: Refactor `_writeSection(..., 'Logs', ...)` into a new mixed timeline rendering logic.
+* **Tests**: Update `test/utils/diagnostic_report_test.dart` to assert the new single-line formats and chronological sorting.

--- a/docs/plans/2026-07-16-diagnostic-report-timeline-design.md
+++ b/docs/plans/2026-07-16-diagnostic-report-timeline-design.md
@@ -16,14 +16,14 @@ Instead of just rendering `logInspector.entries`, the report builder will merge 
 No new data models will be introduced. It reuses the existing `TimestampedEntry` interface.
 
 ### 3.2 Single-Line Format
-Each entry will be rendered as a dense, single-line tag to maximize information density. 
+Each entry renders as a dense, single-line head to maximize information density. The only multi-line case is a log entry carrying a stack trace: its head stays one line and up to 3 indented continuation lines follow (message newlines themselves are flattened).
 
 Timestamps reuse the existing `displayTime` extension (`HH:mm:ss.mmm`, millisecond precision), matching the Nav/DB detail sections.
 
 | Type | Format | Example |
 |------|--------|---------|
 | **LogEntry** | `[HH:mm:ss.mmm] [LOG/{level}] {message}` | `[10:30:06.000] [LOG/error] Fetch failed` |
-| **LogEntry** (with StackTrace) | *Message line* + 3 lines of indented stack trace | `  │ #0 UserRepo.fetch (repo.dart:42)` |
+| **LogEntry** (with StackTrace) | *Message head* + up to 3 continuation lines, each indented 2 spaces and prefixed `│` | `│ #0 UserRepo.fetch (repo.dart:42)` |
 | **NetworkEntry** | `[HH:mm:ss.mmm] [NET] {method} {path} → {status} ({duration}ms)` | `[10:30:05.000] [NET] GET /api/data → 502 (1200ms)` |
 | **NetworkEntry** (Error, no status) | `[HH:mm:ss.mmm] [NET] {method} {path} ✗ {errorType}` | `[10:30:05.000] [NET] POST /api ✗ connectionTimeout` |
 | **NavigatorEntry** | `[HH:mm:ss.mmm] [NAV] {action} {routeName}` | `[10:30:01.000] [NAV] push /home` |

--- a/docs/plans/2026-07-16-diagnostic-report-timeline-design.md
+++ b/docs/plans/2026-07-16-diagnostic-report-timeline-design.md
@@ -18,14 +18,16 @@ No new data models will be introduced. It reuses the existing `TimestampedEntry`
 ### 3.2 Single-Line Format
 Each entry will be rendered as a dense, single-line tag to maximize information density. 
 
+Timestamps reuse the existing `displayTime` extension (`HH:mm:ss.mmm`, millisecond precision), matching the Nav/DB detail sections.
+
 | Type | Format | Example |
 |------|--------|---------|
-| **LogEntry** | `[HH:mm:ss] [LOG/{level}] {message}` | `[10:30:06] [LOG/error] Fetch failed` |
+| **LogEntry** | `[HH:mm:ss.mmm] [LOG/{level}] {message}` | `[10:30:06.000] [LOG/error] Fetch failed` |
 | **LogEntry** (with StackTrace) | *Message line* + 3 lines of indented stack trace | `  │ #0 UserRepo.fetch (repo.dart:42)` |
-| **NetworkEntry** | `[HH:mm:ss] [NET] {method} {path} → {status} ({duration}ms)` | `[10:30:05] [NET] GET /api/data → 502 (1200ms)` |
-| **NetworkEntry** (Error, no status) | `[HH:mm:ss] [NET] {method} {path} ✗ {errorType}` | `[10:30:05] [NET] POST /api ✗ connectionTimeout` |
-| **NavigatorEntry** | `[HH:mm:ss] [NAV] {action} {routeName}` | `[10:30:01] [NAV] push /home` |
-| **DatabaseEntry** | `[HH:mm:ss] [DB] {operation} {tableName} ({rows} rows)` | `[10:30:06] [DB] query users (3 rows)` |
+| **NetworkEntry** | `[HH:mm:ss.mmm] [NET] {method} {path} → {status} ({duration}ms)` | `[10:30:05.000] [NET] GET /api/data → 502 (1200ms)` |
+| **NetworkEntry** (Error, no status) | `[HH:mm:ss.mmm] [NET] {method} {path} ✗ {errorType}` | `[10:30:05.000] [NET] POST /api ✗ connectionTimeout` |
+| **NavigatorEntry** | `[HH:mm:ss.mmm] [NAV] {action} {routeName}` | `[10:30:01.000] [NAV] push /home` |
+| **DatabaseEntry** | `[HH:mm:ss.mmm] [DB] {operation} {tableName} ({rows} rows)` | `[10:30:06.000] [DB] query users (3 rows)` |
 
 ### 3.3 Semantic Updates
 1. **Section Renaming**: The report's `## Logs` header becomes `## Timeline`.
@@ -33,6 +35,7 @@ Each entry will be rendered as a dense, single-line tag to maximize information 
 3. **Detail Sections Unchanged**: The independent `## Network`, `## Navigation`, and `## Database` sections remain at the bottom of the report to preserve full request/response payloads.
 
 ## 4. Implementation Details
-* **`lib/src/utils/log_formatters.dart`**: Add one-liner formatters for each entry type.
+* **`lib/src/utils/log_formatters.dart`**: Add `buildLogOneLiner`.
+* **`lib/src/utils/network_formatters.dart`**: Add `buildNetworkOneLiner`.
 * **`lib/src/utils/diagnostic_report.dart`**: Refactor `_writeSection(..., 'Logs', ...)` into a new mixed timeline rendering logic.
 * **Tests**: Update `test/utils/diagnostic_report_test.dart` to assert the new single-line formats and chronological sorting.

--- a/docs/plans/2026-07-16-diagnostic-report-timeline-plan.md
+++ b/docs/plans/2026-07-16-diagnostic-report-timeline-plan.md
@@ -1,0 +1,258 @@
+# Diagnostic Report Timeline Redesign Implementation Plan
+
+> **For Claude:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the isolated `## Logs` section in the diagnostic report with a chronological, single-line `## Timeline` section that interleaves events from all four sources (Log, Network, Nav, DB).
+
+**Architecture:** Use the existing `TimestampedEntry` interface to merge the 4 source lists, sort them descendingly by `timestamp`, and map each to a concise single-line representation. Re-route the `errorsOnly` logic to filter the unified stream rather than just logs. Independent detail sections for Network, Nav, and DB remain intact.
+
+**Tech Stack:** Dart, Flutter Inspector Kit
+
+---
+
+## Chunk 1: Formatters
+
+### Task 1: Single-Line Formatters
+
+**Files:**
+- Modify: `lib/src/utils/log_formatters.dart`
+- Modify: `lib/src/utils/network_formatters.dart`
+- Create: `test/utils/diagnostic_report_test.dart`
+
+- [ ] **Step 1: Write failing tests for formatters**
+
+```dart
+// test/utils/diagnostic_report_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/models/network_entry.dart';
+import 'package:flutter_inspector_kit/src/utils/log_formatters.dart';
+import 'package:flutter_inspector_kit/src/utils/network_formatters.dart';
+
+void main() {
+  group('Diagnostic Report Formatters', () {
+    test('buildLogOneLiner formats correctly', () {
+      final entry = LogEntry(
+        level: LogLevel.error,
+        message: 'Fetch failed',
+        timestamp: DateTime(2026, 7, 16, 10, 30, 6),
+      );
+      expect(buildLogOneLiner(entry), '[10:30:06] [LOG/error] Fetch failed');
+    });
+
+    test('buildLogOneLiner includes truncated stackTrace', () {
+      final entry = LogEntry(
+        level: LogLevel.error,
+        message: 'Crash',
+        stackTrace: '#0 func (file:1)\n#1 func (file:2)\n#2 func (file:3)\n#3 func (file:4)',
+        timestamp: DateTime(2026, 7, 16, 10, 30, 6),
+      );
+      final out = buildLogOneLiner(entry);
+      expect(out, contains('[LOG/error] Crash\n  │ #0 func'));
+      expect(out.split('\n').length, 4); // msg + 3 lines of stack
+    });
+
+    test('buildNetworkOneLiner formats success correctly', () {
+      final entry = NetworkEntry.test(
+        id: '1',
+        method: 'GET',
+        url: 'https://api.test/data',
+        timestamp: DateTime(2026, 7, 16, 10, 30, 5),
+        duration: const Duration(milliseconds: 1200),
+        statusCode: 200,
+      );
+      expect(buildNetworkOneLiner(entry), '[10:30:05] [NET] GET /data → 200 (1200ms)');
+    });
+
+    test('buildNetworkOneLiner formats error correctly', () {
+      final entry = NetworkEntry.test(
+        id: '2',
+        method: 'POST',
+        url: 'https://api.test/api',
+        timestamp: DateTime(2026, 7, 16, 10, 30, 5),
+        errorType: 'connectionTimeout', // Assuming DioExceptionType enum maps to this
+      );
+      expect(buildNetworkOneLiner(entry), '[10:30:05] [NET] POST /api ✗ connectionTimeout');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/utils/diagnostic_report_test.dart`
+Expected: FAIL with "Undefined name 'buildLogOneLiner'"
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `lib/src/utils/log_formatters.dart`:
+```dart
+String buildLogOneLiner(LogEntry entry) {
+  var line = '[${entry.displayTime}] [LOG/${entry.level.name}] ${entry.message}';
+  if (entry.stackTrace != null) {
+    final traceLines = entry.stackTrace!.split('\n').take(3);
+    for (final t in traceLines) {
+      if (t.trim().isNotEmpty) {
+        line += '\n  │ ${t.trim()}';
+      }
+    }
+  }
+  return line;
+}
+```
+
+Modify `lib/src/utils/network_formatters.dart`:
+```dart
+String buildNetworkOneLiner(NetworkEntry entry) {
+  final path = Uri.tryParse(entry.url)?.path ?? entry.url;
+  var line = '[${entry.displayTime}] [NET] ${entry.method} $path ';
+  if (entry.statusCode == null && entry.errorType != null) {
+    line += '✗ ${entry.errorType!.name}';
+  } else {
+    line += '→ ${entry.statusCode ?? 'N/A'}';
+    if (entry.duration != null) {
+      line += ' (${entry.duration!.inMilliseconds}ms)';
+    }
+  }
+  return line;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/utils/diagnostic_report_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/utils/diagnostic_report_test.dart lib/src/utils/log_formatters.dart lib/src/utils/network_formatters.dart
+git commit -m "feat(report): add one-liner formatters for log and network entries"
+```
+
+## Chunk 2: Timeline Builder
+
+### Task 2: Refactor buildDiagnosticReport
+
+**Files:**
+- Modify: `lib/src/utils/diagnostic_report.dart`
+- Modify: `test/utils/diagnostic_report_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Modify `test/utils/diagnostic_report_test.dart` to add a test for `buildDiagnosticReport`:
+```dart
+// test/utils/diagnostic_report_test.dart
+import 'package:flutter_inspector_kit/src/inspectors/log_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/diagnostic_info.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
+import 'package:flutter_inspector_kit/src/utils/diagnostic_report.dart';
+
+// ... inside group ...
+test('buildDiagnosticReport includes interleaved Timeline section', () {
+  final logs = LogInspector(200);
+  logs.log(LogLevel.info, 'App started', timestamp: DateTime(2026, 7, 16, 10, 30, 0));
+  
+  final navs = [
+    NavigatorEntry(
+      action: NavigationAction.push,
+      routeName: '/home',
+      timestamp: DateTime(2026, 7, 16, 10, 30, 1),
+    )
+  ];
+  
+  final report = buildDiagnosticReport(
+    logInspector: logs,
+    networkEntries: [],
+    navigatorEntries: navs,
+    databaseEntries: [],
+    now: DateTime(2026, 7, 16, 10, 30, 10),
+  );
+  
+  expect(report, contains('## Timeline'));
+  // Should sort newest first (nav then log)
+  final timelineMatch = RegExp(r'## Timeline\n\n- `\[10:30:01\] \[NAV\] push `/home`\n- `\[10:30:00\] \[LOG/info\] App started`').hasMatch(report);
+  expect(timelineMatch, isTrue, reason: 'Timeline should interleave events chronologically');
+  expect(report, isNot(contains('## Logs')));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/utils/diagnostic_report_test.dart`
+Expected: FAIL (missing `## Timeline`, still has `## Logs`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `lib/src/utils/diagnostic_report.dart`:
+1. Remove the `if (sections.contains(TimelineSource.log))` block.
+2. Add a new `## Timeline` section builder before `## Network`.
+```dart
+  // Build the mixed Timeline
+  final timelineEntries = <TimestampedEntry>[];
+  if (sections.contains(TimelineSource.log)) {
+    timelineEntries.addAll(logInspector.entries);
+  }
+  if (sections.contains(TimelineSource.network)) {
+    timelineEntries.addAll(networkEntries);
+  }
+  if (sections.contains(TimelineSource.nav)) {
+    timelineEntries.addAll(navigatorEntries);
+  }
+  if (sections.contains(TimelineSource.db)) {
+    timelineEntries.addAll(databaseEntries);
+  }
+
+  // Apply errorsOnly logic to the mixed timeline
+  Iterable<TimestampedEntry> stream = timelineEntries;
+  if (errorsOnly) {
+    stream = stream.where((e) {
+      if (e is LogEntry) {
+        return e.level == LogLevel.error || e.level == LogLevel.warning;
+      }
+      if (e is NetworkEntry) {
+        return (e.statusCode != null && e.statusCode! >= 400) || e.errorType != null;
+      }
+      return false; // Nav and DB events are stripped in errors-only mode
+    });
+  }
+
+  // Sort descending and apply timeRange window
+  final visibleTimeline = stream.where(inWindow).toList()
+    ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+
+  _writeSection(
+    b,
+    errorsOnly ? 'Timeline (errors & warnings only)' : 'Timeline',
+    visibleTimeline,
+    (e) {
+      String oneLiner;
+      if (e is LogEntry) {
+        oneLiner = buildLogOneLiner(e);
+      } else if (e is NetworkEntry) {
+        oneLiner = buildNetworkOneLiner(e);
+      } else if (e is NavigatorEntry) {
+        oneLiner = '[${e.displayTime}] [NAV] ${e.action.name} ${_routeLabel(e)}';
+      } else if (e is DatabaseEntry) {
+        oneLiner = '[${e.displayTime}] [DB] ${e.operation.name} `${e.tableName}`${e.affectedRows == null ? '' : ' (${e.affectedRows} rows)'}';
+      } else {
+        oneLiner = '[${e.displayTime}] [UNKNOWN]';
+      }
+      return '- `$oneLiner`';
+    },
+  );
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/utils/diagnostic_report_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/src/utils/diagnostic_report.dart test/utils/diagnostic_report_test.dart
+git commit -m "feat(report): replace Logs section with chronological mixed Timeline"
+```

--- a/docs/plans/2026-07-16-diagnostic-report-timeline-plan.md
+++ b/docs/plans/2026-07-16-diagnostic-report-timeline-plan.md
@@ -2,6 +2,13 @@
 
 > **For Claude:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **⚠️ 落地校正註記（PR #87 實作後）**：本 plan 為規劃時的快照，下列細節以實際 codebase 為準，範例碼**不可照抄**：
+> 1. 時間戳為毫秒級 `[HH:mm:ss.mmm]`（復用 `TimestampedEntry.displayTime` extension），非本文範例的 `[HH:mm:ss]`。
+> 2. `NetworkEntry.errorType` 是 `DioExceptionType?` enum，非字串；且 `NetworkEntry` 無 `.test` 工廠、無 `id` 欄位。
+> 3. `LogInspector` 建構子為具名參數 `LogInspector(bufferSize: N)`，且只有 `add(LogEntry)`，無 `log()` 方法。
+> 4. `test/utils/diagnostic_report_test.dart` 為既有檔案（Modify，非 Create）。
+> 5. Timeline 渲染為 `- {oneLiner}` inline list item（非反引號包裹），並將 log 訊息換行（含 `\r`）壓平，杜絕訊息內 ``` fence 撐破 markdown。
+
 **Goal:** Replace the isolated `## Logs` section in the diagnostic report with a chronological, single-line `## Timeline` section that interleaves events from all four sources (Log, Network, Nav, DB).
 
 **Architecture:** Use the existing `TimestampedEntry` interface to merge the 4 source lists, sort them descendingly by `timestamp`, and map each to a concise single-line representation. Re-route the `errorsOnly` logic to filter the unified stream rather than just logs. Independent detail sections for Network, Nav, and DB remain intact.

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -26,9 +26,12 @@ import 'redaction.dart';
 ///   be a special branch in every switch.
 /// * [sections] — which sources to include. Unselected sources are absent
 ///   entirely, not rendered empty.
-/// * [errorsOnly] — restrict the *log* section to error/warning. Off by
-///   default: a report whose whole point is "what happened around the error"
-///   is worth little once the leading info/debug breadcrumbs are stripped.
+/// * [errorsOnly] — restrict the whole Timeline stream to error signals:
+///   error/warning logs and failed network calls (`statusCode >= 400` or a
+///   transport `errorType`); nav/db events are dropped. Off by default: a
+///   report whose whole point is "what happened around the error" is worth
+///   little once the leading info/debug breadcrumbs are stripped. The
+///   independent Network/Navigation/Database detail sections are unaffected.
 ///
 /// [redact] should be the host's `FlutterInspector.redactSensitiveData`, so the
 /// report masks exactly what a single-entry share masks — no more, no less.

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -68,23 +68,33 @@ String buildDiagnosticReport({
     ..writeln('| Device | ${_orNA(info?.deviceModel)} |')
     ..writeln('| OS | ${_orNA(info?.osVersion)} |');
 
-  if (sections.contains(TimelineSource.log)) {
-    // errorsOnly reuses entriesAtLevel(), which returns exactly one level, so
-    // the two levels are merged and re-sorted back into newest-first order.
-    final logs = errorsOnly
-        ? (<LogEntry>[
-            ...logInspector.entriesAtLevel(LogLevel.error),
-            ...logInspector.entriesAtLevel(LogLevel.warning),
-          ]..sort((a, b) => b.timestamp.compareTo(a.timestamp)))
-        : logInspector.entries;
+  // The mixed Timeline: entries from every selected source interleaved by time,
+  // newest first — the cross-layer causality the four detail sections below
+  // can't show. It reuses the shared TimestampedEntry.timestamp sort key and
+  // introduces no new model; it is a formatting projection of existing entries.
+  final timeline = <TimestampedEntry>[
+    if (sections.contains(TimelineSource.log)) ...logInspector.entries,
+    if (sections.contains(TimelineSource.network)) ...networkEntries,
+    if (sections.contains(TimelineSource.nav)) ...navigatorEntries,
+    if (sections.contains(TimelineSource.db)) ...databaseEntries,
+  ];
 
-    _writeSection(
-      b,
-      errorsOnly ? 'Logs (errors & warnings only)' : 'Logs',
-      logs.where(inWindow),
-      (e) => _fenced(buildLogPlainText(e)),
-    );
+  var stream = timeline.where(inWindow);
+  if (errorsOnly) {
+    // errorsOnly now filters the whole stream, not just logs: keep error/warning
+    // logs and failed network calls; nav/db carry no error signal, so drop them.
+    stream = stream.where(_isError);
   }
+
+  final visibleTimeline = stream.toList()
+    ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+
+  _writeSection(
+    b,
+    errorsOnly ? 'Timeline (errors & warnings only)' : 'Timeline',
+    visibleTimeline,
+    _timelineLine,
+  );
 
   if (sections.contains(TimelineSource.network)) {
     _writeSection(
@@ -183,6 +193,34 @@ String _fenced(String body) {
       );
   final fence = '`' * (longest < 3 ? 3 : longest + 1);
   return '$fence\n$text\n$fence\n';
+}
+
+/// Whether [e] carries an error signal, for the errors-only timeline filter.
+/// Only logs and network calls can; nav/db events are never "errors".
+bool _isError(TimestampedEntry e) {
+  if (e is LogEntry) {
+    return e.level == LogLevel.error || e.level == LogLevel.warning;
+  }
+  if (e is NetworkEntry) {
+    return (e.statusCode ?? 0) >= 400 || e.errorType != null;
+  }
+  return false;
+}
+
+/// Renders one timeline entry as a single-line Markdown list item. Nav/DB use
+/// inline formatting matching their detail sections; log/network delegate to
+/// their dedicated one-liner formatters.
+String _timelineLine(TimestampedEntry e) {
+  if (e is LogEntry) return '- ${buildLogOneLiner(e)}';
+  if (e is NetworkEntry) return '- ${buildNetworkOneLiner(e)}';
+  if (e is NavigatorEntry) {
+    return '- [${e.displayTime}] [NAV] ${e.action.name} ${_routeLabel(e)}';
+  }
+  if (e is DatabaseEntry) {
+    final rows = e.affectedRows == null ? '' : ' (${e.affectedRows} rows)';
+    return '- [${e.displayTime}] [DB] ${e.operation.name} `${e.tableName}`$rows';
+  }
+  return '- [${e.displayTime}] [UNKNOWN]';
 }
 
 String _orNA(String? value) => (value == null || value.isEmpty) ? 'N/A' : value;

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -1,7 +1,38 @@
 import '../models/log_entry.dart';
+import '../models/timestamped_entry.dart';
 
 /// Pure formatting helpers for the Console inspector. No Flutter dependencies,
 /// so everything here is unit-testable in isolation.
+
+/// Projects [entry] onto a single dense line for the diagnostic report's
+/// `## Timeline` section: `[HH:mm:ss.mmm] [LOG/{level}] {message}`.
+///
+/// The message is flattened onto one line: a log body can carry its own ```
+/// fence (LLM output, a pasted snippet), and the timeline renders entries as
+/// plain list items, not fenced blocks — keeping the fence off line-start is
+/// what stops it opening a code block that swallows the rest of the report.
+///
+/// When a stack trace is present, up to its first three non-blank frames follow
+/// on their own `  │ ` lines, enough to place the failure without dragging the
+/// whole trace into an at-a-glance view.
+String buildLogOneLiner(LogEntry entry) {
+  final message = entry.message.replaceAll('\n', ' ');
+  final b = StringBuffer(
+    '[${entry.displayTime}] [LOG/${entry.level.name}] $message',
+  );
+
+  final stackTrace = entry.stackTrace;
+  if (stackTrace != null) {
+    final frames = stackTrace
+        .split('\n')
+        .where((l) => l.trim().isNotEmpty)
+        .take(3);
+    for (final frame in frames) {
+      b.write('\n  │ ${frame.trim()}');
+    }
+  }
+  return b.toString();
+}
 
 /// Builds a full plain-text export of [entry] covering general info,
 /// stack trace, and data sections.

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -16,7 +16,10 @@ import '../models/timestamped_entry.dart';
 /// on their own `  │ ` lines, enough to place the failure without dragging the
 /// whole trace into an at-a-glance view.
 String buildLogOneLiner(LogEntry entry) {
-  final message = entry.message.replaceAll('\n', ' ');
+  // \r\n?|\n covers CRLF, lone \r and lone \n — CommonMark treats a lone
+  // carriage return as a line ending too, so leaving it behind would let an
+  // embedded ``` fence back onto line-start.
+  final message = entry.message.replaceAll(RegExp(r'\r\n?|\n'), ' ');
   final b = StringBuffer(
     '[${entry.displayTime}] [LOG/${entry.level.name}] $message',
   );

--- a/lib/src/utils/network_formatters.dart
+++ b/lib/src/utils/network_formatters.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import '../models/network_entry.dart';
+import '../models/timestamped_entry.dart';
 import 'redaction.dart';
 
 /// Pure formatting helpers for the Network inspector. No Flutter dependencies,
@@ -66,6 +67,29 @@ String prettyJson(String? body) {
   } on FormatException {
     return body;
   }
+}
+
+/// Projects [entry] onto a single dense line for the diagnostic report's
+/// `## Timeline` section:
+/// `[HH:mm:ss.mmm] [NET] {method} {path} → {status} ({duration}ms)`, or
+/// `... {method} {path} ✗ {errorType}` for a transport failure (no status code).
+///
+/// Deliberately shows only the URL *path* — never the query string — so
+/// query-param secrets can't leak into the timeline. The full, redacted
+/// request/response stays in the `## Network` detail section.
+String buildNetworkOneLiner(NetworkEntry entry) {
+  final path = Uri.tryParse(entry.url)?.path ?? entry.url;
+  final b = StringBuffer('[${entry.displayTime}] [NET] ${entry.method} $path ');
+
+  if (entry.statusCode == null && entry.errorType != null) {
+    b.write('✗ ${entry.errorType!.name}');
+  } else {
+    b.write('→ ${entry.statusCode ?? 'N/A'}');
+    if (entry.duration != null) {
+      b.write(' (${entry.duration!.inMilliseconds}ms)');
+    }
+  }
+  return b.toString();
 }
 
 /// Builds an executable `curl` command reproducing [entry]'s request.

--- a/lib/src/utils/network_formatters.dart
+++ b/lib/src/utils/network_formatters.dart
@@ -78,7 +78,13 @@ String prettyJson(String? body) {
 /// query-param secrets can't leak into the timeline. The full, redacted
 /// request/response stays in the `## Network` detail section.
 String buildNetworkOneLiner(NetworkEntry entry) {
-  final path = Uri.tryParse(entry.url)?.path ?? entry.url;
+  // A malformed URL (Uri.tryParse == null, e.g. an unclosed IPv6 bracket) must
+  // not fall back to the raw string — that would drag the query, exactly what
+  // this projection exists to hide, into the timeline. Cut the fallback at the
+  // first query/fragment separator and flatten newlines instead.
+  final path =
+      Uri.tryParse(entry.url)?.path ??
+      entry.url.split(RegExp(r'[?#]')).first.replaceAll(RegExp(r'[\r\n]'), ' ');
   final b = StringBuffer('[${entry.displayTime}] [NET] ${entry.method} $path ');
 
   if (entry.statusCode == null && entry.errorType != null) {

--- a/test/ui/export_report_sheet_test.dart
+++ b/test/ui/export_report_sheet_test.dart
@@ -107,7 +107,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(shared.single, isNot(contains('## Network')));
-      expect(shared.single, contains('## Logs'));
+      expect(shared.single, contains('## Timeline'));
     });
 
     testWidgets('errors-only strips info logs from the shared report',

--- a/test/utils/diagnostic_report_test.dart
+++ b/test/utils/diagnostic_report_test.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_inspector_kit/src/inspectors/log_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/database_entry.dart';
 import 'package:flutter_inspector_kit/src/models/database_operation.dart';
@@ -9,6 +10,8 @@ import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
 import 'package:flutter_inspector_kit/src/models/network_entry.dart';
 import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
 import 'package:flutter_inspector_kit/src/utils/diagnostic_report.dart';
+import 'package:flutter_inspector_kit/src/utils/log_formatters.dart';
+import 'package:flutter_inspector_kit/src/utils/network_formatters.dart';
 import 'package:flutter_inspector_kit/src/version.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -72,7 +75,10 @@ void main() {
 
       // Not hardcoded — CI may run in any zone. Assert the shape, then that it
       // matches the fixture clock's actual offset.
-      expect(report, matches(RegExp(r'\| Generated \|.*\(UTC[+-]\d{2}:\d{2}\) \|')));
+      expect(
+        report,
+        matches(RegExp(r'\| Generated \|.*\(UTC[+-]\d{2}:\d{2}\) \|')),
+      );
 
       final offset = _now.timeZoneOffset;
       final sign = offset.isNegative ? '-' : '+';
@@ -103,12 +109,17 @@ void main() {
       expect(report, contains('| OS | iOS 17.4 |'));
     });
 
-    test('a partially-populated source still degrades only the missing fields', () {
-      final report = _report(info: const DiagnosticInfo(osVersion: 'Android 14'));
+    test(
+      'a partially-populated source still degrades only the missing fields',
+      () {
+        final report = _report(
+          info: const DiagnosticInfo(osVersion: 'Android 14'),
+        );
 
-      expect(report, contains('| OS | Android 14 |'));
-      expect(report, contains('| App version | N/A |'));
-    });
+        expect(report, contains('| OS | Android 14 |'));
+        expect(report, contains('| App version | N/A |'));
+      },
+    );
 
     test('states the redaction status honestly', () {
       expect(_report(), contains('| Redaction | enabled |'));
@@ -186,23 +197,26 @@ void main() {
       expect(report, contains('(none)'));
     });
 
-    test('an entry outside the time window leaves its section empty, not absent', () {
-      final report = _report(
-        db: [
-          DatabaseEntry(
-            operation: DatabaseOperation.insert,
-            tableName: 'users',
-            timestamp: _minutesAgo(180),
-          ),
-        ],
-        sections: {TimelineSource.db},
-        timeRange: const Duration(minutes: 5),
-      );
+    test(
+      'an entry outside the time window leaves its section empty, not absent',
+      () {
+        final report = _report(
+          db: [
+            DatabaseEntry(
+              operation: DatabaseOperation.insert,
+              tableName: 'users',
+              timestamp: _minutesAgo(180),
+            ),
+          ],
+          sections: {TimelineSource.db},
+          timeRange: const Duration(minutes: 5),
+        );
 
-      expect(report, contains('## Database'));
-      expect(report, contains('(none)'));
-      expect(report, isNot(contains('users')));
-    });
+        expect(report, contains('## Database'));
+        expect(report, contains('(none)'));
+        expect(report, isNot(contains('users')));
+      },
+    );
   });
 
   group('redaction red line (AC-15, AC-16, AC-18)', () {
@@ -216,15 +230,18 @@ void main() {
       timestamp: _minutesAgo(1),
     );
 
-    test('redact: true masks the secret header and never leaks the plaintext', () {
-      final report = _report(network: [secretRequest()]);
+    test(
+      'redact: true masks the secret header and never leaks the plaintext',
+      () {
+        final report = _report(network: [secretRequest()]);
 
-      expect(report, isNot(contains('super-secret-token')));
-      expect(report, isNot(contains('Bearer')));
-      expect(report, contains('••••'));
-      // Non-sensitive headers survive.
-      expect(report, contains('application/json'));
-    });
+        expect(report, isNot(contains('super-secret-token')));
+        expect(report, isNot(contains('Bearer')));
+        expect(report, contains('••••'));
+        // Non-sensitive headers survive.
+        expect(report, contains('application/json'));
+      },
+    );
 
     test('redact: false emits the plaintext, matching single-entry share', () {
       final report = _report(network: [secretRequest()], redact: false);
@@ -235,28 +252,31 @@ void main() {
   });
 
   group('current route stack (AC-7)', () {
-    test('renders the resolved stack top-first with the current route marked', () {
-      final report = _report(
-        nav: [
-          // newest-first, as FlutterInspector.navigatorEntries yields.
-          NavigatorEntry(
-            action: NavigatorAction.push,
-            routeName: '/checkout',
-            timestamp: _minutesAgo(1),
-          ),
-          NavigatorEntry(
-            action: NavigatorAction.push,
-            routeName: '/cart',
-            timestamp: _minutesAgo(2),
-          ),
-        ],
-        sections: {TimelineSource.nav},
-      );
+    test(
+      'renders the resolved stack top-first with the current route marked',
+      () {
+        final report = _report(
+          nav: [
+            // newest-first, as FlutterInspector.navigatorEntries yields.
+            NavigatorEntry(
+              action: NavigatorAction.push,
+              routeName: '/checkout',
+              timestamp: _minutesAgo(1),
+            ),
+            NavigatorEntry(
+              action: NavigatorAction.push,
+              routeName: '/cart',
+              timestamp: _minutesAgo(2),
+            ),
+          ],
+          sections: {TimelineSource.nav},
+        );
 
-      expect(report, contains('### Current route stack'));
-      expect(report, contains('1. `/checkout` ← current'));
-      expect(report, contains('2. `/cart`'));
-    });
+        expect(report, contains('### Current route stack'));
+        expect(report, contains('1. `/checkout` ← current'));
+        expect(report, contains('2. `/cart`'));
+      },
+    );
 
     test(
       'REGRESSION: the stack replays the full buffer, not the time-windowed list — '
@@ -309,10 +329,12 @@ void main() {
     test('a log message containing a fenced block stays inside its block', () {
       final report = _report(
         logInspector: LogInspector()
-          ..add(LogEntry(
-            message: 'llm replied:\n```\nprint("hi");\n```\ndone',
-            timestamp: _minutesAgo(1),
-          )),
+          ..add(
+            LogEntry(
+              message: 'llm replied:\n```\nprint("hi");\n```\ndone',
+              timestamp: _minutesAgo(1),
+            ),
+          ),
         sections: {TimelineSource.log},
       );
 
@@ -325,10 +347,12 @@ void main() {
       final report = _report(
         logInspector: LogInspector()
           // A truncated LLM response: one lone opening fence, never closed.
-          ..add(LogEntry(
-            message: 'output was cut off:\n```\nvoid main() {}',
-            timestamp: _minutesAgo(1),
-          )),
+          ..add(
+            LogEntry(
+              message: 'output was cut off:\n```\nvoid main() {}',
+              timestamp: _minutesAgo(1),
+            ),
+          ),
         db: [
           DatabaseEntry(
             operation: DatabaseOperation.insert,
@@ -349,10 +373,12 @@ void main() {
     test('inline backticks are harmless and need no wider fence', () {
       final report = _report(
         logInspector: LogInspector()
-          ..add(LogEntry(
-            message: 'the `id` field was null',
-            timestamp: _minutesAgo(1),
-          )),
+          ..add(
+            LogEntry(
+              message: 'the `id` field was null',
+              timestamp: _minutesAgo(1),
+            ),
+          ),
         sections: {TimelineSource.log},
       );
 
@@ -370,26 +396,34 @@ void main() {
     // trap that let FlutterInspector.version rot for three releases.
     LogInspector mixedLevels() {
       return LogInspector()
-        ..add(LogEntry(
-          message: 'boom',
-          level: LogLevel.error,
-          timestamp: _minutesAgo(5),
-        ))
-        ..add(LogEntry(
-          message: 'careful',
-          level: LogLevel.warning,
-          timestamp: _minutesAgo(1),
-        ))
-        ..add(LogEntry(
-          message: 'just-fyi',
-          level: LogLevel.info,
-          timestamp: _minutesAgo(3),
-        ))
-        ..add(LogEntry(
-          message: 'noisy',
-          level: LogLevel.debug,
-          timestamp: _minutesAgo(4),
-        ));
+        ..add(
+          LogEntry(
+            message: 'boom',
+            level: LogLevel.error,
+            timestamp: _minutesAgo(5),
+          ),
+        )
+        ..add(
+          LogEntry(
+            message: 'careful',
+            level: LogLevel.warning,
+            timestamp: _minutesAgo(1),
+          ),
+        )
+        ..add(
+          LogEntry(
+            message: 'just-fyi',
+            level: LogLevel.info,
+            timestamp: _minutesAgo(3),
+          ),
+        )
+        ..add(
+          LogEntry(
+            message: 'noisy',
+            level: LogLevel.debug,
+            timestamp: _minutesAgo(4),
+          ),
+        );
     }
 
     test('off by default: every level is included', () {
@@ -445,5 +479,91 @@ void main() {
       expect(report, contains('https://api.test/ok'));
       expect(report, contains('users'));
     });
+  });
+
+  group('timeline one-liner formatters (AC-1)', () {
+    test('buildLogOneLiner projects [time] [LOG/level] message', () {
+      final entry = LogEntry(
+        message: 'Fetch failed',
+        level: LogLevel.error,
+        timestamp: DateTime(2026, 7, 16, 10, 30, 6),
+      );
+      expect(
+        buildLogOneLiner(entry),
+        '[10:30:06.000] [LOG/error] Fetch failed',
+      );
+    });
+
+    test('buildLogOneLiner appends up to 3 indented stack frames', () {
+      final entry = LogEntry(
+        message: 'Crash',
+        level: LogLevel.error,
+        stackTrace: '#0 a (f:1)\n#1 b (f:2)\n#2 c (f:3)\n#3 d (f:4)',
+        timestamp: DateTime(2026, 7, 16, 10, 30, 6),
+      );
+      final out = buildLogOneLiner(entry);
+
+      expect(
+        out,
+        startsWith('[10:30:06.000] [LOG/error] Crash\n  │ #0 a (f:1)'),
+      );
+      expect(out.split('\n').length, 4); // message + 3 frames, #3 dropped
+    });
+
+    test('buildLogOneLiner flattens message newlines so an embedded fence '
+        'can never sit at line-start', () {
+      final entry = LogEntry(
+        message: 'llm said:\n```\nprint("hi");\n```\ndone',
+        timestamp: DateTime(2026, 7, 16, 10, 30, 6),
+      );
+      final out = buildLogOneLiner(entry);
+
+      // No stackTrace, so the whole projection must be a single line.
+      expect(out.contains('\n'), isFalse);
+      expect(out, contains('print("hi");'));
+    });
+
+    test('buildNetworkOneLiner shows method, path, status and duration', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/data',
+        statusCode: 200,
+        duration: const Duration(milliseconds: 1200),
+        timestamp: DateTime(2026, 7, 16, 10, 30, 5),
+      );
+      expect(
+        buildNetworkOneLiner(entry),
+        '[10:30:05.000] [NET] GET /data → 200 (1200ms)',
+      );
+    });
+
+    test('buildNetworkOneLiner shows ✗ errorType for a transport failure', () {
+      final entry = NetworkEntry(
+        method: 'POST',
+        url: 'https://api.test/api',
+        errorType: DioExceptionType.connectionTimeout,
+        timestamp: DateTime(2026, 7, 16, 10, 30, 5),
+      );
+      expect(
+        buildNetworkOneLiner(entry),
+        '[10:30:05.000] [NET] POST /api ✗ connectionTimeout',
+      );
+    });
+
+    test(
+      'buildNetworkOneLiner shows only the URL path, never query secrets',
+      () {
+        final entry = NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/data?token=super-secret',
+          statusCode: 200,
+          timestamp: DateTime(2026, 7, 16, 10, 30, 5),
+        );
+        final out = buildNetworkOneLiner(entry);
+
+        expect(out, contains('/data'));
+        expect(out, isNot(contains('super-secret')));
+      },
+    );
   });
 }

--- a/test/utils/diagnostic_report_test.dart
+++ b/test/utils/diagnostic_report_test.dart
@@ -187,7 +187,7 @@ void main() {
 
       expect(report, isNot(contains('## Network')));
       expect(report, isNot(contains('https://api.test/x')));
-      expect(report, contains('## Logs'));
+      expect(report, contains('## Timeline'));
     });
 
     test('a selected but empty source renders (none), not a blank block', () {
@@ -324,9 +324,11 @@ void main() {
   group('markdown integrity: payloads that contain their own fences', () {
     // The whole point of this feature is pasting the report into a GitHub or
     // Jira issue. A payload carrying its own ``` (LLM output, CMS content, a
-    // pasted snippet) must not be able to break out of its code block.
+    // pasted snippet) must not be able to break out and swallow what follows.
+    // The timeline renders logs as inline list items and flattens the message,
+    // so a payload fence can never sit at line-start to open a block at all.
 
-    test('a log message containing a fenced block stays inside its block', () {
+    test('a log message with its own fence cannot open a code block', () {
       final report = _report(
         logInspector: LogInspector()
           ..add(
@@ -338,9 +340,10 @@ void main() {
         sections: {TimelineSource.log},
       );
 
-      // The outer fence must outrun the payload's own 3-backtick run.
-      expect(report, contains('````'));
+      // Flattened onto the one-liner, the payload survives but its fence is
+      // mid-line — it never opens a block, so the document stays balanced.
       expect(report, contains('print("hi");'));
+      expect(_fencesBalanced(report), isTrue, reason: 'a fence was left open');
     });
 
     test('an unbalanced fence does not swallow the sections that follow', () {
@@ -363,8 +366,8 @@ void main() {
         sections: {TimelineSource.log, TimelineSource.db},
       );
 
-      // With a fixed 3-backtick fence, the payload's stray fence flips parity
-      // and everything after it is eaten — headings included.
+      // Flattening keeps the stray fence off line-start, so it can't flip block
+      // parity and eat the headings that follow.
       expect(report, contains('## Database'));
       expect(report, contains('users'));
       expect(_fencesBalanced(report), isTrue, reason: 'a fence was left open');
@@ -442,7 +445,7 @@ void main() {
       expect(report, contains('careful'));
       expect(report, isNot(contains('just-fyi')));
       expect(report, isNot(contains('noisy')));
-      expect(report, contains('Logs (errors & warnings only)'));
+      expect(report, contains('Timeline (errors & warnings only)'));
     });
 
     test('on: the surviving logs stay newest-first after the level merge', () {
@@ -454,7 +457,7 @@ void main() {
       expect(report.indexOf('careful'), lessThan(report.indexOf('boom')));
     });
 
-    test('does not touch the network / nav / db sections', () {
+    test('filters the timeline stream but leaves the detail sections intact', () {
       final report = _report(
         logInspector: mixedLevels(),
         network: [
@@ -475,9 +478,51 @@ void main() {
         errorsOnly: true,
       );
 
-      // A 200 is not an error, but errorsOnly is a *log-level* filter only.
+      // errorsOnly now filters the whole timeline stream: a 200 and a plain
+      // query carry no error signal, so neither reaches ## Timeline...
+      expect(report, isNot(contains('[NET] GET /ok')));
+      // ...but the independent ## Network / ## Database detail sections are
+      // untouched and still carry the full record.
       expect(report, contains('https://api.test/ok'));
       expect(report, contains('users'));
+    });
+  });
+
+  group('timeline section (AC-1, AC-6)', () {
+    test('replaces ## Logs with a ## Timeline that interleaves all sources', () {
+      final report = _report(
+        logInspector: LogInspector()
+          ..add(
+            LogEntry(message: 'App started', timestamp: _minutesAgo(3)),
+          ),
+        network: [
+          NetworkEntry(
+            method: 'GET',
+            url: 'https://api.test/data',
+            statusCode: 502,
+            duration: const Duration(milliseconds: 40),
+            timestamp: _minutesAgo(1),
+          ),
+        ],
+        nav: [
+          NavigatorEntry(
+            action: NavigatorAction.push,
+            routeName: '/home',
+            timestamp: _minutesAgo(2),
+          ),
+        ],
+      );
+
+      expect(report, contains('## Timeline'));
+      expect(report, isNot(contains('## Logs')));
+
+      // Newest first: NET (1m) → NAV (2m) → LOG (3m).
+      final net = report.indexOf('[NET] GET /data → 502');
+      final nav = report.indexOf('[NAV] push `/home`');
+      final log = report.indexOf('[LOG/info] App started');
+      expect(net, greaterThanOrEqualTo(0));
+      expect(nav, greaterThan(net));
+      expect(log, greaterThan(nav));
     });
   });
 

--- a/test/utils/diagnostic_report_test.dart
+++ b/test/utils/diagnostic_report_test.dart
@@ -457,73 +457,113 @@ void main() {
       expect(report.indexOf('careful'), lessThan(report.indexOf('boom')));
     });
 
-    test('filters the timeline stream but leaves the detail sections intact', () {
-      final report = _report(
-        logInspector: mixedLevels(),
-        network: [
-          NetworkEntry(
-            method: 'GET',
-            url: 'https://api.test/ok',
-            statusCode: 200,
-            timestamp: _minutesAgo(1),
-          ),
-        ],
-        db: [
-          DatabaseEntry(
-            operation: DatabaseOperation.query,
-            tableName: 'users',
-            timestamp: _minutesAgo(1),
-          ),
-        ],
-        errorsOnly: true,
-      );
+    test(
+      'filters the timeline stream but leaves the detail sections intact',
+      () {
+        final report = _report(
+          logInspector: mixedLevels(),
+          network: [
+            NetworkEntry(
+              method: 'GET',
+              url: 'https://api.test/ok',
+              statusCode: 200,
+              timestamp: _minutesAgo(1),
+            ),
+          ],
+          db: [
+            DatabaseEntry(
+              operation: DatabaseOperation.query,
+              tableName: 'users',
+              timestamp: _minutesAgo(1),
+            ),
+          ],
+          errorsOnly: true,
+        );
 
-      // errorsOnly now filters the whole timeline stream: a 200 and a plain
-      // query carry no error signal, so neither reaches ## Timeline...
-      expect(report, isNot(contains('[NET] GET /ok')));
-      // ...but the independent ## Network / ## Database detail sections are
-      // untouched and still carry the full record.
-      expect(report, contains('https://api.test/ok'));
-      expect(report, contains('users'));
-    });
+        // errorsOnly now filters the whole timeline stream: a 200 and a plain
+        // query carry no error signal, so neither reaches ## Timeline...
+        expect(report, isNot(contains('[NET] GET /ok')));
+        // ...but the independent ## Network / ## Database detail sections are
+        // untouched and still carry the full record.
+        expect(report, contains('https://api.test/ok'));
+        expect(report, contains('users'));
+      },
+    );
+
+    test(
+      'keeps failed network calls in the timeline — both error branches',
+      () {
+        final report = _report(
+          network: [
+            // Server error: statusCode >= 400.
+            NetworkEntry(
+              method: 'GET',
+              url: 'https://api.test/bad-gateway',
+              statusCode: 502,
+              timestamp: _minutesAgo(1),
+            ),
+            // Transport failure: no status, non-null errorType.
+            NetworkEntry(
+              method: 'POST',
+              url: 'https://api.test/timeout',
+              errorType: DioExceptionType.connectionTimeout,
+              timestamp: _minutesAgo(2),
+            ),
+            // Control: a 200 must stay excluded.
+            NetworkEntry(
+              method: 'GET',
+              url: 'https://api.test/ok',
+              statusCode: 200,
+              timestamp: _minutesAgo(3),
+            ),
+          ],
+          errorsOnly: true,
+        );
+
+        expect(report, contains('[NET] GET /bad-gateway → 502'));
+        expect(report, contains('[NET] POST /timeout ✗ connectionTimeout'));
+        expect(report, isNot(contains('[NET] GET /ok')));
+      },
+    );
   });
 
   group('timeline section (AC-1, AC-6)', () {
-    test('replaces ## Logs with a ## Timeline that interleaves all sources', () {
-      final report = _report(
-        logInspector: LogInspector()
-          ..add(
-            LogEntry(message: 'App started', timestamp: _minutesAgo(3)),
-          ),
-        network: [
-          NetworkEntry(
-            method: 'GET',
-            url: 'https://api.test/data',
-            statusCode: 502,
-            duration: const Duration(milliseconds: 40),
-            timestamp: _minutesAgo(1),
-          ),
-        ],
-        nav: [
-          NavigatorEntry(
-            action: NavigatorAction.push,
-            routeName: '/home',
-            timestamp: _minutesAgo(2),
-          ),
-        ],
-      );
+    test(
+      'replaces ## Logs with a ## Timeline that interleaves all sources',
+      () {
+        final report = _report(
+          logInspector: LogInspector()
+            ..add(LogEntry(message: 'App started', timestamp: _minutesAgo(3))),
+          network: [
+            NetworkEntry(
+              method: 'GET',
+              url: 'https://api.test/data',
+              statusCode: 502,
+              duration: const Duration(milliseconds: 40),
+              timestamp: _minutesAgo(1),
+            ),
+          ],
+          nav: [
+            NavigatorEntry(
+              action: NavigatorAction.push,
+              routeName: '/home',
+              timestamp: _minutesAgo(2),
+            ),
+          ],
+        );
 
-      expect(report, contains('## Timeline'));
-      expect(report, isNot(contains('## Logs')));
+        expect(report, contains('## Timeline'));
+        expect(report, isNot(contains('## Logs')));
 
-      // Newest first: NET (1m) → NAV (2m) → LOG (3m).
-      final net = report.indexOf('[NET] GET /data → 502');
-      final nav = report.indexOf('[NAV] push `/home`');
-      final log = report.indexOf('[LOG/info] App started');
-      expect(net, greaterThanOrEqualTo(0));
-      expect(nav, greaterThan(net));
-      expect(log, greaterThan(nav));
-    });
+        // Newest first: NET (1m) → NAV (2m) → LOG (3m).
+        final net = report.indexOf('[NET] GET /data → 502');
+        final nav = report.indexOf('[NAV] push `/home`');
+        final log = report.indexOf('[LOG/info] App started');
+        expect(net, greaterThanOrEqualTo(0));
+        expect(nav, greaterThan(net));
+        expect(log, greaterThan(nav));
+      },
+    );
   });
 
   group('timeline one-liner formatters (AC-1)', () {
@@ -565,6 +605,19 @@ void main() {
 
       // No stackTrace, so the whole projection must be a single line.
       expect(out.contains('\n'), isFalse);
+      expect(out, contains('print("hi");'));
+    });
+
+    test('buildLogOneLiner flattens CRLF and lone CR too — CommonMark treats '
+        'a lone \\r as a line ending', () {
+      final entry = LogEntry(
+        message: 'windows says:\r\n```\r\nprint("hi");\r```\rdone',
+        timestamp: DateTime(2026, 7, 16, 10, 30, 6),
+      );
+      final out = buildLogOneLiner(entry);
+
+      expect(out.contains('\n'), isFalse);
+      expect(out.contains('\r'), isFalse);
       expect(out, contains('print("hi");'));
     });
 
@@ -610,5 +663,22 @@ void main() {
         expect(out, isNot(contains('super-secret')));
       },
     );
+
+    test('buildNetworkOneLiner keeps query secrets out even when the URL is '
+        'malformed and Uri.tryParse fails', () {
+      // An unclosed IPv6 bracket makes Uri.tryParse return null; the raw-url
+      // fallback must still cut everything from the first ?/# separator.
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'http://[::1:8080/path?token=super-secret',
+        statusCode: 500,
+        timestamp: DateTime(2026, 7, 16, 10, 30, 5),
+      );
+      final out = buildNetworkOneLiner(entry);
+
+      expect(out, contains('/path'));
+      expect(out, isNot(contains('super-secret')));
+      expect(out.contains('\n'), isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Summary

`buildDiagnosticReport()` 原本把 Log / Network / Nav / DB 輸出成四個獨立 section,跨層因果(按鈕 → API → 5xx → error log)在報告中斷裂,QA 需人工對齊時間戳。本 PR 將 `## Logs` 替換為按 `timestamp` 降序交錯四層事件的 **`## Timeline` 單行混合串流**,復用既有 `TimestampedEntry` 排序鍵,**不引入新資料模型**。獨立的 `## Network` / `## Navigation` / `## Database` detail section 保留不動,完整 payload 不受影響。

實作依 committed design spec / plan,並以真實 codebase API 校正 plan 中的數處測試碼錯誤。

## 修正問題

- 匯出報告跨層因果斷裂:四層事件依型別分組、無時序交錯。
- `## Logs` 冗長:每筆印 General/StackTrace/Data,90% 無 stackTrace 的 entry 佔滿垂直空間。
- `errorsOnly` 只過濾 log,network 錯誤無法一併聚焦。

## 修正方式

- 新增 `buildLogOneLiner` / `buildNetworkOneLiner` 單行 formatter(`log_formatters.dart` / `network_formatters.dart`)。
- `buildDiagnosticReport` 依 `sections` 合流四源 → `inWindow` 時窗 → 降序 sort → `## Timeline` 逐筆單行渲染。
- `errorsOnly` 升級為過濾整條 stream:留 error/warning log + `statusCode>=400 || errorType!=null` 的 network,剔除 nav/db;detail section 不受影響。
- **markdown 安全**:log 訊息換行壓平 + 以 list item(非 fenced block)渲染,杜絕訊息內含 ``` 撐破報告。
- **redaction**:Timeline 只顯示 URL path(無 query),query-param secret 不外洩;detail section 維持既有 redaction。

## 刻意設計取捨

- Timeline 時間戳含毫秒 `[HH:mm:ss.mmm]`(復用 `displayTime`,與 nav/db detail 一致)。
- log 的 `data` 與完整 stacktrace 不再進報告(Timeline 只留 message + 前 3 frame),符合 design spec §2/§3.2。

## 測試

- `diagnostic_report_test.dart`:+6 formatter 測試、+1 交錯排序測試、fence 安全性改為 inline 行為、errorsOnly 語意鎖定。
- 全套 **379 passed**(排除既有 10 分鐘 timeout 的 `magical_tap_test`,與本變更無關);`flutter analyze lib/` clean(僅 2 個既有 Radio deprecation,非本 PR)。

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 诊断报告改为统一的按时间倒序 **Timeline**：交错展示日志、网络、导航、数据库；不再显示独立 **Logs** 区块。
  * Timeline 使用高信息密度**单行**格式：日志消息扁平化并按需截断堆栈；网络仅展示 URL 路径，并按成功/失败显示状态或错误类型（含耗时）。
* **改进**
  * “仅错误/仅错误与警告”筛选范围扩展到整个时间线：保留错误/警告日志与失败网络请求，导航/数据库在该模式下不再输出；底部 **Network/Navigation/Database** 详情保持不变。
* **文档**
  * 新增时间轴重构设计与实施计划文档。
* **测试**
  * 更新导出与诊断报告测试：校验 Timeline 结构、时间排序、错误筛选、以及渲染围栏完整性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->