### PR TITLE
feat(console): tint error rows in the merged timeline

### DIFF
--- a/lib/src/models/network_entry.dart
+++ b/lib/src/models/network_entry.dart
@@ -101,6 +101,14 @@ class NetworkEntry implements TimestampedEntry {
   /// serialisation (cURL, plain-text, or any other export format).
   final WeakReference<Dio>? sourceDio;
 
+  /// Whether this request carries an error signal: an HTTP status of 400 or
+  /// above, or a transport-level failure ([error] / [errorType]).
+  ///
+  /// Single source of truth for "did this call fail" across the network tab,
+  /// its error-summary groups, the console timeline and the diagnostic report.
+  bool get isFailed =>
+      (statusCode ?? 0) >= 400 || error != null || errorType != null;
+
   /// Truncates [body] to [kNetworkBodyMaxLength] characters, appending
   /// [kTruncatedMarker] when truncation occurs. Returns `null` for `null` input.
   static String? truncateBody(String? body) {

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../core/flutter_inspector.dart';
 import '../../../models/database_entry.dart';
 import '../../../models/log_entry.dart';
+import '../../../models/log_level.dart';
 import '../../../models/navigator_entry.dart';
 import '../../../models/network_entry.dart';
 import '../../../models/timestamped_entry.dart';
@@ -10,6 +11,11 @@ import '../../../extensions/log_level_color_extension.dart';
 import '../../theme/theme.dart';
 import 'console/log_detail_view.dart';
 import 'network/network_detail_view.dart';
+
+/// Row background applied to error logs and failed network calls so they stand
+/// out while scrolling a long merged timeline. Kept faint on purpose: the tint
+/// marks the row without competing with the level-coloured text.
+final Color _kErrorRowTint = ThemeColor.colorF44336.withValues(alpha: 0.08);
 
 /// Tab for displaying a cross-layer merged timeline (logs, network, navigation,
 /// database) with a source filter and per-type row dispatch.
@@ -156,6 +162,7 @@ class _LogEntryRow extends StatelessWidget {
         (entry.stackTrace?.isNotEmpty ?? false) ||
         (entry.data?.isNotEmpty ?? false);
     return ListTile(
+      tileColor: entry.level == LogLevel.error ? _kErrorRowTint : null,
       title: Text(entry.message, style: TextStyle(color: entry.level.color)),
       subtitle: Text(entry.displayTime),
       trailing: canTap
@@ -182,6 +189,7 @@ class _NetworkEntryRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
+      tileColor: entry.isFailed ? _kErrorRowTint : null,
       title: Text('${entry.method} ${entry.statusCode ?? '-'} ${entry.url}'),
       subtitle: Text(entry.displayTime),
       trailing: const Icon(Icons.chevron_right, size: ThemeSize.size18),

--- a/lib/src/ui/dashboard/tabs/network_tab.dart
+++ b/lib/src/ui/dashboard/tabs/network_tab.dart
@@ -47,10 +47,7 @@ class _NetworkTabState extends State<NetworkTab> {
     final entries = group == null
         ? filteredEntries
         : filteredEntries
-              .where(
-                (e) =>
-                    e.error != null || (e.statusCode ?? 0) >= 400,
-              )
+              .where((e) => e.isFailed)
               .where(
                 (e) => group.statusCode != null
                     ? e.statusCode == group.statusCode

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -27,8 +27,8 @@ import 'redaction.dart';
 /// * [sections] — which sources to include. Unselected sources are absent
 ///   entirely, not rendered empty.
 /// * [errorsOnly] — restrict the whole Timeline stream to error signals:
-///   error/warning logs and failed network calls (`statusCode >= 400` or a
-///   transport `errorType`); nav/db events are dropped. Off by default: a
+///   error/warning logs and failed network calls ([NetworkEntry.isFailed]);
+///   nav/db events are dropped. Off by default: a
 ///   report whose whole point is "what happened around the error" is worth
 ///   little once the leading info/debug breadcrumbs are stripped. The
 ///   independent Network/Navigation/Database detail sections are unaffected.
@@ -205,7 +205,7 @@ bool _isError(TimestampedEntry e) {
     return e.level == LogLevel.error || e.level == LogLevel.warning;
   }
   if (e is NetworkEntry) {
-    return (e.statusCode ?? 0) >= 400 || e.errorType != null;
+    return e.isFailed;
   }
   return false;
 }

--- a/lib/src/utils/network_utils.dart
+++ b/lib/src/utils/network_utils.dart
@@ -179,12 +179,9 @@ List<NetworkErrorGroup> aggregateNetworkErrors(List<NetworkEntry> entries) {
   final Map<(int?, DioExceptionType?), _ErrorGroupBuilder> builders = {};
 
   for (final entry in entries) {
-    // 1. Filter out non-error entries: only requests with an error or a
-    // >=400 status code count. Pending requests (both null) are excluded.
-    final statusCode = entry.statusCode;
-    final isError =
-        entry.error != null || (statusCode != null && statusCode >= 400);
-    if (!isError) continue;
+    // 1. Filter out non-error entries. Pending requests (no status, no error)
+    // are excluded by [NetworkEntry.isFailed].
+    if (!entry.isFailed) continue;
 
     // 2. Group by statusCode when present; only transport failures
     // (statusCode == null) fall back to errorType. This keeps all 502s

--- a/test/models/network_entry_test.dart
+++ b/test/models/network_entry_test.dart
@@ -20,6 +20,41 @@ void main() {
       expect(entry.statusCode, isNull);
     });
 
+    group('isFailed', () {
+      NetworkEntry entryWith({
+        int? statusCode,
+        String? error,
+        DioExceptionType? errorType,
+      }) => NetworkEntry(
+        method: 'GET',
+        url: 'https://x',
+        statusCode: statusCode,
+        error: error,
+        errorType: errorType,
+        timestamp: fixedTime,
+      );
+
+      test('is false for success and pending requests', () {
+        expect(entryWith(statusCode: 200).isFailed, isFalse);
+        expect(entryWith(statusCode: 304).isFailed, isFalse);
+        expect(entryWith().isFailed, isFalse);
+      });
+
+      test('is true for 4xx and 5xx responses', () {
+        expect(entryWith(statusCode: 400).isFailed, isTrue);
+        expect(entryWith(statusCode: 404).isFailed, isTrue);
+        expect(entryWith(statusCode: 500).isFailed, isTrue);
+      });
+
+      test('is true for transport failures without a status code', () {
+        expect(entryWith(error: 'Connection refused').isFailed, isTrue);
+        expect(
+          entryWith(errorType: DioExceptionType.connectionTimeout).isFailed,
+          isTrue,
+        );
+      });
+    });
+
     test('copyWith completes the entry', () {
       final pending = NetworkEntry(
         method: 'GET',

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/extensions/log_level_color_extension.dart';
 import 'package:flutter_inspector_kit/src/models/database_entry.dart';
 import 'package:flutter_inspector_kit/src/models/database_operation.dart';
 import 'package:flutter_inspector_kit/src/models/log_entry.dart';
@@ -331,6 +332,7 @@ void main() {
     ) async {
       final inspector = FlutterInspector();
       inspector.log('boom', level: LogLevel.error);
+      inspector.log('heads up', level: LogLevel.warning);
       inspector.log('all good', level: LogLevel.info);
       inspector.logNetwork(
         NetworkEntry(
@@ -368,6 +370,14 @@ void main() {
         isNotNull,
       );
       expect(tileColorOf(find.textContaining('https://api.test/ok')), isNull);
+
+      // Warnings stay text-only: an orange label but no tint, so a
+      // warning-heavy timeline does not wash out and hide the errors.
+      expect(tileColorOf(find.text('heads up')), isNull);
+      expect(
+        tester.widget<Text>(find.text('heads up')).style?.color,
+        LogLevel.warning.color,
+      );
     });
 
     testWidgets('nav and db rows are not tappable (no chevron)', (

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -326,6 +326,50 @@ void main() {
       expect(view.redactSensitiveData, isFalse);
     });
 
+    testWidgets('tints only error logs and failed network rows', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      inspector.log('boom', level: LogLevel.error);
+      inspector.log('all good', level: LogLevel.info);
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/fail',
+          statusCode: 500,
+          isComplete: true,
+        ),
+      );
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/ok',
+          statusCode: 200,
+          isComplete: true,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      Color? tileColorOf(Finder text) => tester
+          .widget<ListTile>(
+            find.ancestor(of: text, matching: find.byType(ListTile)),
+          )
+          .tileColor;
+
+      expect(tileColorOf(find.text('boom')), isNotNull);
+      expect(tileColorOf(find.text('all good')), isNull);
+      expect(
+        tileColorOf(find.textContaining('https://api.test/fail')),
+        isNotNull,
+      );
+      expect(tileColorOf(find.textContaining('https://api.test/ok')), isNull);
+    });
+
     testWidgets('nav and db rows are not tappable (no chevron)', (
       tester,
     ) async {

--- a/test/utils/network_utils_test.dart
+++ b/test/utils/network_utils_test.dart
@@ -103,6 +103,15 @@ void main() {
       expect(aggregateNetworkErrors([]), isEmpty);
     });
 
+    test('只有 errorType 的傳輸失敗仍會產生群組', () {
+      final groups = aggregateNetworkErrors([
+        mkEntry(errorType: DioExceptionType.connectionTimeout),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.first.statusCode, isNull);
+      expect(groups.first.errorType, DioExceptionType.connectionTimeout);
+    });
+
     test('全部成功請求 → 無 error group', () {
       final entries = List.generate(5, (_) => mkEntry(statusCode: 200));
       expect(aggregateNetworkErrors(entries), isEmpty);


### PR DESCRIPTION
## Summary

實作 §P7 Error 高亮強化：讓 error log 與失敗網路請求在混合時序軸上帶淡紅底色，一眼從滾動列表跳出。同時收斂「網路請求是否失敗」的重複判定。

## 修正問題

1. **error 條目不夠醒目**：原本只靠文字顏色區分，在數百條 timeline 裡容易漏看。
2. **失敗判定在三處各寫一份且已經漂移**：`network_tab` 看 `error` 漏 `errorType`、`diagnostic_report` 看 `errorType` 漏 `error`、`network_utils` 的群組聚合兩者都不完整。各自漏掉不同類型的失敗。

## 修正方式

- 新增 `NetworkEntry.isFailed`（`>=400` ∪ `error` ∪ `errorType`）作為單一判定來源，三處呼叫端全部改用它。
- `_LogEntryRow` / `_NetworkEntryRow` 加 `ListTile.tileColor` 淡紅底（`colorF44336` alpha 0.08）。
- 只染 error：warning 保留橘字但不染底，避免 warning 密集時整片泛黃反而失去對比。
- 測試 +4 案例（`isFailed` 四種情境、高亮四種情境、errorType-only 群組）。

## 順帶修掉的既有 bug

收斂判定時發現：**只帶 `errorType` 的傳輸失敗（如 connection timeout）原本不會產生 Error Summary 群組卡片**，等於在網路 tab 的錯誤摘要裡靜默消失。統一到 `isFailed` 後一併修正，已加測試鎖住。

內建的 dio interceptor 目前一律同時寫 `error` 與 `errorType`，所以走不到這個分歧；但 `NetworkEntry` 建構式與 `logNetwork()` 都是公開 API，使用者手動建構即可觸發。

## Verification

- `flutter analyze`：零 error/warning（僅 2 則既有 deprecation，位於 `export_report_sheet.dart`，與本次無關）
- `flutter test`：**425 passed**，全套綠燈
- 獨立 reviewer 審查（correctness lens）：抓到漏統一的第三處判定，已修正並補測

## 相關

實作 `docs/brainstorm/2026-07-24-features-brainstorm.md` 的 §P7（Tier 2 首項）。

> 另記一個與本 PR 無關的發現：`network_detail_view_test.dart` 的 `Resend action disabled when entry is not complete` 存在測試隔離缺陷——單獨執行會失敗，需依賴同 group 前一個測試留下的狀態。已在 clean main 上驗證為既有問題，本 PR 未觸碰，建議另開單處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Highlight error logs and failed network requests in the console timeline and unify network failure detection using a single isFailed flag.

New Features:
- Add faint red background tint for error log rows and failed network entries in the console tab timeline.

Bug Fixes:
- Ensure transport failures that only carry errorType are included in aggregated network error groups and surfaced in error summaries.

Enhancements:
- Introduce NetworkEntry.isFailed as the canonical failure signal and use it across the network tab, diagnostic report, and error aggregation utilities to keep failure logic consistent.

Tests:
- Add console tab widget tests to verify only error logs and failed network rows are tinted.
- Add NetworkEntry.isFailed unit tests covering success, HTTP error, and transport-failure scenarios.
- Add a network_utils test to lock in grouping behavior for entries that only have an errorType.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增统一的“失败”判定口径，用于识别错误响应、异常与无状态码的传输失败。
- **界面优化**
  - 控制台时间线对错误日志与失败的网络请求增加高亮；同时调整“按失败筛选”逻辑以匹配新判定。
- **诊断与报告**
  - 错误/警告为主的诊断报告在启用时将仅保留失败相关的网络调用与日志。
- **测试**
  - 补充失败判定、控制台着色与失败聚合的覆盖，并新增无状态码传输失败的聚合场景断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->