### PR TITLE
test(network-detail): hold the Dio so resend test checks isComplete

### DIFF
--- a/test/ui/tabs/network_detail_view_test.dart
+++ b/test/ui/tabs/network_detail_view_test.dart
@@ -292,12 +292,18 @@ void main() {
 
     // Test 2: incomplete entry → disabled
     testWidgets('disabled when entry is not complete', (tester) async {
+      // Held in a local so the WeakReference inside NetworkEntry stays alive:
+      // once collected, the button disables for the wrong reason and this
+      // stops testing isComplete at all. A bare local is enough because
+      // `flutter test` runs the JIT VM, which keeps it live for the frame;
+      // AOT's last-use liveness would not, but widget tests never run AOT.
+      final dio = Dio();
       final entry = NetworkEntry(
         method: 'GET',
         url: 'https://api.test/ping',
         requestHeaders: {},
         isComplete: false,
-        sourceDio: Dio(),
+        sourceDio: dio,
         timestamp: t,
       );
       await pumpView(tester, entry);


### PR DESCRIPTION
## Summary

修復 `Resend action > disabled when entry is not complete` 的 flakiness，並讓它恢復原本宣稱的防護作用。

Closes #102

## 修正問題

該測試把 `Dio()` 直接當臨時值傳給 `NetworkEntry`，但 `sourceDio` 是 `WeakReference<Dio>`，沒有任何強參考持有。GC 一跑，`.target` 變 null，tooltip 從 `'Resend'` 翻成 `'Cannot resend: source Dio not available'`，`find.byTooltip('Resend')` 找不到元素而拋 `Bad state: No element`。

表現是**單跑紅、全跑綠**——CI 只跑全套，所以一直沒抓到。

### 比 flakiness 更嚴重的一點

這個測試在修好之前是**假的**。`_disabled` 是四個條件的 OR：

```dart
bool get _disabled =>
    widget.entry.sourceDio?.target == null ||
    !widget.entry.isComplete ||
    widget.entry.isRequestTruncated ||
    _inFlight;
```

弱參考失效時，是第一項在讓按鈕禁用。所以把受測的 `!widget.entry.isComplete ||` 整條刪掉，測試**照樣通過**——它掛著 `isComplete` 的名字，實際上什麼都沒守。

修復後另外三個條件都被明確排除（`sourceDio` 存活、`requestBody` 為 null 故未截斷、`_inFlight` 初始 false），`onPressed == null` 只可能來自 `isComplete`。

## 修正方式

改用區域變數 `final dio = Dio()` 持有強參考，與同 group 其餘 5 個測試的既有寫法一致。未動任何產品程式碼。

註解一併說明「憑什麼一個 local 就夠」——這點並非顯而易見，見下方驗證。

## Verification

| 步驟 | 結果 |
|------|------|
| 單獨執行（issue 核心驗證） | 修復前必定紅 → 修復後穩定綠 |
| 整檔 | 17 passed |
| 全套 `flutter test` | **425 passed** |
| **Mutation 驗證** | 移除 `network_detail_view.dart:286` 的 `!widget.entry.isComplete \|\|` → 測試失敗；還原 → 通過。確認修復是 load-bearing 的 |
| `flutter analyze` | 零新增 warning |

## 一個查證過的非顯而易見點

「單純宣告 local 是否足以避免被 GC」值得懷疑——Dart 有 last-use liveness。實測結論：

- **AOT**：local 在最後一次使用後**會**被回收
- **JIT**：存活到 frame 結束

而 `flutter test` 在 host platform 跑的是 JIT，widget test 不走 AOT 路徑，因此這個修法穩當、不需要在測試尾端補 `expect(dio, isNotNull)`。此結論已寫進程式碼註解，避免日後有人誤以為遺漏了什麼。

## 排除範圍

- 未改 `NetworkEntry.sourceDio` 的 `WeakReference` 設計（防 ring buffer 洩漏 Dio 的刻意設計，運作正常）
- 未改 `network_detail_view.dart` 的 `_disabled` / tooltip 邏輯（`sourceDio` 被回收時禁用 resend 是正確行為）
- 未引入強制 GC 或 WeakReference 相關的測試基礎建設
- 同檔其他測試已獨立確認無相同風險；全 repo 已無其他「臨時值傳入 `sourceDio`」的寫法

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Stabilize the network detail view resend-button widget test so it reliably verifies the `isComplete` guard without interference from `WeakReference` garbage collection.

Enhancements:
- Document the interaction between local `Dio` lifetimes, JIT vs AOT liveness, and the `WeakReference`-backed `sourceDio` used in the widget, clarifying why the test setup is safe.

Tests:
- Update the `disabled when entry is not complete` widget test to hold the `Dio` instance in a local variable passed to `NetworkEntry.sourceDio`, preventing GC-induced flakiness and ensuring the disabled state is driven by `isComplete` as intended.