### PR TITLE
chore(release): bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.6.0
+
+### Changed
+* **Diagnostic report Timeline**: the exported report's separate "Logs" section is now a chronological mixed **Timeline** that interleaves log, network, navigation, and database entries by timestamp (newest first), surfacing cross-layer causality at a glance. The independent Network / Navigation / Database detail sections remain below it.
+* **"Errors & warnings only" now filters the whole Timeline**: previously the toggle restricted only the log section; it now keeps error-signal entries across the entire Timeline stream (logs plus failed/errored network calls), while the detail sections are unaffected.
+
+### Fixed
+* **Timeline one-liner hardening**: report one-liners are now guarded against CRLF injection and malformed-URL leaks.
+
 ## 1.5.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.5.0
+  flutter_inspector_kit: ^1.6.0
 ```
 
 Then run `flutter pub get`.
@@ -514,6 +514,13 @@ Open the dashboard and tap the **share icon** in the app bar. Pick which sources
 include, a time window (last 5m / last 1h / all), and optionally "errors & warnings
 only", then hit **Share report** — a Markdown report goes straight to the system
 share sheet. Nothing is written to disk.
+
+The report leads with a single chronological **Timeline** that interleaves the log,
+network, navigation, and database entries you selected by timestamp (newest first),
+so cross-layer causality reads at a glance; the per-source Network / Navigation /
+Database detail sections follow below it. The "errors & warnings only" toggle filters
+this whole Timeline down to error signals (log errors/warnings plus failed network
+calls), leaving those detail sections untouched.
 
 The report inherits your `redactSensitiveData` setting, and its header states
 `Redaction: enabled` / `disabled` so whoever receives it knows what was masked.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 1.5.0
+version: 1.6.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary

[#88](https://github.com/Yomiamy/flutter_inspector_kit/issues/88) Release: Version 1.6.0

**[修正問題]**
發布新版 `1.6.0`，整合最近合併入 `main` 的 Diagnostic Report Timeline 重構，並同步更新 `pubspec.yaml`、說明文檔與變更日誌。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號為 `1.6.0`。
2. **`README.md`**：安裝版號更新為 `^1.6.0`，並在 Export 章節說明報告主體改為跨來源時序 Timeline（log / network / nav / db 依時間交錯，newest first），以及 errors-only 現在過濾整個 Timeline。
3. **`CHANGELOG.md`**：新增 `1.6.0` 版本日誌，分類記錄 Changed / Fixed 異動。
