### PR TITLE
fix(uncaught-error): dedup identical FlutterErrorDetails logged twice across hooks

### DIFF
--- a/docs/features/2026-07-23-uncaught-error-dedup.md
+++ b/docs/features/2026-07-23-uncaught-error-dedup.md
@@ -1,0 +1,48 @@
+# 功能規格：全局未捕捉例外去重
+
+- 日期：2026-07-23
+- 類型：Bug fix（單檔）
+- 影響檔案：`lib/src/core/uncaught_error_handler.dart`
+- 對應 brainstorm：#1 / 第四部分 §D2
+
+## Why（一句話）
+
+同一次 widget build 崩潰在 Console 產生兩筆一模一樣的 error log，讓開發者無法分辨「崩潰一次還是兩次」，直接干擾排查判斷。
+
+## 使用者故事
+
+作為使用 flutter_inspector_kit 的**開發者 / QA**，當我的 App 在某次 widget build 拋出例外時，我打開 Inspector Console 期望看到**一筆**對應的 error log。
+
+目前的實作在 `attach()` 中掛了兩個會記錄 Flutter error 的 hook：
+- `FlutterError.onError` → `_logFlutterError(details, source: 'flutterError')`
+- `ErrorWidget.builder` → `_logFlutterError(details, source: 'errorWidget')`
+
+同一次 build 崩潰時，framework 先觸發 `FlutterError.onError`，隨後呼叫 `ErrorWidget.builder` 建立錯誤畫面，**同一個 `FlutterErrorDetails` 物件**被記錄兩次。結果 Console 出現兩筆完全相同的 error，我誤以為崩潰了兩次，浪費時間追一個不存在的第二次崩潰。
+
+## 驗收條件
+
+對齊 `test/core/uncaught_error_handler_test.dart` 既有契約：
+
+1. **去重（identity）**：`dedup: same FlutterErrorDetails logged once across both hooks`
+   同一個 `FlutterErrorDetails` 物件先後經 `FlutterError.onError` 與 `ErrorWidget.builder`，`onLog` 只被呼叫一次（`callCount == 1`）。
+
+2. **不吞真實重複崩潰**：`no dedup: distinct FlutterErrorDetails are each logged`
+   兩個**不同**的 `FlutterErrorDetails` 物件（不同 exception），各記錄一筆（`callCount == 2`）。
+
+3. **不回歸既有行為**：既有的 `idempotent`、`chain`、`guard` 三個測試保持通過——去重不得改變 host handler 鏈接、`handled` 回傳語意、或 `onLog` 丟例外時的容錯。
+
+## 行為邊界決策：identity 去重（而非 hashCode + 時間窗）
+
+**選定：以 object identity 去重**——記住上一次 log 的 `FlutterErrorDetails` 參考，若下一次傳入的是 `identical` 的同一物件則跳過。
+
+理由（Linus 式：消滅特殊情況優於新增判斷）：
+- 既有測試的語意就是「同一物件」。framework 在同一次 build 崩潰中，把**同一個** `FlutterErrorDetails` 實例先後交給兩個 hook——identity 是這個 bug 的精確特徵。
+- `exception.hashCode ^ stack.hashCode` + 「2 秒時間窗」引入 magic number 與時間依賴，是為「不確定是不是同一物件」而打的補丁。既然是同一物件，identity 判斷就完全足夠。
+- 時間窗有真實副作用：兩次**獨立**的相同型別崩潰若落在 2 秒內會被錯誤吞掉（違反驗收條件 2）。identity 天然免疫——不同崩潰 = 不同物件 = `identical` 為 false。
+- 無新資料結構、無新常數、無時鐘讀取：一個 nullable 欄位記住上一筆參考即可。
+
+## 範圍邊界（Out of scope）
+
+- **(a) `PlatformDispatcher.instance.onError` 不涉及**：這是獨立的 async error 來源，記錄自己的 `source: 'platformDispatcher'`，與 build 崩潰的雙 hook 重複問題無關，維持原樣。
+- **(b) 跨 build 的真實重複崩潰不可被吞**：同一個 bug 反覆觸發（每次都是新的 `FlutterErrorDetails` 物件）必須各自記錄。去重只針對「同一物件跨兩個 hook」。
+- **(c) 不引入新資料模型、不新增相依**：以既有型別與一個 nullable 欄位完成，不加 package、不建新 class。

