### PR TITLE
feat(lifecycle): record app foreground/background transitions as timeline logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached` / `hidden`) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Opt-in and disabled by default; `detach()` removes the observer.
+
 ## 1.7.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Added
-* **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached` / `hidden`) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Opt-in and disabled by default; `detach()` removes the observer.
+* **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Opt-in and disabled by default; `detach()` removes the observer.
 
 ## 1.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Added
-* **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Opt-in and disabled by default; `detach()` removes the observer.
+* **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Each entry names the current top-most page (e.g. `App lifecycle: resumed · HomePage (/home)`) so repeated home/back switches stay distinguishable without cross-referencing the Navigator tab. Opt-in and disabled by default; `detach()` removes the observer.
 
 ## 1.7.1
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,18 @@ This wires three standard Flutter hooks — `FlutterError.onError` (build/layout
 
 Captured errors appear as red logs in the **Console** tab. Tap any log that carries a stack trace or structured data to open a detail view with a copyable stack trace and the structured payload, plus copy/share actions.
 
+### App lifecycle markers (opt-in)
+
+Enable **lifecycle capture** to record every foreground/background transition as an `info`-level Console log, so a crash or a stalled request can be read against whether the app was in the foreground at that moment:
+
+```dart
+final inspector = FlutterInspector(captureLifecycleEvents: true);
+```
+
+It is **disabled by default**, and `detach()` removes the observer again. Each transition (`resumed` / `inactive` / `paused` / `detached` / `hidden`) becomes one entry, which the merged Timeline interleaves with network, navigation and database events automatically.
+
+> The observer is registered with `WidgetsBinding.instance.addObserver`, which appends to a list — your app's own `WidgetsBindingObserver`s keep receiving their callbacks untouched.
+
 ### Track navigation
 
 Nothing to do here — routes are tracked automatically once you register `inspector.navigatorObserver` in `navigatorObservers` (see [Initialize](#initialize)). Pushes, pops, and replacements all show up in the Navigator tab.

--- a/README.md
+++ b/README.md
@@ -414,6 +414,15 @@ final inspector = FlutterInspector(captureLifecycleEvents: true);
 
 It is **disabled by default**, and `detach()` removes the observer again. Each transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) becomes one entry, which the merged Timeline interleaves with network, navigation and database events automatically.
 
+Each entry also names the current top-most page, so repeated home/back switches stay distinguishable in the Console without jumping to the Navigator tab:
+
+```text
+App lifecycle: resumed · HomePage (/home)
+App lifecycle: paused · CheckoutPage
+```
+
+The page is a best-effort replay of the navigation history; when it cannot be resolved (empty history), the suffix is simply omitted.
+
 > The observer is registered with `WidgetsBinding.instance.addObserver`, which appends to a list — your app's own `WidgetsBindingObserver`s keep receiving their callbacks untouched.
 
 ### Track navigation

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Enable **lifecycle capture** to record every foreground/background transition as
 final inspector = FlutterInspector(captureLifecycleEvents: true);
 ```
 
-It is **disabled by default**, and `detach()` removes the observer again. Each transition (`resumed` / `inactive` / `paused` / `detached` / `hidden`) becomes one entry, which the merged Timeline interleaves with network, navigation and database events automatically.
+It is **disabled by default**, and `detach()` removes the observer again. Each transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) becomes one entry, which the merged Timeline interleaves with network, navigation and database events automatically.
 
 > The observer is registered with `WidgetsBinding.instance.addObserver`, which appends to a list — your app's own `WidgetsBindingObserver`s keep receiving their callbacks untouched.
 

--- a/docs/brainstorm/2026-07-17-workflow-brainstorm.md
+++ b/docs/brainstorm/2026-07-17-workflow-brainstorm.md
@@ -20,6 +20,7 @@
 | **Gap 2.3** 缺任務完成校驗（`completed_tasks`） | ✅ 已修 | 於 2026-07-21 修復，`advance` 增加任務數量校驗 |
 | **Gap 2.4** STAGE 5 缺 `reviewer→responder` 退回 | ✅ 已修 | 於 2026-07-21 修復，新增閉環轉移路徑 |
 | **Gap 2.5** 廢棄 `.pending-*.json` 無 `prune` GC | ✅ 已修 | 於 2026-07-21 修復，新增 `prune` 指令 |
+| **Bug 1.6** `promote` 後 `stage-done 1` 恆遭拒（STAGE 1 happy path 斷裂） | ⬜ 待修 | 於 2026-07-25 實作 §P13 時撞到並實查確認，詳見 §6 |
 
 > **已落地的地基**（analysis 確認，非本 brainstorm 提出的待辦）：`wf-state.sh` 已成 state 檔唯一入口——狀態機轉移表（非法轉移 `exit 1`）、暫停點棘輪（無 `--confirmed` 拒絕 `advance`）、`set` 白名單、schema 校驗 + 原子寫入皆已實作。
 >
@@ -213,3 +214,35 @@
    在新 session 的 Root 倉庫中呼叫 `continue`，確認腳本會輸出當前所有 worktree 中的 active workflows 列表。
 2. **驗證 Quick 升級隔離性**：
    啟動一個 quick 流程，並執行 `upgrade`。驗證系統是否確實自動建立了對應的 git worktree，並且狀態 JSON 成功被 promote 至該 worktree 目錄下。
+
+---
+
+## 6. 後續發現的待修項目（2026-07-21 之後）
+
+### Bug 1.6: `promote` 後 `stage-done <1>` 恆遭拒，STAGE 1 happy path 斷裂 — ⬜ 待修
+
+* **撞到的情境**：2026-07-25 用本流程實作 §P13（PR #100）時，STAGE 1 建好 worktree 後，照 SKILL.md 的指示跑 `promote` → 隨後 `stage-done <檔> 1`，被腳本直接拒絕：
+  ```
+  wf-state: sequence 模式 stage-done 參數須等於目前 stage（目前：0a），改 stage 請用 advance
+  ```
+* **根因（已實查 `wf-state.sh` 原始碼與多次隔離重現確認）**：
+  - `promote`（Line 144-163）只做兩件事：把 `.branch` 欄位填上、把檔案搬到新 worktree。**它不碰 `stage` 也不碰 `mode`**——所以 promote 完的檔案仍是 `{mode: "sequence", stage: "0a"}`。
+  - 但 SKILL.md 的「狀態機腳本」表格指示 STAGE 1 建好 worktree 後執行 `stage-done <檔> 1`。
+  - `stage-done`（Line 176-187）在 sequence 模式下強制 `<stage> 參數 == 目前 stage`（Line 182-184）。此時目前 stage 還是 `0a`，傳 `1` 必被拒。
+  - 換句話說：**SKILL.md 記載的 STAGE 1 收尾流程，在 sequence 模式下必定失敗**。正常 sequence 從 0a 一路 `advance` 上來時，promote 發生在 STAGE 1，但 stage 欄位並沒有跟著 promote 一起前進到 `1`，兩者脫節。
+* **我最初的誤判（記錄下來以免重蹈）**：當下我把 `&&` 鏈的中斷誤讀成「`promote` 把 state 檔吃掉了」，還推測是 `--dest` 指向不存在目錄 + EXIT trap 所致。**這個診斷是錯的**——事後隔離重現證明 `promote` 對不存在的 dest 目錄運作完全正常（`mkdir -p` + `claim_new` 會建好），檔案該寫的有寫、該刪的 pending 有刪。真正的失敗是後續 `stage-done 1` 被 sequence guard 擋下，中斷了我串起來的 `&&` 鏈，而我沒往下追就 fallback 到 `init --mode jump` 重建。**教訓：`&&` 鏈中斷要逐段定位是哪一段 exit 非零，不要看到 `get` 報 pending 路徑就腦補整條鏈的因果。**
+* **修復方向（二選一，傾向前者）**：
+  1. **`promote` 一併把 stage 推進到 `1`**（語意最直覺：promote 這個動作本身就代表「STAGE 1 的 worktree 建好了」）。改 Line 159 的 `jq`：
+     ```bash
+     jq --arg b "$branch" '.branch = $b | .stage = "1"' "$src" | atomic_write "$f"
+     ```
+     這樣 promote 完就是 `{stage: "1"}`，隨後 `stage-done <檔> 1` 的 sequence guard 通過。promote 不走 `advance`、不受 legal_transition 轉移表約束，安全。
+  2. **改 SKILL.md 的 STAGE 1 流程**，promote 之後先 `advance 0b --confirmed`、`advance 1 --confirmed` 再 `stage-done 1`。缺點：STAGE 1 本來就沒有 0a/0b 的暫停確認語意，硬走 advance 會多兩個不必要的 `--confirmed`，且和「promote 就是進 STAGE 1」的直覺相悖。
+* **影響面**：只要是**正常 sequence 流程**（非 `--mode jump`）跑到 STAGE 1，都會撞到。本次因為 fallback 到 jump 模式而繞過，但 jump 模式喪失了 sequence 的轉移表保護——是繞過不是修好。
+* **驗證方法**：
+  ```bash
+  P=$(wf-state.sh init)                                    # sequence, stage 0a
+  wf-state.sh promote "$P" --branch feat/x --dest wt/.claude/workflow-state
+  WT=wt/.claude/workflow-state/feat-x.json
+  wf-state.sh stage-done "$WT" 1                           # 修復前：被拒；修復後：通過
+  ```

--- a/docs/brainstorm/2026-07-17-workflow-brainstorm.md
+++ b/docs/brainstorm/2026-07-17-workflow-brainstorm.md
@@ -222,7 +222,7 @@
 ### Bug 1.6: `promote` 後 `stage-done <1>` 恆遭拒，STAGE 1 happy path 斷裂 — ⬜ 待修
 
 * **撞到的情境**：2026-07-25 用本流程實作 §P13（PR #100）時，STAGE 1 建好 worktree 後，照 SKILL.md 的指示跑 `promote` → 隨後 `stage-done <檔> 1`，被腳本直接拒絕：
-  ```
+  ```text
   wf-state: sequence 模式 stage-done 參數須等於目前 stage（目前：0a），改 stage 請用 advance
   ```
 * **根因（已實查 `wf-state.sh` 原始碼與多次隔離重現確認）**：
@@ -231,13 +231,10 @@
   - `stage-done`（Line 176-187）在 sequence 模式下強制 `<stage> 參數 == 目前 stage`（Line 182-184）。此時目前 stage 還是 `0a`，傳 `1` 必被拒。
   - 換句話說：**SKILL.md 記載的 STAGE 1 收尾流程，在 sequence 模式下必定失敗**。正常 sequence 從 0a 一路 `advance` 上來時，promote 發生在 STAGE 1，但 stage 欄位並沒有跟著 promote 一起前進到 `1`，兩者脫節。
 * **我最初的誤判（記錄下來以免重蹈）**：當下我把 `&&` 鏈的中斷誤讀成「`promote` 把 state 檔吃掉了」，還推測是 `--dest` 指向不存在目錄 + EXIT trap 所致。**這個診斷是錯的**——事後隔離重現證明 `promote` 對不存在的 dest 目錄運作完全正常（`mkdir -p` + `claim_new` 會建好），檔案該寫的有寫、該刪的 pending 有刪。真正的失敗是後續 `stage-done 1` 被 sequence guard 擋下，中斷了我串起來的 `&&` 鏈，而我沒往下追就 fallback 到 `init --mode jump` 重建。**教訓：`&&` 鏈中斷要逐段定位是哪一段 exit 非零，不要看到 `get` 報 pending 路徑就腦補整條鏈的因果。**
-* **修復方向（二選一，傾向前者）**：
-  1. **`promote` 一併把 stage 推進到 `1`**（語意最直覺：promote 這個動作本身就代表「STAGE 1 的 worktree 建好了」）。改 Line 159 的 `jq`：
-     ```bash
-     jq --arg b "$branch" '.branch = $b | .stage = "1"' "$src" | atomic_write "$f"
-     ```
-     這樣 promote 完就是 `{stage: "1"}`，隨後 `stage-done <檔> 1` 的 sequence guard 通過。promote 不走 `advance`、不受 legal_transition 轉移表約束，安全。
-  2. **改 SKILL.md 的 STAGE 1 流程**，promote 之後先 `advance 0b --confirmed`、`advance 1 --confirmed` 再 `stage-done 1`。缺點：STAGE 1 本來就沒有 0a/0b 的暫停確認語意，硬走 advance 會多兩個不必要的 `--confirmed`，且和「promote 就是進 STAGE 1」的直覺相悖。
+* **⚠️ 一個被否決的錯誤修復方向（記錄下來以免重蹈）**：本文件初稿曾提議「讓 `promote` 一併 `.stage = "1"`」，並自稱「promote 不受轉移表約束，安全」。**這是錯的，經 PR #100 的 CodeRabbit review 抓出並實查確認**：`promote` 不只服務 sequence-from-0a，還服務 **quick→sequence 升級路徑**——SKILL.md L288 明載，`upgrade`（已把 stage 設為 `2`）之後也走 `promote` 把狀態搬進 worktree。若 `promote` 無條件寫死 `stage=1`，會把升級後的 `stage=2` 打回 `1`，讓一個已在實作階段的流程重跑 STAGE 1。原方案只看了一條路徑就下「安全」結論，是典型的以偏概全。
+* **正確的修復方向（限定作用範圍，不動 `promote` 的共用邏輯）**：
+  1. **首選——修 SKILL.md 的 sequence STAGE 1 收尾流程，不碰腳本**：正常 sequence 從 0a 一路 `advance` 上來，promote 之後 stage 仍是 `0a`。收尾時不該用 `stage-done 1`（會撞 guard），而是先 `advance 0b --confirmed` → `advance 1 --confirmed` 走完既有轉移表，stage 到 `1` 後才 `stage-done 1`。這條路徑本來就沒有 0a→0b 的暫停語意，兩個 `--confirmed` 是形式上的多餘、但**零腳本改動、零副作用**，且完全尊重轉移表。
+  2. **次選——若要動腳本，改也只能限定在 sequence STAGE 1**：例如在 SKILL.md 呼叫 promote 後、緊接一個**只在 mode==sequence 且 stage==0a 時**才把 stage 推到 `1` 的動作（不可寫進 `promote` 本體，因為 promote 對 quick 升級是 stage-agnostic 的搬運工）。此路徑必須補 **quick、jump、非-0a** 三種流程的 regression 才能落地，成本高於首選。
 * **影響面**：只要是**正常 sequence 流程**（非 `--mode jump`）跑到 STAGE 1，都會撞到。本次因為 fallback 到 jump 模式而繞過，但 jump 模式喪失了 sequence 的轉移表保護——是繞過不是修好。
 * **驗證方法**：
   ```bash

--- a/docs/features/2026-07-24-app-lifecycle-marker.md
+++ b/docs/features/2026-07-24-app-lifecycle-marker.md
@@ -68,11 +68,16 @@ reviewer 可逐條驗證：
 
 `captureUncaughtErrors` 的 dartdoc 中「hooks are not torn down（detach 只移除 FAB overlay）」這句敘述在本功能落地後會失準，需同步修訂為「error hooks 不 teardown」以免誤導——這是文件精確性問題，不是行為變更。
 
-### (c) log 的 `data` Map — **不帶額外欄位，純 message**
+### (c) log 的 `data` Map — **維持 `null`；top page 資訊放進 message，不放 `data`**
 
-`UncaughtErrorHandler` 帶 `data: {'source': ...}` 是因為它有**三個來源**（`flutterError` / `platformDispatcher` / `errorWidget`）需要區分，那是真實的資訊需求。
+`UncaughtErrorHandler` 帶 `data: {'source': ...}` 是因為它有**三個來源**（`flutterError` / `platformDispatcher` / `errorWidget`）需要區分，那是真實的資訊需求。lifecycle 沒有這種來源歧義，`{'source': 'lifecycle'}` 無消費者——不加，`data` 維持 `null`。
 
-lifecycle 只有一個來源，狀態名稱已經在 message 裡。加 `{'source': 'lifecycle'}` 是為不存在的消費者準備的欄位——沒有任何 UI 或篩選器讀它。YAGNI：不加。真的需要程式化篩選時，message 前綴 `App lifecycle:` 已足夠。
+**修訂（2026-07-25，回應使用者實際使用回饋）**：初版的「純狀態名 message」在真實使用中不夠——home/back 頻繁切換時 `resumed`/`paused` 每筆長得一樣，要知道「這次切換是在哪一頁」得跳去 Navigator tab 對時間戳。因此 message 尾巴附加**當前 top-most page**：`App lifecycle: resumed · HomePage (/home)`（`displayName` 優先 `widgetType` 型態、後接 `routeName`；無 routeName 時只顯示型態；堆疊推不出來時整段省略）。
+
+- **仍放 message、不放 `data`**：使用者要的是 Console 上肉眼一眼可辨，message 尾巴正好；`data` 維持 `null`，不為「未來可能的程式化篩選」預先開欄位（那才是 YAGNI）。
+- **來源是 best-effort 推導**：透過 `NavigatorStackResolver.resolve(navigatorEntries).first` 取得，這是純函式重播、會因 observer 掛載前導航 / buffer 淘汰 / nested Navigator 而失準。故推不出來時**明確省略尾巴**而非硬掰——不讓讀者把推導值當事實（這正是 §P2 被否決的核心教訓，此處用「省略而非猜測」避開同一個坑）。
+- **不帶 `arguments`**：可能含大量資料或 PII，塞進 lifecycle log 是噪音也是洩漏風險，只取型態 + path。
+- **耦合邊界**：`LifecycleHandler` 不持有 registry/resolver，只收一個 `String? Function()? topPageLabel` callback；resolve 邏輯留在 `FlutterInspector._currentTopPageLabel()`。handler 仍是「症狀記錄器」，不知道那個字串怎麼來的。
 
 ### (d) 多實例情境 — **不做去重，文件說明**
 

--- a/docs/features/2026-07-24-app-lifecycle-marker.md
+++ b/docs/features/2026-07-24-app-lifecycle-marker.md
@@ -1,0 +1,122 @@
+# 功能規格：App 前景/背景切換標記（Lifecycle Marker）
+
+- 日期：2026-07-24
+- 類型：新功能（opt-in flag）
+- 對應 brainstorm：`docs/brainstorm/2026-07-24-features-brainstorm.md` §P13（Tier 1）
+- Effort：low ｜排查價值：⭐⭐⭐⭐
+
+## Why（一句話）
+
+崩潰或異常網路行為發生時，「當下 app 是在前景還是背景」這個 context 現在完全沒被記錄——把生命週期切換記成一筆 log，Timeline 上崩潰前最近一筆 lifecycle log 就是答案。
+
+## 背景與痛點
+
+iOS/Android 對背景 app 有資源限制（網路被暫停、被系統 kill 前的緊急回收）。一筆看起來詭異的 timeout、一次沒有明顯成因的崩潰，如果知道它發生在 app 剛被切到背景的瞬間，排查方向立刻收斂。Sentry 等工具的 breadcrumb 預設就包含這個維度，本 package 目前缺席。
+
+`lib/` 與 `test/` 完全沒有 `WidgetsBindingObserver` / `didChangeAppLifecycleState` / `AppLifecycleState` 的任何使用——這是全新地基，不是既有行為的修改。
+
+## 好品味判斷：不新增資料模型
+
+生命週期切換**本身就是一條 log**。比照 §1 未捕捉例外的既有做法，轉成一筆 `LogEntry`（`LogLevel.info`，訊息如 `App lifecycle: resumed`）灌進既有 log buffer。
+
+由此免費得到：
+- Console 分頁直接看得到
+- `mergedTimeline()` 自動把它與 network / nav / db 事件按時間軸交錯排序
+- 診斷報告、匯出、篩選全部無需改動
+
+**不需要**任何側欄、新分頁、新 model、新 buffer。零 UI 工作。
+
+## 使用者故事
+
+作為使用 flutter_inspector_kit 的**開發者 / QA**：
+
+1. 我在 `FlutterInspector(captureLifecycleEvents: true)` 開啟後，把 app 切到背景再切回前景，打開 Console 能看到對應的 lifecycle log 條目。
+2. 我在 Timeline（`mergedTimeline()`）上看到一筆 error 或失敗的 network entry 時，往上找最近一筆 lifecycle log，就能判斷「當時 app 在前景還是背景」。
+3. 我**沒有**開啟這個 flag 時（預設），package 完全不掛 observer、Console 不出現任何 lifecycle log——與升級前行為完全一致。
+
+## 驗收條件
+
+reviewer 可逐條驗證：
+
+1. **預設 off**：`FlutterInspector()` 不帶參數建構後，觸發任意 `AppLifecycleState` 變化，`logEntries` 中不出現 lifecycle log。
+2. **opt-in 生效**：`FlutterInspector(captureLifecycleEvents: true)` 後，每次生命週期狀態變化各產生**一筆** `LogLevel.info` 的 `LogEntry`，message 可辨識狀態名稱（如 `App lifecycle: paused`）。
+3. **狀態覆蓋**：`resumed` / `inactive` / `paused` / `detached` / `hidden` 五個狀態各自都能產生對應 log（見「範圍邊界 (a)」）。
+4. **可乾淨移除**：呼叫 `detach()` 後，再觸發生命週期變化**不再**產生新的 lifecycle log（見「範圍邊界 (b)」）。
+5. **idempotent**：重複掛載不造成同一次狀態變化記錄兩筆。
+6. **不影響宿主**：package 使用 `WidgetsBinding.instance.addObserver`，宿主 app 自己註冊的 observer 照常收到回呼（Flutter 的 observer 是 list，天生並存）。
+7. **容錯**：log 呼叫若拋例外，不得讓 `didChangeAppLifecycleState` 向上拋錯影響宿主——比照 `UncaughtErrorHandler` 內部 try-catch 的既有做法。
+8. `flutter test` 全綠、`flutter analyze` 無新增 warning。
+
+## 範圍邊界（Out of scope）與設計判斷
+
+### (a) `AppLifecycleState.hidden` — **納入**
+
+本專案 Flutter 3.35，`hidden` 是 enum 的合法成員。**不特別處理它就是最好的處理**：直接把 enum 值轉成字串記錄，五個狀態走同一條路徑，沒有 `if`、沒有白名單、沒有 switch。
+
+刻意排除 `hidden` 反而需要寫一個特殊情況分支，而且會在 desktop / web 上遺失真實訊號（`hidden` 在那些平台是有意義的獨立狀態）。Linus 原則：消滅邊界情況優於新增條件檢查。
+
+副作用可接受：iOS 上 `hidden` 與 `inactive` 常成對出現，會多一筆 log。這是誠實反映 framework 實際發出的狀態，不是雜訊——而且未來 Flutter 新增狀態時，此設計自動支援，零改動。
+
+### (b) observer 生命週期 — **`detach()` 負責 `removeObserver`**
+
+**不沿用** `captureUncaughtErrors` 的「不 teardown」慣例。理由是實質差異，不是慣例偏好：
+
+- `FlutterError.onError` 是**單一 slot**。它之所以不 teardown，是因為 attach 後宿主可能又覆寫過，貿然還原 `_old*` 會把宿主後裝的 handler 也一起幹掉——那才是真正的 break userspace。
+- `WidgetsBindingObserver` 是**一個 list**。`removeObserver(this)` 只移除自己這一個實例，對宿主與其他 observer 零影響。可以乾淨移除，就應該乾淨移除——這是 Flutter style guide §7.4「資源管理」的直接要求。
+
+因此 `detach()` 的職責從「只移除 FAB overlay」擴充為「移除 FAB overlay + 移除 lifecycle observer」。這**不是**破壞性變更：既有呼叫者對 `detach()` 的期待是「停止 inspector 的畫面介入」，多清一個自己註冊的 observer 完全落在這個語意內；且未開啟 flag 時 detach 行為逐字不變。
+
+`captureUncaughtErrors` 的 dartdoc 中「hooks are not torn down（detach 只移除 FAB overlay）」這句敘述在本功能落地後會失準，需同步修訂為「error hooks 不 teardown」以免誤導——這是文件精確性問題，不是行為變更。
+
+### (c) log 的 `data` Map — **不帶額外欄位，純 message**
+
+`UncaughtErrorHandler` 帶 `data: {'source': ...}` 是因為它有**三個來源**（`flutterError` / `platformDispatcher` / `errorWidget`）需要區分，那是真實的資訊需求。
+
+lifecycle 只有一個來源，狀態名稱已經在 message 裡。加 `{'source': 'lifecycle'}` 是為不存在的消費者準備的欄位——沒有任何 UI 或篩選器讀它。YAGNI：不加。真的需要程式化篩選時，message 前綴 `App lifecycle:` 已足夠。
+
+### (d) 多實例情境 — **不做去重，文件說明**
+
+同一 app 建多個 `captureLifecycleEvents: true` 的 inspector，會有多個 observer 各記各的 buffer——每個 inspector 的 Console 各看到一筆，行為正確且無交互污染（不像 error hooks 會層層疊加）。
+
+比照 `captureUncaughtErrors` 的既有做法，在 dartdoc 註明「建議只在單一 app-wide inspector 開啟」，不引入全域 registry 或跨實例去重機制。
+
+### (e) 其他明確不做
+
+- **不記錄狀態停留時長**：`paused` 停了多久，讀 Timeline 上兩筆 log 的時間差即可，不預先計算。
+- **不新增 UI**：不做側欄、不做 Timeline 上的視覺標記、不做背景時段的區塊著色。
+- **不記錄 app 啟動當下的初始狀態**：只記錄「變化」。啟動即前景是常態，一筆固定的開場 log 沒有排查價值。
+- **不觸碰 `AppLifecycleListener`**（Flutter 3.13+ 的更細粒度 API，含 `onRestart`/`onExitRequested` 等）：五個狀態已滿足痛點，更細的粒度是 YAGNI。
+- **不新增相依套件**：`WidgetsBindingObserver` 來自 `flutter/widgets.dart`，已 import。
+
+## 破壞性分析
+
+**預期為零。** 逐項論證：
+
+| 面向 | 影響 | 理由 |
+|------|------|------|
+| 公開建構參數 | 無 | 新增**可選**參數 `captureLifecycleEvents = false`，既有呼叫端一字不改仍可編譯，行為完全相同 |
+| `logEntries` 內容 | 無 | flag off 時不註冊 observer，不產生任何新 log |
+| `detach()` 行為 | 無 | flag off 時沒有 observer 可移除，執行路徑與現況等價 |
+| 宿主的 observer | 無 | `addObserver` 是加入 list，非覆寫；宿主的 `didChangeAppLifecycleState` 照常被呼叫 |
+| 既有測試 | 無 | 所有既有測試皆以預設參數建構 inspector |
+| Buffer 容量 | 極小 | lifecycle 事件頻率低（人為切換），`bufferSize` 預設 500，不構成擠壓風險 |
+
+唯一需要留意的是 `captureUncaughtErrors` dartdoc 中對 `detach()` 的描述需修訂措辭（見 (b)）——文件精確性，非行為破壞。
+
+## 重用清單
+
+不新增任何資料模型、UI、相依。全部重用既有零件：
+
+- `FlutterInspector.log()` — 寫入 log buffer 的唯一入口
+- `LogEntry` / `LogLevel.info` — 既有資料模型
+- `typedef LogCallback`（`lib/src/core/uncaught_error_handler.dart` 已定義並匯出）— handler 收 log 回呼的既有簽章
+- `mergedTimeline()` — 時序交錯，免費疊加
+- `UncaughtErrorHandler` 的**模式**（非程式碼）：獨立 handler class、建構式收 `LogCallback onLog`、`_attached` 旗標做 idempotent、內部 try-catch 保護宿主
+- `WidgetsBindingObserver` + `WidgetsBinding.instance.addObserver/removeObserver` — Flutter framework 內建
+- `test/core/uncaught_error_handler_test.dart` 的**測試模式**：`TestWidgetsFlutterBinding.ensureInitialized()`、注入 counting `onLog` 直接驗證行為
+- 文件三處既有慣例對齊：`README.md`（`captureUncaughtErrors: true` 範例附近）、`CHANGELOG.md`、`example/lib/main.dart`
+
+## 不確定 / 待決事項
+
+1. **message 文字格式**：規格採 `App lifecycle: resumed`（brainstorm 原提案）。實作時若 enum 的 `.name` 直接輸出更簡潔，可在不影響驗收條件 2「message 可辨識狀態名稱」的前提下微調。
+2. **`detached` 的可觀測性**：Android 上 `detached` 後 log 未必來得及被讀取（進程即將終止）。這是平台限制，不是實作缺陷；規格不承諾 `detached` 的 log 在真機上一定能被撈到，但仍要記錄（測試環境可驗證）。

--- a/docs/plans/2026-07-24-app-lifecycle-marker.md
+++ b/docs/plans/2026-07-24-app-lifecycle-marker.md
@@ -1,0 +1,301 @@
+# 實作計畫：App 前景/背景切換標記（Lifecycle Marker）
+
+- 日期：2026-07-24
+- 對應規格：`docs/features/2026-07-24-app-lifecycle-marker.md`（已定案，本計畫不重新設計）
+- 類型：新功能（opt-in flag），low effort
+- 實作檔：`lib/src/core/lifecycle_handler.dart`（新增）、`lib/src/core/flutter_inspector.dart`（接線）
+- 測試檔：`test/core/lifecycle_handler_test.dart`（新增，TDD red 先行）、`test/core/flutter_inspector_lifecycle_test.dart`（新增，接線層驗收）
+
+---
+
+## 一、核心決策（已由規格鎖定，implementer 不需再做設計判斷）
+
+| 決策點 | 結論 | 依據 |
+|--------|------|------|
+| 資料模型 | **不新增**。生命週期變化 = 一筆 `LogEntry`（`LogLevel.info`） | 規格「好品味判斷」 |
+| message 格式 | `'App lifecycle: ${state.name}'` | 規格 §待決 1，`.name` 直接輸出即滿足驗收條件 2 |
+| `data` Map | **不帶**（傳 `null`，即不傳該具名參數） | 規格 (c) YAGNI |
+| `hidden` 狀態 | 不特判，五狀態走同一條路徑，零 `if`／零 `switch` | 規格 (a) |
+| observer teardown | `detach()` 呼叫 `removeObserver` | 規格 (b) |
+| 多實例去重 | **不做**，dartdoc 註明建議單一 app-wide inspector | 規格 (d) |
+| 初始狀態 | **不記錄**，只記錄「變化」 | 規格 (e) |
+| 新相依 | **無**（`WidgetsBindingObserver` 來自已 import 的 `flutter/widgets.dart`） | 規格 (e) |
+
+### 為何開新檔而非塞進 `flutter_inspector.dart`
+
+`FlutterInspector` 若自己 `implements WidgetsBindingObserver`，就得在公開 API 上曝露 `didChangeAppLifecycleState`、`didChangeMetrics` 等一整組 framework 回呼——污染公開介面，且與既有 `UncaughtErrorHandler` 的「獨立 handler class」慣例衝突。獨立 class 是規格「重用清單」明列的模式，且是**唯一**新檔。
+
+---
+
+## 二、資料結構
+
+新 class `LifecycleHandler` 的完整狀態：
+
+| 欄位 | 型別 | 用途 |
+|------|------|------|
+| `onLog` | `final LogCallback` | 既有 typedef，從 `uncaught_error_handler.dart` **import 重用**，禁止重複定義 |
+| `_attached` | `bool`（初值 `false`） | idempotent 旗標，比照 `UncaughtErrorHandler` |
+
+無其他欄位。**不存**「上一個狀態」——規格未要求去重相鄰重複狀態，framework 本來就只在狀態真的變化時回呼。
+
+---
+
+## 三、核心程式碼結構（implementer 照此實作，不需再做設計決策）
+
+### 3.1 `lib/src/core/lifecycle_handler.dart`（新增）
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import '../models/log_level.dart';
+import 'uncaught_error_handler.dart' show LogCallback;
+
+/// Records app lifecycle transitions as [LogLevel.info] log entries.
+///
+/// Registers itself on [WidgetsBinding.instance] as an observer. Flutter keeps
+/// observers in a list, so the host app's own observers keep receiving their
+/// callbacks unaffected.
+class LifecycleHandler with WidgetsBindingObserver {
+  /// The function called to log a lifecycle transition.
+  final LogCallback onLog;
+
+  bool _attached = false;
+
+  /// Creates a new LifecycleHandler instance.
+  LifecycleHandler({required this.onLog});
+
+  /// Registers this handler as a [WidgetsBindingObserver].
+  ///
+  /// Idempotent: the `_attached` flag ensures a single state change is never
+  /// recorded twice by the same instance.
+  void attach() {
+    if (_attached) return;
+    _attached = true;
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  /// Removes this handler from [WidgetsBinding.instance].
+  ///
+  /// Safe to call when not attached, and safe to call twice.
+  void detach() {
+    if (!_attached) return;
+    _attached = false;
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    try {
+      onLog('App lifecycle: ${state.name}', level: LogLevel.info);
+    } catch (e, s) {
+      debugPrintStack(stackTrace: s, label: 'inspector lifecycle log failed: $e');
+    }
+  }
+}
+```
+
+實作備註：
+- `with WidgetsBindingObserver`（mixin）而非 `implements`——避免被迫實作全部回呼。
+- `detach()` 後 `_attached = false`，使 attach → detach → attach 可重新生效（驗收條件 4、5 的自然結果，非額外功能）。
+- catch 內措辭沿用既有 `debugPrintStack(... label: '...failed: $e')` 格式。
+- 不覆寫其他 `WidgetsBindingObserver` 回呼。
+
+### 3.2 `lib/src/core/flutter_inspector.dart`（修改）
+
+四處異動，全部在既有結構的對應位置：
+
+1. **import**：新增 `import 'lifecycle_handler.dart';`
+2. **公開欄位 + dartdoc**（緊接在 `captureUncaughtErrors` 欄位之後，L71 附近）：
+
+```dart
+/// Whether to record app lifecycle transitions (`resumed` / `inactive` /
+/// `paused` / `detached` / `hidden`) as [LogLevel.info] log entries, so a
+/// crash or a stalled request can be read against whether the app was in the
+/// foreground at that moment.
+///
+/// Defaults to `false` so the package registers no observer unless the host
+/// opts in.
+///
+/// Notes:
+/// - Enable this on a single, app-wide inspector. Each enabled instance keeps
+///   its own observer and its own buffer, so multiple instances each record
+///   their own copy (correct per instance, just duplicated across them).
+/// - Unlike the error hooks, this observer *is* torn down: [detach] removes it
+///   from [WidgetsBinding.instance]. Removing one observer from the binding's
+///   list cannot affect the host's own observers.
+final bool captureLifecycleEvents;
+```
+
+3. **私有欄位**（`_uncaughtErrorHandler` 附近，L87 區塊）：`late final LifecycleHandler _lifecycleHandler;`
+4. **建構式**：具名參數清單加 `this.captureLifecycleEvents = false,`（置於 `captureUncaughtErrors` 之後，維持既有順序語意）；body 內緊接 `if (captureUncaughtErrors) setupErrorHandlers();` 之後加：
+
+```dart
+_lifecycleHandler = LifecycleHandler(onLog: log);
+if (captureLifecycleEvents) _lifecycleHandler.attach();
+```
+
+5. **`detach()`**：
+
+```dart
+/// Removes the FAB overlay, and the lifecycle observer when
+/// [captureLifecycleEvents] is enabled.
+void detach() {
+  _overlayManager.detach();
+  _lifecycleHandler.detach();
+}
+```
+
+（`_lifecycleHandler.detach()` 在未 attach 時是 no-op，不需外層 `if`——消滅特殊情況。）
+
+6. **`captureUncaughtErrors` dartdoc 修訂**（規格 (b) 要求）：L68-70 原句
+
+> `The hooks are not torn down: once attached they remain for the process lifetime ([detach] only removes the FAB overlay).`
+
+改為：
+
+> `The error hooks are not torn down: once attached they remain for the process lifetime ([detach] does not restore them). The `_old*` handlers are kept solely to chain to, not to restore.`
+
+**只改這句措辭**，不動同段其他內容。
+
+---
+
+## 四、檔案異動清單與寫入 scope
+
+| # | 檔案 | 動作 | 寫入 scope（STAGE 2 並行判斷用） |
+|---|------|------|-----------------------------|
+| 1 | `test/core/lifecycle_handler_test.dart` | 新增 | 獨佔新檔 |
+| 2 | `test/core/flutter_inspector_lifecycle_test.dart` | 新增 | 獨佔新檔 |
+| 3 | `lib/src/core/lifecycle_handler.dart` | 新增 | 獨佔新檔 |
+| 4 | `lib/src/core/flutter_inspector.dart` | 修改 | 欄位區 L71/L87、建構式 L130-158、`detach()` L191-193、dartdoc L68-70 — **單一檔案，不可與任何其他任務並行寫入** |
+| 5 | `README.md` | 修改 | L390-399「Uncaught error capture (opt-in)」段落**之後**插入新小節 |
+| 6 | `CHANGELOG.md` | 修改 | 檔頭新增 `## 1.8.0` → `### Added` 條目 |
+| 7 | `example/lib/main.dart` | 修改 | L18-27 建構式區塊 |
+
+`lib/src/core/uncaught_error_handler.dart` **不修改**（`LogCallback` 直接 import 重用）。
+
+---
+
+## 五、測試計畫（TDD：測試先寫，先看到 red）
+
+### 5.1 `test/core/lifecycle_handler_test.dart`（handler 單元層）
+
+沿用 `uncaught_error_handler_test.dart` 模式：`TestWidgetsFlutterBinding.ensureInitialized()` 起手，直接建 handler 注入 counting `onLog` closure，透過 `WidgetsBinding.instance.handleAppLifecycleStateChanged(state)` 驅動 framework 廣播（真正走 observer list，不是直接呼叫方法——這樣才驗證到 `addObserver` 有生效）。
+
+`tearDown` 內對測試建立的 handler 呼叫 `detach()`，避免 observer 洩漏到下個測試。
+
+| # | 測試名稱 | 驗證 | 對應驗收條件 |
+|---|---------|------|------------|
+| T1 | `attach: state change produces one info log with the state name` | callCount == 1、level 為 `LogLevel.info`、message 含 `resumed` | 2 |
+| T2 | `all five states are recorded` | 依序送 `resumed`/`inactive`/`paused`/`detached`/`hidden`，收到 5 筆，messages 各含對應 `.name` | 3 |
+| T3 | `idempotent: attach twice records a state change once` | attach() 兩次後送一次變化，callCount == 1 | 5 |
+| T4 | `detach: no further logs after detach` | attach → 送變化 → detach → 再送變化，callCount 維持 1；再呼叫 detach() 不拋錯 | 4 |
+| T5 | `not attached: state change produces no log` | 只建構不 attach，送變化，callCount == 0 | 1（handler 層） |
+| T6 | `guard: onLog throws does not propagate` | onLog 固定 throw，`handleAppLifecycleStateChanged` 不向上拋；同一次廣播中另一個宿主 observer 仍收到回呼 | 7、6 |
+
+T6 的宿主 observer：測試內定義一個極簡的 `_HostObserver with WidgetsBindingObserver` 記旗標，`addObserver` 進去驗證並存（規格驗收條件 6）。放在測試檔尾，不進 `lib/`。
+
+### 5.2 `test/core/flutter_inspector_lifecycle_test.dart`（接線層）
+
+| # | 測試名稱 | 驗證 | 對應驗收條件 |
+|---|---------|------|------------|
+| T7 | `default off: no lifecycle log in logEntries` | `FlutterInspector()` 無參數，送狀態變化，`logEntries` 為空 | 1 |
+| T8 | `opt-in: lifecycle transition appears in logEntries` | `FlutterInspector(captureLifecycleEvents: true)`，送 `paused`，`logEntries.single.message` 含 `paused`、`level == LogLevel.info`、`data == null` | 2、(c) |
+| T9 | `detach stops lifecycle logging` | opt-in 後送一次 → `detach()` → 再送一次，`logEntries.length == 1` | 4 |
+
+T7/T9 的 tearDown 統一呼叫 `inspector.detach()`，確保跨測試不殘留 observer。
+
+驗收條件 8（`flutter test` 全綠、`flutter analyze` 無新增 warning）由第六節驗證步驟覆蓋。
+
+---
+
+## 六、任務拆分
+
+| # | 任務 | 驗收條件 | 複雜度等級 | 相依 |
+|---|------|---------|-----------|------|
+| **T-1** | 寫 `test/core/lifecycle_handler_test.dart`（T1–T6，含 `_HostObserver`）。此時 `LifecycleHandler` 尚不存在 → 編譯失敗即為預期的 red | 6 個 test case 齊備，測試名稱與 §5.1 一致 | **整合**（需正確使用 `handleAppLifecycleStateChanged` 驅動 binding） | 無。**可與 T-2 並行** |
+| **T-2** | 寫 `test/core/flutter_inspector_lifecycle_test.dart`（T7–T9）。`captureLifecycleEvents` 參數尚不存在 → red | 3 個 test case 齊備 | **機械性** | 無。**可與 T-1 並行** |
+| **T-3** | 新增 `lib/src/core/lifecycle_handler.dart`，照 §3.1 實作 | `flutter test test/core/lifecycle_handler_test.dart` 全綠 | **機械性**（§3.1 已給完整結構） | 依賴 T-1 |
+| **T-4** | 修改 `lib/src/core/flutter_inspector.dart`：新參數、私有欄位、建構式接線、`detach()` 擴充、`captureUncaughtErrors` dartdoc 修訂（§3.2 六處） | `flutter test test/core/` 全綠；既有 `flutter_inspector` 相關測試不回歸 | **設計判斷**（動到公開 API 與 `detach()` 語意，需確認既有測試零回歸、dartdoc 措辭正確） | 依賴 T-2、T-3 |
+| **T-5** | 文件三處：`README.md` 新小節、`CHANGELOG.md` `## 1.8.0 → ### Added` 條目、`example/lib/main.dart` 加 `captureLifecycleEvents: true` 與說明註解 | 三處措辭與既有 opt-in 條目風格一致；example 可編譯 | **機械性** | 依賴 T-4（措辭需與最終 API 一致）。三處檔案彼此獨立，**內部可並行** |
+
+**並行示意**：`(T-1 ∥ T-2)` → `T-3` → `T-4` → `T-5(三檔並行)`
+
+不再拆更細：T-3/T-4 各自是單檔單一連貫改動，拆成「加欄位」「加 detach」只會製造中間態編譯失敗與額外交接成本。
+
+### 文件三處的具體內容
+
+**README.md**（L399 之後、該小節結尾處新增）：
+
+```markdown
+### App lifecycle markers (opt-in)
+
+Enable **lifecycle capture** to record every foreground/background transition
+as an `info`-level Console log, so a crash or a stalled request can be read
+against whether the app was in the foreground at that moment:
+
+```dart
+final inspector = FlutterInspector(captureLifecycleEvents: true);
+```
+
+It is **disabled by default**, and `detach()` removes the observer again.
+Each transition (`resumed` / `inactive` / `paused` / `detached` / `hidden`)
+becomes one entry, which the merged Timeline interleaves with network,
+navigation and database events automatically.
+```
+
+**CHANGELOG.md**（檔頭）：
+
+```markdown
+## 1.8.0
+
+### Added
+* **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached` / `hidden`) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Opt-in and disabled by default; `detach()` removes the observer.
+```
+
+（若 release 流程另有版號規則，交由 releaser 調整標題，條目內容不變。）
+
+**example/lib/main.dart**（L26 之後）：
+
+```dart
+    // Record app foreground/background transitions as info logs (opt-in).
+    // Handy when reading the Console timeline: the nearest lifecycle entry
+    // above a crash tells you whether the app was in the foreground.
+    captureLifecycleEvents: true,
+```
+
+---
+
+## 七、驗證步驟
+
+```bash
+# T-3 完成後
+flutter test test/core/lifecycle_handler_test.dart
+
+# T-4 完成後
+flutter test test/core/
+
+# 全案完成後（magical_tap_test 有 10 分鐘既有 timeout，全套較慢）
+flutter test
+flutter analyze
+```
+
+預期結果：
+
+- `test/core/lifecycle_handler_test.dart`：6 個測試全綠。
+- `test/core/flutter_inspector_lifecycle_test.dart`：3 個測試全綠。
+- 既有測試零回歸（所有既有測試皆以預設參數建構 inspector，flag off 時執行路徑與現況等價）。
+- `flutter analyze`：無新增 warning／info。
+- `example/` 可編譯（`flutter analyze` 已涵蓋）。
+
+---
+
+## 八、破壞性分析（規格已論證，此處僅列 implementer 須實際守住的點）
+
+| 風險點 | 守法 |
+|--------|------|
+| `detach()` 語意擴充 | flag off 時 `_lifecycleHandler.detach()` 因 `_attached == false` 直接 return，執行路徑等價於現況 |
+| observer 洩漏到其他測試 | 所有新測試的 `tearDown` 必須 `detach()` |
+| 公開 API 破壞 | 新參數為可選且預設 `false`，既有呼叫端一字不改 |
+| 宿主 observer | 只用 `addObserver`／`removeObserver(this)`，不觸碰 list 其他成員；T6 測試守住 |
+| `LogCallback` 重複定義 | 一律 `import 'uncaught_error_handler.dart' show LogCallback;`，禁止在新檔重新宣告 |

--- a/docs/plans/2026-07-24-app-lifecycle-marker.md
+++ b/docs/plans/2026-07-24-app-lifecycle-marker.md
@@ -103,7 +103,7 @@ class LifecycleHandler with WidgetsBindingObserver {
 
 ### 3.2 `lib/src/core/flutter_inspector.dart`（修改）
 
-四處異動，全部在既有結構的對應位置：
+六處異動，全部在既有結構的對應位置：
 
 1. **import**：新增 `import 'lifecycle_handler.dart';`
 2. **公開欄位 + dartdoc**（緊接在 `captureUncaughtErrors` 欄位之後，L71 附近）：
@@ -150,13 +150,13 @@ void detach() {
 
 6. **`captureUncaughtErrors` dartdoc 修訂**（規格 (b) 要求）：L68-70 原句
 
-> `The hooks are not torn down: once attached they remain for the process lifetime ([detach] only removes the FAB overlay).`
+   > The hooks are not torn down: once attached they remain for the process lifetime ([detach] only removes the FAB overlay).
 
-改為：
+   改為：
 
-> `The error hooks are not torn down: once attached they remain for the process lifetime ([detach] does not restore them). The `_old*` handlers are kept solely to chain to, not to restore.`
+   > The error hooks are not torn down: once attached they remain for the process lifetime ([detach] does not restore them). The `_old*` handlers are kept solely to chain to, not to restore.
 
-**只改這句措辭**，不動同段其他內容。
+   **只改這句措辭**，不動同段其他內容。
 
 ---
 
@@ -169,7 +169,7 @@ void detach() {
 | 3 | `lib/src/core/lifecycle_handler.dart` | 新增 | 獨佔新檔 |
 | 4 | `lib/src/core/flutter_inspector.dart` | 修改 | 欄位區 L71/L87、建構式 L130-158、`detach()` L191-193、dartdoc L68-70 — **單一檔案，不可與任何其他任務並行寫入** |
 | 5 | `README.md` | 修改 | L390-399「Uncaught error capture (opt-in)」段落**之後**插入新小節 |
-| 6 | `CHANGELOG.md` | 修改 | 檔頭新增 `## 1.8.0` → `### Added` 條目 |
+| 6 | `CHANGELOG.md` | 修改 | 檔頭新增 `## Unreleased` → `### Added` 條目（版號留給 release 流程統一 bump 四處） |
 | 7 | `example/lib/main.dart` | 修改 | L18-27 建構式區塊 |
 
 `lib/src/core/uncaught_error_handler.dart` **不修改**（`LogCallback` 直接 import 重用）。
@@ -217,7 +217,7 @@ T7/T9 的 tearDown 統一呼叫 `inspector.detach()`，確保跨測試不殘留 
 | **T-2** | 寫 `test/core/flutter_inspector_lifecycle_test.dart`（T7–T9）。`captureLifecycleEvents` 參數尚不存在 → red | 3 個 test case 齊備 | **機械性** | 無。**可與 T-1 並行** |
 | **T-3** | 新增 `lib/src/core/lifecycle_handler.dart`，照 §3.1 實作 | `flutter test test/core/lifecycle_handler_test.dart` 全綠 | **機械性**（§3.1 已給完整結構） | 依賴 T-1 |
 | **T-4** | 修改 `lib/src/core/flutter_inspector.dart`：新參數、私有欄位、建構式接線、`detach()` 擴充、`captureUncaughtErrors` dartdoc 修訂（§3.2 六處） | `flutter test test/core/` 全綠；既有 `flutter_inspector` 相關測試不回歸 | **設計判斷**（動到公開 API 與 `detach()` 語意，需確認既有測試零回歸、dartdoc 措辭正確） | 依賴 T-2、T-3 |
-| **T-5** | 文件三處：`README.md` 新小節、`CHANGELOG.md` `## 1.8.0 → ### Added` 條目、`example/lib/main.dart` 加 `captureLifecycleEvents: true` 與說明註解 | 三處措辭與既有 opt-in 條目風格一致；example 可編譯 | **機械性** | 依賴 T-4（措辭需與最終 API 一致）。三處檔案彼此獨立，**內部可並行** |
+| **T-5** | 文件三處：`README.md` 新小節、`CHANGELOG.md` `## Unreleased → ### Added` 條目、`example/lib/main.dart` 加 `captureLifecycleEvents: true` 與說明註解 | 三處措辭與既有 opt-in 條目風格一致；example 可編譯 | **機械性** | 依賴 T-4（措辭需與最終 API 一致）。三處檔案彼此獨立，**內部可並行** |
 
 **並行示意**：`(T-1 ∥ T-2)` → `T-3` → `T-4` → `T-5(三檔並行)`
 
@@ -227,7 +227,7 @@ T7/T9 的 tearDown 統一呼叫 `inspector.detach()`，確保跨測試不殘留 
 
 **README.md**（L399 之後、該小節結尾處新增）：
 
-```markdown
+````markdown
 ### App lifecycle markers (opt-in)
 
 Enable **lifecycle capture** to record every foreground/background transition
@@ -239,18 +239,18 @@ final inspector = FlutterInspector(captureLifecycleEvents: true);
 ```
 
 It is **disabled by default**, and `detach()` removes the observer again.
-Each transition (`resumed` / `inactive` / `paused` / `detached` / `hidden`)
-becomes one entry, which the merged Timeline interleaves with network,
-navigation and database events automatically.
-```
+Each transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden`
+on Flutter 3.13+) becomes one entry, which the merged Timeline interleaves with
+network, navigation and database events automatically.
+````
 
 **CHANGELOG.md**（檔頭）：
 
 ```markdown
-## 1.8.0
+## Unreleased
 
 ### Added
-* **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached` / `hidden`) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Opt-in and disabled by default; `detach()` removes the observer.
+* **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Opt-in and disabled by default; `detach()` removes the observer.
 ```
 
 （若 release 流程另有版號規則，交由 releaser 調整標題，條目內容不變。）

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,8 +25,9 @@ void main() {
     // involved, so there is no Zone mismatch to worry about.
     captureUncaughtErrors: true,
     // Record app foreground/background transitions as info logs (opt-in).
-    // Handy when reading the Console timeline: the nearest lifecycle entry
-    // above a crash tells you whether the app was in the foreground.
+    // Each entry names the current top page (e.g. "resumed · HomePage"), so
+    // the nearest lifecycle entry above a crash tells you both whether the app
+    // was in the foreground and which page it was on.
     captureLifecycleEvents: true,
   );
   runApp(const MyApp());

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,6 +24,10 @@ void main() {
     // together cover framework, asynchronous and build-time errors. No zone is
     // involved, so there is no Zone mismatch to worry about.
     captureUncaughtErrors: true,
+    // Record app foreground/background transitions as info logs (opt-in).
+    // Handy when reading the Console timeline: the nearest lifecycle entry
+    // above a crash tells you whether the app was in the foreground.
+    captureLifecycleEvents: true,
   );
   runApp(const MyApp());
 }

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -18,6 +18,7 @@ import '../observers/navigator_observer.dart';
 import '../ui/dashboard/dashboard_modal.dart';
 import 'inspector_overlay_manager.dart';
 import 'inspector_registry.dart';
+import 'lifecycle_handler.dart';
 import 'uncaught_error_handler.dart';
 import '../version.dart';
 
@@ -65,10 +66,27 @@ class FlutterInspector {
   ///   per-instance, so creating multiple capture-enabled inspectors layers the
   ///   hooks and records the same error once per instance (host errors still
   ///   forward correctly — just duplicated logs).
-  /// - The hooks are not torn down: once attached they remain for the process
-  ///   lifetime ([detach] only removes the FAB overlay). The `_old*` handlers
+  /// - The error hooks are not torn down: once attached they remain for the
+  ///   process lifetime ([detach] does not restore them). The `_old*` handlers
   ///   are kept solely to chain to, not to restore.
   final bool captureUncaughtErrors;
+
+  /// Whether to record app lifecycle transitions (`resumed` / `inactive` /
+  /// `paused` / `detached` / `hidden`) as [LogLevel.info] log entries, so a
+  /// crash or a stalled request can be read against whether the app was in the
+  /// foreground at that moment.
+  ///
+  /// Defaults to `false` so the package registers no observer unless the host
+  /// opts in.
+  ///
+  /// Notes:
+  /// - Enable this on a single, app-wide inspector. Each enabled instance keeps
+  ///   its own observer and its own buffer, so multiple instances each record
+  ///   their own copy (correct per instance, just duplicated across them).
+  /// - Unlike the error hooks, this observer *is* torn down: [detach] removes
+  ///   it from [WidgetsBinding.instance]. Removing one observer from the
+  ///   binding's list cannot affect the host's own observers.
+  final bool captureLifecycleEvents;
 
   /// Whether to mask sensitive headers (e.g. `Authorization`, `Cookie`,
   /// `Set-Cookie`, `X-Api-Key`) in all share/export paths (cURL, plain text).
@@ -85,6 +103,7 @@ class FlutterInspector {
   final DiagnosticInfoSource? diagnosticInfoSource;
 
   late final UncaughtErrorHandler _uncaughtErrorHandler;
+  late final LifecycleHandler _lifecycleHandler;
   late final InspectorRegistry _registry;
   late final FlutterInspectorNavigatorObserver _navigatorObserver;
   late final OperationLogSource _operationLogSource;
@@ -134,6 +153,7 @@ class FlutterInspector {
     this.showNetworkNotification = false,
     this.navigatorKey,
     this.captureUncaughtErrors = false,
+    this.captureLifecycleEvents = false,
     this.redactSensitiveData = true,
     this.diagnosticInfoSource,
     int bufferSize = 500,
@@ -146,6 +166,8 @@ class FlutterInspector {
     _registry = InspectorRegistry(bufferSize: bufferSize);
     _uncaughtErrorHandler = UncaughtErrorHandler(onLog: log);
     if (captureUncaughtErrors) setupErrorHandlers();
+    _lifecycleHandler = LifecycleHandler(onLog: log);
+    if (captureLifecycleEvents) _lifecycleHandler.attach();
     _navigatorObserver = FlutterInspectorNavigatorObserver(this);
     _operationLogSource = OperationLogSource(_registry.database);
     if (databaseSources != null) {
@@ -187,9 +209,11 @@ class FlutterInspector {
     _overlayManager.attach(context: context, visible: visible);
   }
 
-  /// Removes the FAB overlay.
+  /// Removes the FAB overlay, and the lifecycle observer when
+  /// [captureLifecycleEvents] is enabled.
   void detach() {
     _overlayManager.detach();
+    _lifecycleHandler.detach();
   }
 
   /// Records a log message.

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 
 import '../inspectors/log_inspector.dart';
 import '../inspectors/navigator_inspector.dart';
+import '../inspectors/navigator_stack_resolver.dart';
 import '../models/database_browser_source.dart';
 import '../models/database_entry.dart';
 import '../models/database_operation.dart';
@@ -75,6 +76,12 @@ class FlutterInspector {
   /// `paused` / `detached`, plus `hidden` on Flutter 3.13+) as [LogLevel.info]
   /// log entries, so a crash or a stalled request can be read against whether
   /// the app was in the foreground at that moment.
+  ///
+  /// Each entry names the current top-most page so repeated home/back switches
+  /// stay distinguishable without cross-referencing the Navigator tab, e.g.
+  /// `App lifecycle: resumed · HomePage (/home)`. The page is a best-effort
+  /// replay of the navigation history; when it cannot be resolved the suffix is
+  /// simply omitted.
   ///
   /// Defaults to `false` so the package registers no observer unless the host
   /// opts in.
@@ -171,7 +178,10 @@ class FlutterInspector {
     _registry = InspectorRegistry(bufferSize: bufferSize);
     _uncaughtErrorHandler = UncaughtErrorHandler(onLog: log);
     if (captureUncaughtErrors) setupErrorHandlers();
-    _lifecycleHandler = LifecycleHandler(onLog: log);
+    _lifecycleHandler = LifecycleHandler(
+      onLog: log,
+      topPageLabel: _currentTopPageLabel,
+    );
     if (captureLifecycleEvents) _lifecycleHandler.attach();
     _navigatorObserver = FlutterInspectorNavigatorObserver(this);
     _operationLogSource = OperationLogSource(_registry.database);
@@ -286,6 +296,21 @@ class FlutterInspector {
       TimelineSource.db,
     },
   }) => _registry.mergedTimeline(sources: sources);
+
+  /// Best-effort label for the current top-most page, for the lifecycle log
+  /// suffix. Replays [navigatorEntries] and formats the top route as
+  /// `displayName (routeName)`, dropping the `(routeName)` part when the route
+  /// has no name. Returns `null` when the stack cannot be resolved (empty
+  /// history), so the caller omits the suffix rather than inventing one.
+  String? _currentTopPageLabel() {
+    final stack = NavigatorStackResolver().resolve(navigatorEntries);
+    if (stack.isEmpty) return null;
+    final top = stack.first;
+    final route = top.routeName;
+    return (route == null || route.isEmpty)
+        ? top.displayName
+        : '${top.displayName} ($route)';
+  }
 
   /// Opens the full-screen dashboard modal.
   ///

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -72,14 +72,19 @@ class FlutterInspector {
   final bool captureUncaughtErrors;
 
   /// Whether to record app lifecycle transitions (`resumed` / `inactive` /
-  /// `paused` / `detached` / `hidden`) as [LogLevel.info] log entries, so a
-  /// crash or a stalled request can be read against whether the app was in the
-  /// foreground at that moment.
+  /// `paused` / `detached`, plus `hidden` on Flutter 3.13+) as [LogLevel.info]
+  /// log entries, so a crash or a stalled request can be read against whether
+  /// the app was in the foreground at that moment.
   ///
   /// Defaults to `false` so the package registers no observer unless the host
   /// opts in.
   ///
   /// Notes:
+  /// - When `true`, the inspector registers a [WidgetsBindingObserver] at
+  ///   construction time, so the binding must already exist — construct the
+  ///   inspector after `WidgetsFlutterBinding.ensureInitialized()` / `runApp`.
+  ///   (Any real app satisfies this; it is the same precondition the host
+  ///   already meets before calling `runApp`.)
   /// - Enable this on a single, app-wide inspector. Each enabled instance keeps
   ///   its own observer and its own buffer, so multiple instances each record
   ///   their own copy (correct per instance, just duplicated across them).

--- a/lib/src/core/lifecycle_handler.dart
+++ b/lib/src/core/lifecycle_handler.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/widgets.dart';
+
+import '../models/log_level.dart';
+import 'uncaught_error_handler.dart' show LogCallback;
+
+/// Records app lifecycle transitions as [LogLevel.info] log entries.
+///
+/// Registers itself on [WidgetsBinding.instance] as an observer. Flutter keeps
+/// observers in a list, so the host app's own observers keep receiving their
+/// callbacks unaffected.
+class LifecycleHandler with WidgetsBindingObserver {
+  /// The function called to log a lifecycle transition.
+  final LogCallback onLog;
+
+  bool _attached = false;
+
+  /// Creates a new LifecycleHandler instance.
+  LifecycleHandler({required this.onLog});
+
+  /// Registers this handler as a [WidgetsBindingObserver].
+  ///
+  /// Idempotent: the `_attached` flag ensures a single state change is never
+  /// recorded twice by the same instance.
+  void attach() {
+    if (_attached) return;
+    _attached = true;
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  /// Removes this handler from [WidgetsBinding.instance].
+  ///
+  /// Safe to call when not attached, and safe to call twice.
+  void detach() {
+    if (!_attached) return;
+    _attached = false;
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    try {
+      onLog('App lifecycle: ${state.name}', level: LogLevel.info);
+    } catch (e, s) {
+      debugPrintStack(
+        stackTrace: s,
+        label: 'inspector lifecycle log failed: $e',
+      );
+    }
+  }
+}

--- a/lib/src/core/lifecycle_handler.dart
+++ b/lib/src/core/lifecycle_handler.dart
@@ -12,10 +12,19 @@ class LifecycleHandler with WidgetsBindingObserver {
   /// The function called to log a lifecycle transition.
   final LogCallback onLog;
 
+  /// Optional supplier of a label for the current top-most page, appended to
+  /// the log message so a background/foreground switch reads as the page it
+  /// happened on (e.g. `App lifecycle: resumed · HomePage (/home)`).
+  ///
+  /// Returns `null` when the top page cannot be resolved (empty history, or a
+  /// best-effort replay that came up empty); the message then omits the suffix
+  /// rather than inventing one.
+  final String? Function()? topPageLabel;
+
   bool _attached = false;
 
   /// Creates a new LifecycleHandler instance.
-  LifecycleHandler({required this.onLog});
+  LifecycleHandler({required this.onLog, this.topPageLabel});
 
   /// Registers this handler as a [WidgetsBindingObserver].
   ///
@@ -39,7 +48,9 @@ class LifecycleHandler with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     try {
-      onLog('App lifecycle: ${state.name}', level: LogLevel.info);
+      final page = topPageLabel?.call();
+      final suffix = (page == null || page.isEmpty) ? '' : ' · $page';
+      onLog('App lifecycle: ${state.name}$suffix', level: LogLevel.info);
     } catch (e, s) {
       debugPrintStack(
         stackTrace: s,

--- a/test/core/flutter_inspector_lifecycle_test.dart
+++ b/test/core/flutter_inspector_lifecycle_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -56,5 +58,36 @@ void main() {
       AppLifecycleState.paused,
     );
     expect(inspector.logEntries, hasLength(1));
+  });
+
+  test('lifecycle log names the current top page from the nav stack', () {
+    final inspector = FlutterInspector(captureLifecycleEvents: true);
+    currentInspector = inspector;
+
+    // 推一筆 push 進 navigator buffer，讓 resolver 有 top page 可推導。
+    inspector.registry.navigator.add(
+      NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
+    );
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.paused,
+    );
+
+    // routeName 有值 → message 尾巴帶 (routeName)；此 entry 無 widgetType，
+    // displayName 退回 routeName，故格式為 "/home (/home)"。
+    expect(inspector.logEntries.single.message, contains('paused'));
+    expect(inspector.logEntries.single.message, contains('/home'));
+  });
+
+  test('empty nav stack yields a bare lifecycle message', () {
+    final inspector = FlutterInspector(captureLifecycleEvents: true);
+    currentInspector = inspector;
+
+    // 未推任何 navigator 事件 → resolver 回空 → 不加尾巴。
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+
+    expect(inspector.logEntries.single.message, 'App lifecycle: resumed');
   });
 }

--- a/test/core/flutter_inspector_lifecycle_test.dart
+++ b/test/core/flutter_inspector_lifecycle_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  FlutterInspector? currentInspector;
+
+  tearDown(() {
+    currentInspector?.detach();
+    currentInspector = null;
+  });
+
+  test('default off: no lifecycle log in logEntries', () {
+    final inspector = FlutterInspector();
+    currentInspector = inspector;
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.paused,
+    );
+
+    expect(inspector.logEntries, isEmpty);
+  });
+
+  test('opt-in: lifecycle transition appears in logEntries', () {
+    final inspector = FlutterInspector(captureLifecycleEvents: true);
+    currentInspector = inspector;
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.paused,
+    );
+
+    final entries = inspector.logEntries;
+    expect(entries, hasLength(1));
+
+    final entry = entries.single;
+    expect(entry.message, contains('paused'));
+    expect(entry.level, LogLevel.info);
+    expect(entry.data, isNull);
+  });
+
+  test('detach stops lifecycle logging', () {
+    final inspector = FlutterInspector(captureLifecycleEvents: true);
+    currentInspector = inspector;
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+    expect(inspector.logEntries, hasLength(1));
+
+    inspector.detach();
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.paused,
+    );
+    expect(inspector.logEntries, hasLength(1));
+  });
+}

--- a/test/core/lifecycle_handler_test.dart
+++ b/test/core/lifecycle_handler_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_inspector_kit/src/core/lifecycle_handler.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  LifecycleHandler? handler;
+
+  tearDown(() {
+    handler?.detach();
+    handler = null;
+  });
+
+  test('attach: state change produces one info log with the state name', () {
+    var callCount = 0;
+    LogLevel? lastLevel;
+    String? lastMessage;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+        lastLevel = level;
+        lastMessage = message;
+      },
+    );
+    handler = h;
+    h.attach();
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+
+    expect(callCount, 1);
+    expect(lastLevel, LogLevel.info);
+    expect(lastMessage, contains('resumed'));
+  });
+
+  test('all five states are recorded', () {
+    final messages = <String>[];
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        messages.add(message);
+      },
+    );
+    handler = h;
+    h.attach();
+
+    const states = [
+      AppLifecycleState.resumed,
+      AppLifecycleState.inactive,
+      AppLifecycleState.paused,
+      AppLifecycleState.detached,
+      AppLifecycleState.hidden,
+    ];
+    for (final state in states) {
+      WidgetsBinding.instance.handleAppLifecycleStateChanged(state);
+    }
+
+    expect(messages.length, 5);
+    for (var i = 0; i < states.length; i++) {
+      expect(messages[i], contains(states[i].name));
+    }
+  });
+
+  test('idempotent: attach twice records a state change once', () {
+    var callCount = 0;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+      },
+    );
+    handler = h;
+    h.attach();
+    h.attach();
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+
+    expect(callCount, 1);
+  });
+
+  test('detach: no further logs after detach', () {
+    var callCount = 0;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+      },
+    );
+    handler = h;
+    h.attach();
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+    h.detach();
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.paused,
+    );
+
+    expect(callCount, 1);
+    expect(h.detach, returnsNormally);
+  });
+
+  test('not attached: state change produces no log', () {
+    var callCount = 0;
+    handler = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+      },
+    );
+
+    // 刻意不呼叫 attach()。
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+
+    expect(callCount, 0);
+  });
+
+  test('guard: onLog throws does not propagate', () {
+    var hostCalled = false;
+    final hostObserver = _HostObserver(() => hostCalled = true);
+
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        throw StateError('onLog failed');
+      },
+    );
+    handler = h;
+
+    // 註冊順序刻意讓 handler 排在 hostObserver 之前：binding 的廣播迴圈沒有
+    // per-observer try-catch，handler 若讓例外逃逸，迴圈會在 hostObserver
+    // 之前中斷。倒過來註冊會讓 hostCalled 恆為 true，測不到 guard 是否存在。
+    h.attach();
+    WidgetsBinding.instance.addObserver(hostObserver);
+    addTearDown(() => WidgetsBinding.instance.removeObserver(hostObserver));
+
+    expect(
+      () => WidgetsBinding.instance.handleAppLifecycleStateChanged(
+        AppLifecycleState.resumed,
+      ),
+      returnsNormally,
+    );
+    expect(hostCalled, isTrue);
+  });
+}
+
+/// Minimal host observer, proving [LifecycleHandler] never crowds out the
+/// other observers registered on the binding.
+class _HostObserver with WidgetsBindingObserver {
+  _HostObserver(this.onStateChange);
+
+  final VoidCallback onStateChange;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    onStateChange();
+  }
+}

--- a/test/core/lifecycle_handler_test.dart
+++ b/test/core/lifecycle_handler_test.dart
@@ -145,6 +145,70 @@ void main() {
     );
     expect(hostCalled, isTrue);
   });
+
+  test('topPageLabel: non-empty label is appended after " · "', () {
+    String? lastMessage;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        lastMessage = message;
+      },
+      topPageLabel: () => 'HomePage (/home)',
+    );
+    handler = h;
+    h.attach();
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+
+    expect(lastMessage, 'App lifecycle: resumed · HomePage (/home)');
+  });
+
+  test('topPageLabel: null and empty both omit the suffix', () {
+    final messages = <String>[];
+    final labels = <String?>['', null];
+    var i = 0;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        messages.add(message);
+      },
+      topPageLabel: () => labels[i++],
+    );
+    handler = h;
+    h.attach();
+
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.paused,
+    );
+    WidgetsBinding.instance.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+
+    // 空字串與 null 都不加 " · " 尾巴，退回純狀態訊息。
+    expect(messages, ['App lifecycle: paused', 'App lifecycle: resumed']);
+  });
+
+  test('topPageLabel: a throwing supplier is caught, does not propagate', () {
+    var logged = false;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        logged = true;
+      },
+      topPageLabel: () => throw StateError('resolve failed'),
+    );
+    handler = h;
+    h.attach();
+
+    expect(
+      () => WidgetsBinding.instance.handleAppLifecycleStateChanged(
+        AppLifecycleState.resumed,
+      ),
+      returnsNormally,
+    );
+    // supplier 拋錯落入既有 try-catch，該次 log 被吞（與 onLog 拋錯同路徑），
+    // 但不向宿主傳播。
+    expect(logged, isFalse);
+  });
 }
 
 /// Minimal host observer, proving [LifecycleHandler] never crowds out the

--- a/test/core/lifecycle_handler_test.dart
+++ b/test/core/lifecycle_handler_test.dart
@@ -100,7 +100,7 @@ void main() {
     );
 
     expect(callCount, 1);
-    expect(h.detach, returnsNormally);
+    expect(() => h.detach(), returnsNormally);
   });
 
   test('not attached: state change produces no log', () {


### PR DESCRIPTION
## Summary

Closes #99

崩潰或異常網路行為若發生在 app 被切到背景的瞬間（iOS/Android 對背景 app 的資源限制、被系統 kill 前的緊急回收），「當下 app 在前景還是背景」這個 context 完全沒被記錄。本 PR 以 opt-in 方式把生命週期切換記成一筆 log，Timeline 上崩潰前最近一筆 lifecycle log 就是答案。

## 修正問題

- `lib/` 與 `test/` 完全沒有 `WidgetsBindingObserver` / `didChangeAppLifecycleState` / `AppLifecycleState` 的任何使用——這是全新的 hook 類別，不是既有行為的缺陷。
- 排查一筆詭異的 timeout 或沒有明顯成因的崩潰時，若知道它發生在 app 剛被切到背景的瞬間，方向立刻收斂。Sentry 等工具的 breadcrumb 預設就包含這個維度，本 package 缺席。

## 修正方式

**核心判斷：生命週期切換本身就是一條 log。** 比照既有 `captureUncaughtErrors` 的做法轉成 `LogEntry`，不新增資料模型——`mergedTimeline()`、Console tab、診斷報告因此**零改動即可支援**。

- 新增 `LifecycleHandler with WidgetsBindingObserver`（50 行），`didChangeAppLifecycleState` 轉一筆 `LogLevel.info` 的 `LogEntry`（message `App lifecycle: ${state.name}`）。
- **五個狀態走同一條路徑**：`resumed` / `inactive` / `paused` / `detached` / `hidden` 直接把 enum 轉字串，零 `if`、零 `switch`。刻意排除 `hidden` 反而要寫特殊情況分支，且未來 Flutter 新增狀態時此設計自動支援。
- 新增可選建構參數 `captureLifecycleEvents`（default **off**），比照 `captureUncaughtErrors` 的保守慣例。重用既有 `typedef LogCallback`，不重複定義。
- **`detach()` 擴充為一併移除 observer**，不沿用 error hooks 的「不 teardown」慣例。這是實質差異而非慣例偏好：`FlutterError.onError` 是**單一 slot**（還原 `_old*` 會幹掉宿主後裝的 handler，那才是真正的 break userspace），而 `WidgetsBindingObserver` 是**一個 list**，`removeObserver(this)` 只移除自己，對宿主零影響。能乾淨移除就該乾淨移除。
- `detach()` 內**不寫** `if (captureLifecycleEvents)`——handler 在未 attach 時自身 no-op，特殊情況消滅在正確的層級。
- 連帶修訂 `captureUncaughtErrors` dartdoc 中失準的敘述（原文稱 `detach` 只移除 FAB overlay），改為明指 **error** hooks 不 teardown。

零新資料模型、零新 UI、零新相依（`WidgetsBindingObserver` 來自已 import 的 `flutter/widgets.dart`）。

## 破壞性分析：零

- **建構參數純加法**：可選且預設 `false`，既有呼叫端一字不改。掃過全部約 30 處 `FlutterInspector(` 建構點，除新測試外無一處傳此參數 → 一律走 flag off 路徑。
- **`detach()` 語意擴充**：`lib/` 內既有呼叫點只有 `InspectorOverlayManager.detach()`（不同類別）。flag off 時 `_attached == false` 直接 return，執行路徑與現況等價。
- **宿主 observer**：`addObserver` 是 list append，宿主自己註冊的 observer 照常收到回呼。

## 測試

`flutter test test/core/` **59/59 通過**（9 個新測試 + 既有測試零回歸）；`flutter analyze` 零新增 warning（僅剩 2 個既有的 `export_report_sheet.dart` deprecation info）。

- `test/core/lifecycle_handler_test.dart`（6 個）：單筆 info log、五狀態全覆蓋、attach 冪等、detach 後停止、未 attach 不記錄、`onLog` 拋例外不逃逸且宿主 observer 仍收到回呼
- `test/core/flutter_inspector_lifecycle_test.dart`（3 個）：預設 off 不產生 log、opt-in 生效且 `data == null`、`detach()` 停止記錄

**一處值得注意的測試設計**：guard 測試的註冊順序刻意讓 handler 排在宿主 observer **之前**。Flutter 的廣播迴圈沒有 per-observer try-catch，倒過來註冊會讓 `hostCalled` 斷言恆為 true、完全測不到 guard 是否存在。此順序經 mutation test 驗證——移除 guard 後該斷言確實轉紅（`Expected: true / Actual: false`），程式碼內已加註解防止日後被「整理」掉。

## 已知的既有問題（非本 PR 造成）

`test/ui/tabs/network_detail_view_test.dart` 的 `Resend action disabled when entry is not complete` 在全套執行時會失敗，即**既有 issue #92**。已實證與本次改動無關：把本 PR 的 `flutter_inspector.dart` 變更完全 stash 掉後仍 4/4 失敗，乾淨 `main` 隔離跑 3 次也有 1 次失敗。根因是 `NetworkEntry.sourceDio` 為 `WeakReference<Dio>`，測試建立的臨時 `Dio()` 被 GC 回收後 tooltip 變成 `Cannot resend...`，`find.byTooltip('Resend')` 因而找不到目標。

> 補充觀察：該測試在 worktree 環境下是**穩定失敗**而非偶發，#92 的實際嚴重度可能高於原記錄。

## 附帶文件

- `docs/features/2026-07-24-app-lifecycle-marker.md`：功能規格（含 `hidden` 納入、observer teardown、`data` map 三個設計判斷的論證）
- `docs/plans/2026-07-24-app-lifecycle-marker.md`：實作計畫

## 對應 roadmap

`docs/brainstorm/2026-07-24-features-brainstorm.md` §P13，Tier 1（往時間軸加資訊）唯一存活項目——文件判定它是「真正往 timeline 加上原本拿不到的維度，且無隱藏成本」，建議最先動工。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an opt-in lifecycle event capture to FlutterInspector that logs app foreground/background transitions as timeline entries without altering existing behavior by default.

New Features:
- Introduce a LifecycleHandler that observes Flutter app lifecycle changes and records them as info-level log entries via the existing logging pipeline.
- Expose a new optional FlutterInspector constructor flag `captureLifecycleEvents` to enable lifecycle logging and wire it into the inspector’s log buffer and timeline.
- Document the lifecycle marker feature in README and dedicated spec/plan docs, and showcase enabling it in the example app.

Enhancements:
- Extend FlutterInspector.detach() to also remove the lifecycle observer when lifecycle capture is enabled, while leaving error hooks behavior unchanged and clarifying its dartdoc.
- Ensure lifecycle logging is idempotent, covers all current AppLifecycleState values, and guards against exceptions in log callbacks without affecting host observers.

Documentation:
- Add feature and implementation plan documents describing the app lifecycle marker design, scope, and acceptance criteria.
- Update README with an "App lifecycle markers" section explaining how to opt in and how the logs appear in the timeline.
- Note the new lifecycle capture capability in the CHANGELOG under the Unreleased section.

Tests:
- Add unit tests for LifecycleHandler to validate logging behavior, lifecycle state coverage, idempotent attach/detach, and non-interference with host observers.
- Add integration tests for FlutterInspector to confirm default-off behavior, opt-in lifecycle logging, and that detach stops further lifecycle logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增可选的应用生命周期日志捕获功能：启用后以信息级别记录 resumed、inactive、paused、detached、hidden 等前后台切换事件，并进入合并时间线；默认关闭；调用 `detach()` 后停止记录。
- **文档**
  - 更新 README 与 CHANGELOG，新增功能说明与详细规格文档，并补充示例用法。
- **测试**
  - 新增覆盖生命周期日志默认不启用、启用后记录、以及 `detach()` 后不再新增日志条目的测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->