### PR TITLE
chore(release): bump version to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.7.0
+
+### Added
+* **WebView inline debugging**: introduced `WebViewBridgeAdapter` and injected JS bridge payload to seamlessly capture and translate a WebView's `console.*`, `window.onerror`, `fetch`, and `XMLHttpRequest` activity into the native Console and Network tabs.
+* **First-class provenance metadata**: network and log entries now include `origin` (e.g., `NetworkOrigin.webview` vs `NetworkOrigin.dio`) and `pageUrl` fields, clearly distinguishing native HTTP traffic from WebView traffic in the detail views.
+
+### Fixed
+* **WebView bridge reliability**: capped raw bridge message size before JSON decoding to prevent memory spikes, and properly guarded `XHR` response text reads for non-text response types.
+
 ## 1.6.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.6.0
+  flutter_inspector_kit: ^1.7.0
 ```
 
 Then run `flutter pub get`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 1.6.0
+version: 1.7.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary
[#93](https://github.com/Yomiamy/flutter_inspector_kit/issues/93) Release: Version 1.7.0

**[修正問題]**
發布新版 `1.7.0`，整合最近合併入 `main` 的 WebView inline debugging（包含 WebViewBridgeAdapter 與來源中繼資料標記）等變更，並同步更新 `pubspec.yaml`、說明文檔與變更日誌。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號為 `1.7.0`。
2. **`README.md`**：更新安裝版號為 `^1.7.0`。
3. **`CHANGELOG.md`**：新增 `1.7.0` 的版本日誌，分類記錄各項 Added（WebView 橋接支援與來源標記）與 Fixed（橋接穩定性修正）異動。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持 WebView 内联调试，可在原生控制台与网络视图中查看日志、错误及请求活动。
  - 网络与日志信息新增来源和页面地址，便于区分 WebView 与其他请求来源。
- **问题修复**
  - 限制桥接消息大小，降低异常内存占用风险。
  - 改进非文本响应的请求读取，避免读取错误。
- **文档**
  - 更新安装示例至 1.7.0 版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->