--- a/docs/plans/2026-07-23-uncaught-error-dedup.md
+++ b/docs/plans/2026-07-23-uncaught-error-dedup.md
@@ -3,8 +3,8 @@
 - 日期：2026-07-23
 - 對應規格：`docs/features/2026-07-23-uncaught-error-dedup.md`
 - 類型：Bug fix（單檔、low-effort）
-- 實作檔：`lib/src/core/uncaught_error_handler.dart`（唯一）
-- 測試檔：`test/core/uncaught_error_handler_test.dart`（已寫好，TDD red 完成，本次不動）
+- 實作檔：`lib/src/core/uncaught_error_handler.dart`（唯一邏輯異動）
+- 測試檔：`test/core/uncaught_error_handler_test.dart`（TDD red 先行，本 PR 新增 `dedup` / `no dedup` 兩個測試；既有 3 個測試不動）
 
 ## 核心決策（已鎖定）
 

--- a/docs/plans/2026-07-23-uncaught-error-dedup.md
+++ b/docs/plans/2026-07-23-uncaught-error-dedup.md
@@ -1,0 +1,73 @@
+# 實作計畫：全局未捕捉例外去重（identity dedup）
+
+- 日期：2026-07-23
+- 對應規格：`docs/features/2026-07-23-uncaught-error-dedup.md`
+- 類型：Bug fix（單檔、low-effort）
+- 實作檔：`lib/src/core/uncaught_error_handler.dart`（唯一）
+- 測試檔：`test/core/uncaught_error_handler_test.dart`（已寫好，TDD red 完成，本次不動）
+
+## 核心決策（已鎖定）
+
+以 **object identity** 去重：記住上一次 log 的 `FlutterErrorDetails` 參考，
+下一次進 `_logFlutterError` 時若 `identical(details, _lastLoggedDetails)` 為 true 則 early return。
+兩個 hook（`FlutterError.onError`、`ErrorWidget.builder`）共用同一 guard。
+
+## 資料結構異動
+
+新增單一實例欄位：
+
+| 欄位 | 型別 | 初值 | 為何 nullable |
+|------|------|------|---------------|
+| `_lastLoggedDetails` | `FlutterErrorDetails?` | `null`（不寫初值，Dart 預設 null） | attach 後、第一次崩潰前沒有「上一筆」；null 代表「尚無前一筆可比對」，第一筆 `identical(details, null)` 恆為 false，自然放行。 |
+
+- 無新常數、無時鐘、無 Queue/ring buffer、無新相依、無新 class。
+- 只需保留「上一筆」的理由（**已知邊界**）：build 崩潰的實際順序是
+  `onError(A)` 緊接 `errorWidget(A)`，framework 不會在兩者之間插入其他
+  `FlutterErrorDetails`。因此單一 nullable 參考即可涵蓋全部驗收條件；
+  ring buffer 是為不存在的交錯情境所做的過度設計。
+- `PlatformDispatcher.instance.onError` 不走 `_logFlutterError`，天然不受此欄位影響。
+
+## 檔案異動清單
+
+### `lib/src/core/uncaught_error_handler.dart`
+
+1. 在欄位區（`_attached` 附近）新增：
+   `FlutterErrorDetails? _lastLoggedDetails;`
+   並加一行 `// ponytail:` 註解說明「只記上一筆足矣」的已知邊界。
+2. 在 `_logFlutterError` 進入處加入 guard：
+   - `if (identical(details, _lastLoggedDetails)) return;`
+   - 通過後 `_lastLoggedDetails = details;`，再照原邏輯 build `data` 並呼叫 `onLog`。
+3. 其餘邏輯（chain、wrap、try/catch 容錯、`data` 組裝）完全不動。
+
+## 任務拆分
+
+單一任務（單檔、單欄位、一個 guard）。
+
+| # | 任務 | 寫入 scope | 複雜度等級 |
+|---|------|-----------|-----------|
+| 1 | 在 `UncaughtErrorHandler` 新增 `_lastLoggedDetails` 欄位，於 `_logFlutterError` 入口加入 `identical` guard 與記錄上一筆參考，使既有測試轉綠 | `lib/src/core/uncaught_error_handler.dart` | **機械性** |
+
+理由：改動局限單一函式入口 + 單欄位宣告，無設計分歧、無跨檔整合，測試契約已固定。
+
+## 驗證方式
+
+```bash
+flutter test test/core/uncaught_error_handler_test.dart
+```
+
+- 目標：5 個測試全綠（3 既有 + 2 新增）。
+- 去重生效：`dedup: same FlutterErrorDetails logged once across both hooks`（callCount == 1）。
+- 不吞真實重複：`no dedup: distinct FlutterErrorDetails are each logged`（callCount == 2）。
+- 不回歸：`idempotent`、`chain`、`guard` 維持通過。
+
+## 破壞性分析（對既有行為零破壞）
+
+- **chain / wrap 不變**：guard 只在 `_logFlutterError` 內攔截「是否呼叫 `onLog`」，
+  host handler 鏈接（`_oldFlutterErrorHandler`、`original(details)`）在 guard 之外，
+  無論是否去重都照常執行 → `chain` 測試不受影響。
+- **`handled` 回傳語意不變**：`PlatformDispatcher.onError` 分支完全未觸及 `_lastLoggedDetails`，
+  回傳值來源不變 → `guard` 測試的 `handled == true` 成立。
+- **容錯不變**：`_logFlutterError` 仍在各 hook 的 try/catch 內，去重 early return 不拋例外。
+- **idempotent 不變**：`_attached` 邏輯未動；去重與重複 attach 是正交關注點。
+- **不同物件不被吞**：`identical` 對不同 `FlutterErrorDetails` 恆為 false，
+  跨 build 的真實重複崩潰（每次新物件）各自記錄 → 符合範圍邊界 (b)。

--- a/lib/src/core/uncaught_error_handler.dart
+++ b/lib/src/core/uncaught_error_handler.dart
@@ -20,6 +20,10 @@ class UncaughtErrorHandler {
   FlutterExceptionHandler? _oldFlutterErrorHandler;
   bool Function(Object, StackTrace)? _oldPlatformDispatcherOnError;
   bool _attached = false;
+  // ponytail: only tracks the last logged details, dedups the common
+  // FlutterError.onError + ErrorWidget.builder double-fire for the same
+  // error; a bounded history would be needed to dedup non-adjacent repeats.
+  FlutterErrorDetails? _lastLoggedDetails;
 
   /// Creates a new UncaughtErrorHandler instance.
   UncaughtErrorHandler({required this.onLog});
@@ -27,7 +31,7 @@ class UncaughtErrorHandler {
   /// Attaches the three standard Flutter error hooks, chaining/wrapping any
   /// existing host handler so errors are always forwarded downstream.
   ///
-  /// Idempotent: the dedup flag ensures hooks are attached at most once.
+  /// Idempotent: the `_attached` flag ensures hooks are attached at most once.
   void attach() {
     if (_attached) return;
     _attached = true;
@@ -83,6 +87,9 @@ class UncaughtErrorHandler {
   }
 
   void _logFlutterError(FlutterErrorDetails details, {required String source}) {
+    if (identical(details, _lastLoggedDetails)) return;
+    _lastLoggedDetails = details;
+
     final data = <String, dynamic>{
       'source': source,
       'exceptionType': details.exception.runtimeType.toString(),

--- a/test/core/uncaught_error_handler_test.dart
+++ b/test/core/uncaught_error_handler_test.dart
@@ -118,4 +118,39 @@ void main() {
     final widget = ErrorWidget.builder(buildDetails(StateError('boom')));
     expect(widget.runtimeType, originalBuilder(buildDetails(StateError('boom'))).runtimeType);
   });
+
+  test('dedup: same FlutterErrorDetails logged once across both hooks', () {
+    var callCount = 0;
+    final handler = UncaughtErrorHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+      },
+    );
+    handler.attach();
+
+    // 同一次 build 崩潰：framework 建立單一 details，先觸發 FlutterError.onError，
+    // 再把「同一物件」傳給 ErrorWidget.builder。應只記錄一筆。
+    final details = buildDetails(StateError('boom'));
+    FlutterError.onError!(details);
+    ErrorWidget.builder(details);
+
+    expect(callCount, 1);
+  });
+
+  test('no dedup: distinct FlutterErrorDetails are each logged', () {
+    var callCount = 0;
+    final handler = UncaughtErrorHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+      },
+    );
+    handler.attach();
+
+    // 兩次獨立崩潰 = 兩個不同的 details 物件（identical 為 false）→ 各自記錄。
+    // 這也涵蓋「同一 bug 反覆崩潰不該被吞」的情境。
+    FlutterError.onError!(buildDetails(StateError('a')));
+    ErrorWidget.builder(buildDetails(StateError('b')));
+
+    expect(callCount, 2);
+  });
 }


### PR DESCRIPTION
## Summary

Closes #95

同一次 build 崩潰時，`FlutterError.onError` 與 `ErrorWidget.builder` 會收到**同一個** `FlutterErrorDetails` 物件，兩個 hook 各自呼叫 `_logFlutterError` 記錄一次，導致 Console 對單一錯誤出現兩筆重複 log。

## 修正問題

- Flutter framework 在 widget build 拋錯時，會先觸發 `FlutterError.onError`，再把同一份 `details` 傳給 `ErrorWidget.builder` 產生錯誤畫面。
- `UncaughtErrorHandler` 兩個 hook 各自獨立呼叫 `_logFlutterError`，沒有去重機制，同一錯誤因此被記錄兩次，污染 Console 的錯誤列表。

## 修正方式

- 在 `_logFlutterError` 入口加一道 object-identity guard：新增 `_lastLoggedDetails` 欄位記住上一次已記錄的 `FlutterErrorDetails`，若新進來的 `details` 與其 `identical`，直接 return；否則記錄並更新該欄位。
- 兩個 hook 共用同一個去重點（`_logFlutterError`），不用在每個呼叫端各補一次判斷，改動集中在單一函式。
- 採 **identity 比對**而非 hashCode 或時間窗：同一次崩潰的兩個 hook 傳的是同一物件（identity 恆真），而兩次獨立崩潰即使訊息相同也是不同物件（identity 恆假），不會誤吞短時間內接連發生的獨立錯誤。這也是唯一僅追蹤「最後一筆」而非維護一份有界歷史記錄的取捨（見程式碼內 `ponytail:` 註解）。

## 測試

`test/core/uncaught_error_handler_test.dart` 全數通過（5 個測試，`flutter test` 確認 `All tests passed!`）：
- 3 個既有測試無回歸
- 新增 2 個測試：
  - 同一 `FlutterErrorDetails` 經兩個 hook 各觸發一次 → 僅記錄 1 次
  - 兩個不同的 `FlutterErrorDetails`（各自獨立崩潰）→ 各自記錄，共 2 次，驗證不會誤吞非重複錯誤

## 附帶文件

- `docs/features/2026-07-23-uncaught-error-dedup.md`：功能規格
- `docs/plans/2026-07-23-uncaught-error-dedup.md`：修正計畫

## Summary by Sourcery

Deduplicate identical FlutterErrorDetails logged from FlutterError.onError and ErrorWidget.builder to avoid duplicate console entries for a single build crash.

Bug Fixes:
- Ensure a single FlutterErrorDetails instance is only logged once even if both FlutterError.onError and ErrorWidget.builder receive it.
- Keep distinct FlutterErrorDetails from separate crashes fully logged so real repeated errors are not suppressed.

Enhancements:
- Add object-identity tracking of the last logged FlutterErrorDetails in UncaughtErrorHandler to centralize deduplication at the logging entry point.

Documentation:
- Add a feature specification documenting identity-based deduplication of uncaught Flutter errors and its behavioral boundaries.
- Add an implementation plan describing the UncaughtErrorHandler changes, testing strategy, and non-breaking analysis for the deduplication fix.

Tests:
- Extend uncaught_error_handler tests with scenarios covering deduplication of a single FlutterErrorDetails across hooks and non-deduplication for distinct error details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 全局未捕获异常日志新增自动去重：同一次组件构建中，同一份异常详情只会被记录一次，避免重复上报。
* **错误修复**
  * 不同的异常详情仍会分别记录，确保真实差异不被误合并；既有链式/容错与错误处理行为保持不变。
* **文档**
  * 补充去重功能规格说明，并新增实现计划与验收/验证要点。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->