### PR TITLE
fix(navigator): stop inspector's own routes polluting host navigation history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+* **Inspector routes no longer pollute the Navigator tab**: opening a detail view or bottom sheet inside the dashboard (log/network details, table rows, cell details, the export sheet) was recorded as navigation in the *host app's* history, so the more thoroughly you investigated, the noisier the Navigator tab became — the export sheet even wrote itself into the report it was about to produce. Every route the dashboard opens is now tagged with a shared prefix that the observer filters on. Host app navigation is untouched, including unnamed routes.
+
 ### Added
 * **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Each entry names the current top-most page (e.g. `App lifecycle: resumed · HomePage (/home)`) so repeated home/back switches stay distinguishable without cross-referencing the Navigator tab. Opt-in and disabled by default; `detach()` removes the observer.
 

--- a/docs/features/2026-07-26-inspector-route-pollution.md
+++ b/docs/features/2026-07-26-inspector-route-pollution.md
@@ -26,7 +26,7 @@
 
 在掛載 `FlutterInspectorNavigatorObserver` 的 app 中開啟 dashboard、點開一筆 network entry 後，`inspector.navigatorInspector.entries` 的實際內容：
 
-```
+```text
 ENTRIES: [NavigatorAction.push/NetworkDetailView, NavigatorAction.push/SizedBox]
 ```
 
@@ -127,7 +127,7 @@ ENTRIES: [NavigatorAction.push/NetworkDetailView, NavigatorAction.push/SizedBox]
 
 ### AC-3：正確性由單一來源保證（消滅特殊情況）
 
-- [ ] Dashboard 內部所有 route 推送皆經由**收斂後的入口**取得 route name，不存在「某處自行硬編 name 字串」的旁路。
+- [ ] Dashboard 內部所有 route 的名稱皆來自**同一份常數定義**，不存在「某處自行硬編 name 字串」的旁路。名稱的**傳遞方式**依 route 形狀而異：page route 走 `pushInspectorRoute` helper、bottom sheet 經 `showModalBottomSheet` 的 `routeSettings:`、dashboard dialog 用共用常數——三者共用同一份常數與前綴，這才是「單一來源」的實質內容（非單一函式，見 §6）。
 - [ ] `_isInspectorRoute` 的判斷只依賴**一個**來源定義的名稱規則。
 - [ ] `'flutter_inspector_dashboard'` 這類字串常值收斂為**單一共用常數**，產生端與判斷端引用同一份定義。
 - [ ] 誤用（未依規則命名）在 **debug build 會當場失敗**（例如 `assert`），而非靜默漏過成為新的污染點。

--- a/docs/features/2026-07-26-inspector-route-pollution.md
+++ b/docs/features/2026-07-26-inspector-route-pollution.md
@@ -1,0 +1,261 @@
+# 功能規格：修復 Inspector 自身頁面污染 NavigatorTab
+
+- **日期**：2026-07-26
+- **狀態**：STAGE 0a — 待確認
+- **來源**：`docs/brainstorm/2026-07-26-features-brainstorm.md` §D6
+- **類型**：**既有缺陷修復（bug fix）**，非新功能
+- **實測驗證**：2026-07-26 probe test 實跑確認，非推論
+
+---
+
+## 1. 問題陳述（What & Why）
+
+### 一句話本質
+
+打開 inspector dashboard 後在裡面點開的每一個 detail view，都被誤記進**使用者 app 的** Navigator 軌跡，導致 NavigatorTab 顯示的不是「我的 app 的導航」，而是「我的 app 的導航 + inspector 自己的導航」混在一起。
+
+### 現況行為 vs 期望行為
+
+| | 現況（bug） | 期望 |
+|---|---|---|
+| 使用者 app 自身的 push/pop/replace/remove | 記錄進 `navigatorInspector.entries` ✅ | 維持不變 ✅ |
+| Dashboard 本體（`showGeneralDialog`） | 已被排除 ✅ | 維持排除 ✅ |
+| Dashboard 內的 detail view / bottom sheet | **被誤記進 entries** ❌ | **一律不記錄** |
+
+### 實測證據
+
+在掛載 `FlutterInspectorNavigatorObserver` 的 app 中開啟 dashboard、點開一筆 network entry 後，`inspector.navigatorInspector.entries` 的實際內容：
+
+```
+ENTRIES: [NavigatorAction.push/NetworkDetailView, NavigatorAction.push/SizedBox]
+```
+
+`NetworkDetailView` 是 inspector 自己的 UI，卻出現在使用者 app 的導航軌跡中。
+
+### 根因鏈（三段，逐檔核對）
+
+1. **Dashboard 掛在被觀察的 Navigator 上**
+   `lib/src/ui/dashboard/dashboard_modal.dart:30` 的 `showGeneralDialog` 未指定 `useRootNavigator`，Flutter 預設為 `true` → dashboard 掛在**宿主 app 的 root Navigator**，正是掛載 `FlutterInspectorNavigatorObserver` 的那一個。
+
+2. **Detail view 繼承同一個 Navigator**
+   Dashboard 子樹內的 `Navigator.of(context).push(...)` / `showModalBottomSheet(...)`，其 `context` 來自 dashboard 子樹 → 解析到同一個 root Navigator → 同樣被觀察。
+
+3. **過濾器認不出它們**
+   `lib/src/observers/navigator_observer.dart:17-18` 的過濾條件是：
+
+   ```dart
+   bool _isInspectorRoute(Route<dynamic> route) =>
+       route.settings.name == 'flutter_inspector_dashboard';
+   ```
+
+   而這些 detail view 的 route **完全沒帶 `RouteSettings.name`**（`name == null`）→ 條件不成立 → 過濾器一律放行，四個覆寫（`didPush` / `didPop` / `didReplace` / `didRemove`）的 early return 全部失效。
+
+### 完整污染來源清單（2026-07-26 實查 grep，共 7 處）
+
+> ⚠️ brainstorm 文件記錄 4 處，為過時快照。以下為當下實查結果，其中 `export_report_sheet.dart` 是文件**完全未列到**的污染點。
+
+| # | 檔案 | 行 | 呼叫形式 | 推送的頁面 | 現有 route name |
+|---|------|---|---------|-----------|----------------|
+| 1 | `lib/src/ui/dashboard/dashboard_modal.dart` | 30 | `showGeneralDialog` | `DashboardModal` 本體 | ✅ `'flutter_inspector_dashboard'` |
+| 2 | `lib/src/ui/dashboard/tabs/console_tab.dart` | 172 | `Navigator.of(context).push` + `MaterialPageRoute` | `LogDetailView` | ❌ 無 |
+| 3 | `lib/src/ui/dashboard/tabs/console_tab.dart` | 196 | `Navigator.of(context).push` + `MaterialPageRoute` | `NetworkDetailView` | ❌ 無 |
+| 4 | `lib/src/ui/dashboard/tabs/network_tab.dart` | 268 | `Navigator.of(context).push` + `MaterialPageRoute` | `NetworkDetailView` | ❌ 無 |
+| 5 | `lib/src/ui/dashboard/tabs/database_tab.dart` | 181 | `Navigator.push(context, ...)` + `MaterialPageRoute` | `TableRowsView` | ❌ 無 |
+| 6 | `lib/src/ui/dashboard/tabs/database/table_rows_view.dart` | 118 | `showModalBottomSheet` | `_CellDetailsBottomSheet` | ❌ 無 |
+| 7 | `lib/src/ui/dashboard/export_report_sheet.dart` | 19 | `showModalBottomSheet` | `ExportReportSheet` | ❌ 無 |
+
+**形狀分類（影響方案設計，勿假設可套同一個入口）**：
+
+- **A 類（4 處：#2 #3 #4 #5）**：`MaterialPageRoute` + `builder`，形狀一致。
+- **B 類（2 處：#6 #7）**：`showModalBottomSheet`，**不建構 `MaterialPageRoute`**，需透過其 `routeSettings:` 參數帶入名稱。bottom sheet 同樣是 route，一樣觸發 `didPush` / `didPop`。
+- **C 類（1 處：#1）**：`showGeneralDialog`，已有名稱，但字串常值目前散落三份（見下），需一併收斂。
+
+**字串常值現況（實查）**：`'flutter_inspector_dashboard'` 目前硬編在三個地方——
+
+- `lib/src/ui/dashboard/dashboard_modal.dart:32`（產生端）
+- `lib/src/observers/navigator_observer.dart:18`（判斷端）
+- `test/observers/navigator_observer_test.dart:109`（測試端）
+
+沒有共用常數。若不收斂，前綴定義會出現多份，同樣的漏接問題會在常數層再犯一次。
+
+### 為何值得修（Why）
+
+污染量與使用者的**排查強度成正比**。越是深入追查（反覆開關 detail view、逐筆點進 network entry、瀏覽資料表），NavigatorTab 就被灌進越多雜訊——**正好在最需要乾淨導航軌跡的時候最髒**。
+
+這違背診斷工具的基本原則：**不干擾被觀測對象**（觀測者效應）。一個會把自己寫進使用者資料的 inspector，其 NavigatorTab 的資料可信度是不可靠的——使用者無法分辨某一筆記錄是自己 app 的行為，還是 inspector 自己的行為。
+
+此缺陷同時波及下游：`NavigatorStackResolver` 從 `entries` 推導的 Active Stack 視圖會混入 inspector 的路由層，`docs/features/2026-07-01-navigator-active-stack.md` 的 US-3（「inspector 自身路由不出現在堆疊視圖」）在 detail view 情境下**實際未達成**。
+
+---
+
+## 2. 使用者故事
+
+### US-1：排查中的開發者看到乾淨的導航軌跡
+
+> 身為使用 inspector 追查導航問題的開發者，我在 dashboard 內點開 detail view 檢視細節時，**不希望我的檢視動作本身被記錄成我 app 的導航事件**。我要看的是「我的 app 走過哪些頁面」，不是「我剛才在 inspector 裡點過哪些卡片」。
+
+**痛點情境**：追一個「某頁面被重複 push 兩次」的 bug。開啟 dashboard → 進 NavigatorTab → 發現需要對照 network 請求 → 切到 NetworkTab 點開三筆請求細節 → 回 NavigatorTab。此時軌跡多了 3 筆 `NetworkDetailView`，與正在追查的真實 push 事件混在一起，必須靠肉眼分辨哪些是雜訊。
+
+### US-2：使用診斷報告的開發者拿到可信的資料
+
+> 身為要把診斷報告貼進 issue 或給同事看的開發者，我希望匯出的導航軌跡是我 app 的真實行為，不含 inspector 自己的 UI 導航。
+
+**痛點情境**：`ExportReportSheet` 本身就是污染點 #7 ——**開啟匯出面板這個動作，會把 `ExportReportSheet` 這筆 push 寫進即將被匯出的資料裡**。使用者拿到的報告在最後一筆記著一個他從未在 app 裡訪問過的頁面。
+
+### US-3：package 使用者（維護者視角）不必記得補 route name
+
+> 身為 flutter_inspector_kit 的維護者，我希望未來新增任何 detail view 時，**不必記得**手動補上 route name 才不會污染使用者資料。正確性應由結構保證，而非由人的記憶保證。
+
+**痛點情境**：本次污染清單從 brainstorm 記錄的 4 處長成實查的 7 處，正是「靠記憶維護」的失敗實證——`export_report_sheet.dart` 加入時沒人記得它是 route。
+
+---
+
+## 3. 驗收條件
+
+### AC-1：Dashboard 內的所有 route 都不進入 entries
+
+- [ ] 開啟 dashboard 後，於 dashboard 內開啟**上述清單第 2～7 處的任一頁面**（`LogDetailView`、`NetworkDetailView`（兩個入口皆須驗）、`TableRowsView`、`_CellDetailsBottomSheet`、`ExportReportSheet`），`inspector.navigatorInspector.entries` **不新增任何一筆**。
+- [ ] 上述頁面的**關閉（pop）**動作同樣不新增 entry（`didPop` 亦被排除）。
+- [ ] Dashboard 本體（`showGeneralDialog`）維持不被記錄（既有行為不回歸）。
+- [ ] 針對實測證據的回歸驗證：重跑該情境，`entries` 中**不再出現** `NetworkDetailView`。
+
+### AC-2：使用者 app 自身的導航仍完整記錄（不可誤殺）
+
+- [ ] 使用者 app 的 `push` / `pop` / `replace` / `remove` 事件仍如常記錄進 `entries`，含 `routeName`、`widgetType`、`arguments`。
+- [ ] **無名稱的**使用者 route（`RouteSettings.name == null`，例如 app 自己 `MaterialPageRoute(builder: ...)` 未設 name）**仍被記錄**——過濾條件不得退化成「無名稱就丟棄」。此為誤殺風險最高的一條。
+- [ ] 名稱**碰巧**與 inspector 前綴無關的使用者 route（例如 `/flutter`、`/inspector`、`/home`）不受影響。
+
+### AC-3：正確性由單一來源保證（消滅特殊情況）
+
+- [ ] Dashboard 內部所有 route 推送皆經由**收斂後的入口**取得 route name，不存在「某處自行硬編 name 字串」的旁路。
+- [ ] `_isInspectorRoute` 的判斷只依賴**一個**來源定義的名稱規則。
+- [ ] `'flutter_inspector_dashboard'` 這類字串常值收斂為**單一共用常數**，產生端與判斷端引用同一份定義。
+- [ ] 誤用（未依規則命名）在 **debug build 會當場失敗**（例如 `assert`），而非靜默漏過成為新的污染點。
+
+### AC-4：既有測試與行為不回歸
+
+- [ ] `test/observers/navigator_observer_test.dart` 既有 8 個測試全數通過，其中 `'ignores inspector dashboard route'` 與 4 個 `did*` 記錄測試（皆使用 `/home`、`/new`、`/removed` 等使用者路由名）行為不變。
+- [ ] `test/inspectors/navigator_stack_resolver_test.dart`、`test/ui/tabs/navigator_tab_test.dart`、`test/ui/tabs/navigator_active_stack_test.dart` 不因本次修復而失效或需被放寬。
+- [ ] `test/ui/export_report_sheet_test.dart`、`test/ui/tabs/console_tab_test.dart` 等碰到 dashboard 內部推送的測試不需修改斷言即可通過（若需修改，須為斷言本身反映舊 bug 行為的情況，並在計畫中明列）。
+
+### AC-5：新增污染點會被擋下（防回歸）
+
+- [ ] 存在一個測試涵蓋「dashboard 內開啟 detail view 不污染 entries」的端到端路徑，使未來新增未走收斂入口的 detail view 時測試會失敗。
+
+---
+
+## 4. 範圍邊界（Scope）
+
+### In-Scope
+
+- 收斂 dashboard 內部 route 推送的命名來源（7 處污染點全數納管）。
+- 收斂 `'flutter_inspector_dashboard'` 字串常值為單一共用常數。
+- 調整 `_isInspectorRoute` 的判斷規則，使其只認收斂後的單一來源。
+- `showModalBottomSheet`（B 類，2 處）以 `routeSettings:` 帶入名稱——形狀與 A 類不同，需個別處理。
+- 新增防回歸測試（AC-5）。
+
+### Out-of-Scope（明確排除，不做）
+
+- **不改 `useRootNavigator`**：不把 dashboard 改掛到獨立 Navigator。那是改變 dashboard 的掛載拓撲，風險遠大於本次修復範圍（會影響全螢幕行為、返回鍵、系統手勢），且**不需要**——名稱過濾已足以解決問題。此為刻意的最小 diff 選擇。
+- **不改 NavigatorTab UI**：本次是資料層修復，不動任何呈現。
+- **不動 `NavigatorStackResolver`**：Active Stack 是 `entries` 的衍生視圖，資料源乾淨後它自然乾淨，不需為此修改推導邏輯。
+- **不改 `NavigatorEntry` 模型**：欄位、`displayName`、`copyWith`、相等性一律不動。
+- **不新增「顯示/隱藏 inspector 路由」的使用者開關**：inspector 的路由對使用者**永遠**無意義，做成可切換是為不存在的需求增加狀態（YAGNI）。
+- **不清理歷史已污染的 entries**：既有 buffer 中的髒資料不做回溯清除；使用者以 `clearNavigator()` 處理即可。
+- **不處理宿主 app 自行推送 inspector widget 的情況**：若使用者把 `NetworkDetailView` 當作自己 app 的一個頁面推送（極不可能），該記錄仍會保留——這是正確行為，因為那確實是使用者 app 的導航。
+- **不改 `FlutterInspector` 的公開 API 形狀**：`navigatorEntries`、`navigatorObserver`、`clearNavigator()` 語意不變。
+
+---
+
+## 5. 破壞性分析（Never break userspace）
+
+本 package 已發布至 pub.dev，任何變更須逐項評估對既有使用者的影響。
+
+### 5.1 公開 API 曝光面
+
+| 符號 | 是否於 `lib/flutter_inspector_kit.dart` export | 使用者可達路徑 | 結論 |
+|---|---|---|---|
+| `FlutterInspectorNavigatorObserver` | ❌ **未直接 export** | ✅ 可達：`FlutterInspector.navigatorObserver` getter（`flutter_inspector.dart:126`）回傳此型別，而 `FlutterInspector` 有 export | **型別公開可達，但成員未直接曝光** |
+| `_isInspectorRoute` | — | ❌ 私有方法 | 可自由修改 |
+| `didPush` / `didPop` / `didReplace` / `didRemove` | — | ✅ 公開覆寫（`NavigatorObserver` 契約） | **簽章不得變更** |
+| `DashboardModal.show` | ❌ 未 export（`ui/dashboard/` 不在 export 清單） | ❌ | 可自由修改 |
+| 各 detail view（`NetworkDetailView` 等） | ❌ 未 export | ❌ | 可自由修改 |
+| `'flutter_inspector_dashboard'` 字串 | — | ⚠️ 使用者可能已在自家程式中硬編此字串做過濾 | 見 5.2 |
+
+**判斷**：使用者能持有 `FlutterInspectorNavigatorObserver` 實例並掛到 `navigatorObservers`（這正是套件的標準用法），但**無法**呼叫或覆寫其內部過濾邏輯。修改 `_isInspectorRoute` 的實作**不構成 API 破壞**。
+
+### 5.2 行為相容性風險
+
+| 風險項 | 評估 | 緩解 |
+|---|---|---|
+| **誤殺使用者 route** | 🔴 **最高風險**。若新規則寫成「無名稱 → 排除」或前綴比對過寬（例如 `contains` 而非 `startsWith`），會吞掉使用者的合法導航記錄——這是比原 bug 更嚴重的破壞（資料遺失 vs 資料多餘）。 | AC-2 三條驗收條件專門守此；前綴須具足夠辨識度以避免碰撞。 |
+| **既有 route name 字串變更** | 🟡 中。若 `'flutter_inspector_dashboard'` 的**值**被改動，任何在自家程式中硬編此字串做過濾的使用者會失效。 | **常數的值必須保持 `'flutter_inspector_dashboard'` 不變**，只做「收斂到常數」而非「改名」。新增的 detail view 名稱是全新字串，不影響既有使用者。 |
+| **新增 route name 造成使用者側行為改變** | 🟢 低。detail view 原本 `name == null`，改為帶名稱後，理論上使用者若掛了自己的 `NavigatorObserver`，會從「收到 name=null 的事件」變成「收到帶 inspector 前綴的事件」。 | 事件本身數量不變，只是多了可辨識的名稱——對使用者而言是**淨改善**（原本無從分辨，現在可自行過濾）。 |
+| **`entries` 數量減少** | 🟢 低，且**這正是修復目的**。使用者若有測試斷言 dashboard detail view 出現在 entries 中，該斷言本身是在驗證 bug。 | CHANGELOG 明列為 bug fix。 |
+| **`showGeneralDialog` / `showModalBottomSheet` 行為改變** | 🟢 無。僅新增 `routeSettings`，不改 `useRootNavigator`、`isScrollControlled` 等既有參數。 | — |
+
+### 5.3 既有測試影響評估（實查）
+
+碰觸 navigator observer 或 dashboard 內部推送的測試共 12 個檔案：
+
+| 測試檔 | 影響評估 |
+|---|---|
+| `test/observers/navigator_observer_test.dart` | 🟡 **直接相關**。含 `'ignores inspector dashboard route'`（硬編 `'flutter_inspector_dashboard'`，第 109 行）與 4 個使用具名使用者路由（`/home` 等）的記錄測試。前者應改為引用共用常數；後者行為不得變。**另需補一則「無名稱使用者 route 仍被記錄」的測試守 AC-2。** |
+| `test/ui/export_report_sheet_test.dart` | 🟡 可能受影響（#7 是污染點，其 `show` 會加 `routeSettings`）。 |
+| `test/ui/tabs/console_tab_test.dart` | 🟡 可能受影響（#2 #3 為污染點）。 |
+| `test/ui/tabs/navigator_tab_test.dart`、`navigator_active_stack_test.dart` | 🟢 應不受影響（讀取端，資料源乾淨後行為更正確）。 |
+| `test/inspectors/navigator_stack_resolver_test.dart`、`navigator_inspector_test.dart`、`models/navigator_entry_test.dart` | 🟢 不受影響（不經過 observer 過濾）。 |
+| `test/core/*`、`test/utils/diagnostic_report_test.dart` | 🟢 應不受影響。 |
+
+> 出口要求：修復完成後上述測試須**全數通過且不放寬斷言**；任何需要修改的斷言，須在實作計畫中逐條說明「該斷言原本在驗證舊 bug」。
+
+### 5.4 CHANGELOG 定位
+
+本次為 **bug fix**（修正 inspector 自身 UI 導航污染使用者 Navigator 記錄）。無公開 API 變更、無使用者遷移動作。
+
+---
+
+## 6. 設計判斷：為何採方案 B
+
+> 本節複述 `docs/brainstorm/2026-07-26-features-brainstorm.md` §D6 已定案的結論，非重新提案。
+
+### 方案 A（已否決）— 逐處補 `RouteSettings(name: ...)`
+
+為 7 處污染點各自補上帶前綴的 `RouteSettings(name: ...)`，`_isInspectorRoute` 改用 `startsWith` 前綴比對。
+
+**否決理由：治標。** 把正確性寄託在人的記憶上——新增任何 detail view 都必須記得補 name，漏一個就再破一次。本次污染清單從 brainstorm 記錄的 4 處長成實查的 7 處（`export_report_sheet.dart` 是新增的、無人察覺的污染點），**已經是這個方案失敗的實證**。
+
+### 方案 B（採用）— 收斂為單一推送入口
+
+Dashboard 內部推送統一走一個 helper（如 `pushInspectorRoute`），由它統一掛上帶前綴的 route name；`_isInspectorRoute` 只認這一個來源。
+
+**採用理由**：符合專案的 Linus 式判準——**消滅特殊情況優先於增加判斷**。4+ 個散落的命名判斷點收斂成 1 個，正確性由結構保證而非人的記憶保證。新增 detail view 時，若走 helper 就自動正確；若不走 helper，AC-3 要求的 `assert` 會在 debug build 當場失敗，而非靜默成為下一個污染點。
+
+### 已知的形狀落差（不可忽略）
+
+方案 B 的「統一入口」在實作上**不是單一函式**：
+
+- **A 類（4 處）** 建構 `MaterialPageRoute`，可由單一 helper 完整覆蓋。
+- **B 類（2 處）** `showModalBottomSheet` 不建構 `MaterialPageRoute`，需經其 `routeSettings:` 參數帶入。**不可假設能套同一個 helper。**
+- **C 類（1 處）** `showGeneralDialog` 已有名稱，只需將字串常值收進共用常數。
+
+三類共用**同一份名稱規則與前綴常數**（這是「單一來源」的實質內容），但入口形式可有兩種。這是形狀差異的必然結果，不是設計妥協——強行把 bottom sheet 塞進 page route helper 才是為統一而統一。
+
+### 實作備忘（brainstorm 提供，供 STAGE 0b 參考）
+
+- Helper 內建議加 `assert(name.startsWith(prefix))`，讓誤用在 debug build 當場炸出來。
+- `dashboard_modal.dart` 現有的 `'flutter_inspector_dashboard'` 字串常值一併收進共用常數（**值不變**，見 §5.2）。
+- 專案既有常數慣例為 file 層級 `const String kXxx`（見 `lib/src/utils/redaction.dart:6`、`lib/src/models/network_entry.dart:14`、`lib/src/webview/webview_bridge_js.dart:5`）；`lib/src/` 下**無**集中式 constants 檔，常數放置位置由 STAGE 0b 依既有慣例決定（候選：`lib/src/ui/dashboard/` 下的新檔，或既有的 `lib/src/utils/`）。
+
+---
+
+## 7. 規格出口條件
+
+- [ ] 問題陳述與實測證據已確認（7 處污染點清單為實查結果，取代 brainstorm 的 4 處快照）。
+- [ ] AC-1～AC-5 已確認為可測試、可驗收。
+- [ ] 範圍邊界已確認：不改 `useRootNavigator`、不改 NavigatorTab UI、不動 `NavigatorStackResolver`、不改 `NavigatorEntry`、不新增使用者開關。
+- [ ] 破壞性分析已確認：`FlutterInspectorNavigatorObserver` 未直接 export（僅經 `navigatorObserver` getter 可達），修改 `_isInspectorRoute` 不構成 API 破壞；`'flutter_inspector_dashboard'` 的**值**保持不變。
+- [ ] AC-2「無名稱使用者 route 仍被記錄」已確認為最高風險項並列入驗收。
+- [ ] 方案 B 的三類形狀落差（page route / bottom sheet / general dialog）已確認為已知事實，不視為方案缺陷。
+
+進入 STAGE 0b（實作計畫），細化：共用常數與前綴的具體定義與放置位置、helper 的簽章與 `assert` 條件、bottom sheet 的 `routeSettings` 接線方式、`_isInspectorRoute` 的新判斷規則、7 處污染點的逐檔異動清單，以及對應的 TDD 任務拆解。

--- a/docs/plans/2026-07-26-inspector-route-pollution.md
+++ b/docs/plans/2026-07-26-inspector-route-pollution.md
@@ -47,7 +47,7 @@ const String kInspectorExportReportRoute = 'flutter_inspector_export_report';
 - 常數的**語意所有者是過濾規則**（observer），UI 只是規則的遵守方。放在判斷端，依賴方向是 `ui/ → observers/`，單向。
 - 反向（放 `lib/src/ui/dashboard/`）會讓 `observers/` 依賴 `ui/`，把過濾邏輯綁在 UI 層上，方向錯誤。
 - 放 `lib/src/utils/` 也可行，但 `utils/` 現有內容（redaction、formatters、table_sort）皆為無狀態純函式工具，route 命名契約不屬於這個語意群。
-- `observers/` 目前只有 `navigator_observer.dart`，無任何 import；新檔零 import（純 `const String`）→ 不可能循環相依。測試端 `test/observers/navigator_observer_test.dart` 已 import 同目錄的 observer，路徑自然。
+- 新檔只依賴 Flutter 基礎庫（helper 需 `package:flutter/material.dart` 取得 `BuildContext` / `WidgetBuilder` / `MaterialPageRoute`），不 import 本專案任何模組 → 不可能與 `ui/` 形成循環相依。測試端 `test/observers/navigator_observer_test.dart` 已 import 同目錄的 observer，路徑自然。
 - 檔名 `snake_case`，符合 §2.4。
 
 **慣例對齊**：file 層級 `const String kXxx` + 檔頭說明註解，與 `lib/src/utils/redaction.dart:6`、`lib/src/webview/webview_bridge_js.dart:5` 完全同形。
@@ -290,7 +290,7 @@ testWidgets('opening the export sheet does not pollute entries',
 
 ## 3. 任務拆分
 
-任務粒度 2–5 分鐘。相依順序：**T1 → (T2 ‖ T3 ‖ T4 ‖ T5 ‖ T6) → T7 → T8**。
+任務粒度 2–5 分鐘。相依順序：**T1 → (T2 ‖ T3 ‖ T4 ‖ T5 ‖ T6) → (T7 ‖ T8) → T9**。T7 與 T8 寫入不同測試檔、互無資料相依，可並行（與下方 Wave 3 一致）。
 
 ### T1｜建立共用常數與 helper（TDD 起點）
 
@@ -399,7 +399,7 @@ testWidgets('opening the export sheet does not pollute entries',
 **Wave 1（序列）**：T1
 
 **Wave 2（5 路並行，寫入路徑互不重疊）**：
-```
+```text
 T2  → lib/src/observers/navigator_observer.dart
 T3  → lib/src/ui/dashboard/dashboard_modal.dart
 T4  → lib/src/ui/dashboard/tabs/console_tab.dart

--- a/docs/plans/2026-07-26-inspector-route-pollution.md
+++ b/docs/plans/2026-07-26-inspector-route-pollution.md
@@ -1,0 +1,438 @@
+# 實作計畫：修復 Inspector 自身頁面污染 NavigatorTab
+
+- **日期**：2026-07-26
+- **狀態**：STAGE 0b — 待執行
+- **規格來源**：`docs/features/2026-07-26-inspector-route-pollution.md`（已確認，方案 B）
+- **類型**：bug fix，最小 diff
+
+---
+
+## 1. 技術決策（Decisions）
+
+以下六項為規格 §7 要求 STAGE 0b 細化的內容。每項附「為何這樣、為何不那樣」。
+
+### D1. 共用常數：值與放置位置
+
+**新檔**：`lib/src/observers/inspector_route_names.dart`
+
+```dart
+// Route names for the inspector's own UI. The observer filters on this
+// prefix so inspector navigation never lands in the host app's Navigator
+// history. Producers (dashboard UI) and the consumer (the observer) must
+// share this one definition — a second copy is how the original bug happened.
+
+/// Prefix every inspector-owned route name starts with.
+///
+/// Deliberately verbose and package-qualified: it must not collide with a
+/// host app's own route names, which are typically path-like (`/home`) or
+/// short identifiers. `startsWith` on this prefix is the whole filter.
+const String kInspectorRoutePrefix = 'flutter_inspector_';
+
+/// The dashboard modal itself.
+///
+/// The value is frozen: it shipped on pub.dev and users may already filter
+/// on this exact string in their own NavigatorObserver.
+const String kInspectorDashboardRoute = 'flutter_inspector_dashboard';
+
+const String kInspectorLogDetailRoute = 'flutter_inspector_log_detail';
+const String kInspectorNetworkDetailRoute = 'flutter_inspector_network_detail';
+const String kInspectorTableRowsRoute = 'flutter_inspector_table_rows';
+const String kInspectorCellDetailsRoute = 'flutter_inspector_cell_details';
+const String kInspectorExportReportRoute = 'flutter_inspector_export_report';
+```
+
+**前綴值 `'flutter_inspector_'` 的理由**：`kInspectorDashboardRoute` 的值被規格 §5.2 凍結為 `'flutter_inspector_dashboard'`，前綴必須是它的真前綴，否則 dashboard 本體會漏過過濾（AC-1 第三條回歸）。`'flutter_inspector_'` 是同時滿足「凍結值的前綴」與「辨識度足夠」的最長選擇。規格 AC-2 點名的三個使用者 route 樣本 `/flutter`、`/inspector`、`/home` 皆不以此開頭 → 不誤殺。
+
+**放在 `lib/src/observers/` 的理由**：
+- 常數的**語意所有者是過濾規則**（observer），UI 只是規則的遵守方。放在判斷端，依賴方向是 `ui/ → observers/`，單向。
+- 反向（放 `lib/src/ui/dashboard/`）會讓 `observers/` 依賴 `ui/`，把過濾邏輯綁在 UI 層上，方向錯誤。
+- 放 `lib/src/utils/` 也可行，但 `utils/` 現有內容（redaction、formatters、table_sort）皆為無狀態純函式工具，route 命名契約不屬於這個語意群。
+- `observers/` 目前只有 `navigator_observer.dart`，無任何 import；新檔零 import（純 `const String`）→ 不可能循環相依。測試端 `test/observers/navigator_observer_test.dart` 已 import 同目錄的 observer，路徑自然。
+- 檔名 `snake_case`，符合 §2.4。
+
+**慣例對齊**：file 層級 `const String kXxx` + 檔頭說明註解，與 `lib/src/utils/redaction.dart:6`、`lib/src/webview/webview_bridge_js.dart:5` 完全同形。
+
+**不做**：不建 `enum` 或 `class InspectorRoutes { static const ... }`。專案沒有這個慣例，且 `const String` 已足夠（Ponytail：不為單一用途加抽象）。
+
+### D2. Helper：簽章與 assert
+
+**放置**：與常數同檔 `lib/src/observers/inspector_route_names.dart`。
+
+**理由**：helper 的全部價值就是「掛上前綴合規的名字」，它是常數契約的執行者，兩者同生共死。分兩檔會讓「單一來源」變兩個檔案，違反 AC-3 的精神。同檔也讓 UI 端只需一行 import。
+
+```dart
+/// Pushes an inspector-owned page route, tagged so the navigator observer
+/// can keep it out of the host app's navigation history.
+///
+/// Every page route opened from inside the dashboard must go through here.
+/// [name] must start with [kInspectorRoutePrefix]; a stray name would
+/// silently become the next pollution source, so it fails loudly in debug.
+void pushInspectorRoute(
+  BuildContext context,
+  String name,
+  WidgetBuilder builder,
+) {
+  assert(
+    name.startsWith(kInspectorRoutePrefix),
+    'Inspector route name "$name" must start with '
+    '"$kInspectorRoutePrefix" or the navigator observer will leak it into '
+    'the host app history.',
+  );
+  Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(
+      settings: RouteSettings(name: name),
+      builder: builder,
+    ),
+  );
+}
+```
+
+此 helper 需 `import 'package:flutter/widgets.dart';`（`BuildContext` / `Navigator` / `MaterialPageRoute` 皆在 widgets 之外——`MaterialPageRoute` 在 `material.dart`，故實際 import `package:flutter/material.dart'`）。此 import 不會造成循環：`navigator_observer.dart` 已 import `flutter/widgets.dart`。
+
+**簽章決策逐條**：
+
+| 決策 | 選擇 | 理由 |
+|---|---|---|
+| 回傳型別 | `void` | 4 個呼叫端全部是 `onTap: () => ...` 的 fire-and-forget，無一使用回傳的 `Future`。回傳 `Future<void>` 會製造未 await 的 future（lint 噪音）且無人消費。**Ponytail：不為零個消費者留回傳值。** |
+| 泛型 `<T>` | 不加 | 沒有 detail view 回傳值。單一實作的泛型是投機抽象。 |
+| 參數形式 | `context` 與 `name` 為 positional，`builder` 為 positional | 依 §2.8：3 個參數但型別全異、順序語意明確（誰、叫什麼、長什麼樣），且與 `Navigator.push(context, route)` 的既有直覺一致。不強制 named。 |
+| 統一 `Navigator.of(context).push` vs `Navigator.push(context, ...)` | helper 內統一用 `Navigator.of(context).push`；呼叫端形式差異隨之消失 | 這正是收斂的附帶收益——`database_tab.dart:181` 的 `Navigator.push(context, ...)` 特例被 helper 吃掉。 |
+| `MaterialPageRoute<void>` 顯式泛型 | 加 | 避免推導成 `dynamic`。 |
+
+**assert 條件**：`name.startsWith(kInspectorRoutePrefix)`。滿足 AC-3 第四條「誤用在 debug build 當場失敗」。用 `startsWith` 而非 `==` 某清單，是因為新增 detail view 時只需宣告一個新常數，不需改 helper。
+
+**不做**：不加 `assert(context.mounted)`（呼叫點皆在同步 `onTap` 內，無 async gap）；不加 `useRootNavigator` 參數（規格 §4 明確 out-of-scope）。
+
+### D3. B 類 bottom sheet 接線
+
+**決策：不寫第二個 helper。2 處各自在既有的 `showModalBottomSheet` 呼叫加一行 `routeSettings:`。**
+
+```dart
+showModalBottomSheet<void>(
+  context: context,
+  routeSettings: const RouteSettings(name: kInspectorCellDetailsRoute),
+  builder: ...,
+);
+```
+
+**理由**（規格 §6「不可假設能套同一個 helper」「強行把 bottom sheet 塞進 page route helper 是為統一而統一」）：
+- 兩處的 `showModalBottomSheet` 參數已經不同（`export_report_sheet.dart` 有 `isScrollControlled: true`，`table_rows_view.dart` 沒有），且 `showModalBottomSheet` 另有 `backgroundColor`、`shape`、`constraints` 等十餘個參數。包一個 helper 就得決定透傳哪些、或寫死；兩者都比多一行 `routeSettings:` 差。
+- 一個只被呼叫 2 次、內容是「原封不動轉呼叫 + 塞一個參數」的 wrapper，是 Ponytail 明令的不必要抽象。
+- 「單一來源」的實質內容是**共用同一份常數與前綴**（規格 §6 原文），而非同一個函式。這裡兩處都 import 同一份常數，契約已滿足。
+
+**assert 覆蓋落差（已知且接受）**：B 類 2 處不經過 helper，故不受 D2 的 assert 保護。緩解手段為 D6 的防回歸測試（AC-5）：測試直接斷言 `entries` 為空，任何未掛 `routeSettings` 的新 bottom sheet 都會讓測試失敗。**測試守 B 類，assert 守 A 類**，兩者合起來覆蓋 AC-3。這是形狀差異的必然結果，不是漏洞。
+
+### D4. `_isInspectorRoute` 的新規則
+
+```dart
+bool _isInspectorRoute(Route<dynamic> route) =>
+    route.settings.name?.startsWith(kInspectorRoutePrefix) ?? false;
+```
+
+**逐項對照風險（規格 §5.2 最高風險項）**：
+
+| 要求 | 本實作如何滿足 |
+|---|---|
+| AC-2：`name == null` 的**使用者** route 仍被記錄 | `?.` 讓 null 短路到 `?? false` → 回傳 `false` → **不排除** → 照常記錄。null 走的是「保留」而非「丟棄」。 |
+| 規格 §5.2：用 `startsWith` 而非 `contains` | 直接使用 `startsWith`。`contains` 會誤殺名為 `/settings/flutter_inspector_help` 之類的使用者 route。 |
+| AC-1 第三條：dashboard 本體維持排除 | `'flutter_inspector_dashboard'.startsWith('flutter_inspector_')` 為 `true`，行為不變。 |
+| AC-2 第三條：`/flutter`、`/inspector`、`/home` 不受影響 | 三者皆不以 `flutter_inspector_` 開頭。 |
+| AC-3 第二條：只依賴一個來源 | 唯一依賴 `kInspectorRoutePrefix`。 |
+
+**不做**：不改 `didPush` / `didPop` / `didReplace` / `didRemove` 的簽章與結構（規格 §5.1 明令簽章不得變更）；不改 `_record`、`_resolveWidgetType`。本檔淨 diff = 1 行邏輯 + 1 行 import。
+
+### D5. 7 處污染點逐檔異動清單
+
+行號為 2026-07-26 實查確認，與規格一致。
+
+| # | 檔案:行 | 類別 | 異動 | route name 常數 |
+|---|---|---|---|---|
+| 1 | `lib/src/ui/dashboard/dashboard_modal.dart:32` | C | `'flutter_inspector_dashboard'` 字面值 → `kInspectorDashboardRoute`（**值不變**）。加 import。`const RouteSettings(...)` 維持 `const`（常數是編譯期常數）。 | `kInspectorDashboardRoute` |
+| 2 | `lib/src/ui/dashboard/tabs/console_tab.dart:171-175` | A | `Navigator.of(context).push(MaterialPageRoute(builder: ...))` → `pushInspectorRoute(context, kInspectorLogDetailRoute, (_) => LogDetailView(entry: entry))` | `kInspectorLogDetailRoute` |
+| 3 | `lib/src/ui/dashboard/tabs/console_tab.dart:196-203` | A | 同上 → `pushInspectorRoute(context, kInspectorNetworkDetailRoute, (_) => NetworkDetailView(entry: entry, redactSensitiveData: redactSensitiveData))` | `kInspectorNetworkDetailRoute` |
+| 4 | `lib/src/ui/dashboard/tabs/network_tab.dart:268-275` | A | 同 #3 形狀 | `kInspectorNetworkDetailRoute` |
+| 5 | `lib/src/ui/dashboard/tabs/database_tab.dart:180-190` | A | `Navigator.push(context, MaterialPageRoute(builder: (context) => TableRowsView(...)))` → `pushInspectorRoute(context, kInspectorTableRowsRoute, (_) => TableRowsView(source: selectedSource, tableName: table.name))`。順帶消除 `Navigator.push(context, ...)` 這個形式特例。 | `kInspectorTableRowsRoute` |
+| 6 | `lib/src/ui/dashboard/tabs/database/table_rows_view.dart:118-121` | B | `showModalBottomSheet` 加 `routeSettings: const RouteSettings(name: kInspectorCellDetailsRoute)` | `kInspectorCellDetailsRoute` |
+| 7 | `lib/src/ui/dashboard/export_report_sheet.dart:19-24` | B | `showModalBottomSheet<void>` 加 `routeSettings: const RouteSettings(name: kInspectorExportReportRoute)`；`isScrollControlled: true` 等既有參數不動 | `kInspectorExportReportRoute` |
+
+**#2～#5 的 import 調整**：4 個檔案加入 `inspector_route_names.dart` 的相對 import；若移除 `MaterialPageRoute` 後該檔不再需要某個 import，順手清掉（實測時以 `dart analyze` 為準，不預先猜測——各檔皆 import `material.dart` 整包，實際不會有 unused import）。
+
+**#3 與 #4 共用同一個常數**：兩處推的都是 `NetworkDetailView`，同一種頁面就該同一個名字。不為「兩個入口」造兩個常數。
+
+### D6. 測試策略（TDD）
+
+四項測試工作，全部落在 `test/observers/navigator_observer_test.dart`（既有檔）與一個新檔。
+
+**T-a（守 AC-2，最高風險）— 新增單元測試**：無名稱的使用者 route 仍被記錄。規格 §5.3 指出這是既有測試的缺口。
+
+```dart
+test('records an unnamed user route (name == null must not be dropped)', () {
+  final route = MaterialPageRoute<void>(builder: (_) => const SizedBox());
+  observer.didPush(route, null);
+
+  expect(inspector.navigatorInspector.entries.length, 1);
+  expect(inspector.navigatorInspector.entries.first.routeName, isNull);
+});
+```
+
+**T-b（守 AC-2 第三條）— 新增單元測試**：名稱近似但不以前綴開頭的使用者 route 仍被記錄。
+
+```dart
+test('records user routes whose names merely resemble the prefix', () {
+  for (final name in ['/flutter', '/inspector', '/home', 'flutter_x']) {
+    observer.didPush(
+      MaterialPageRoute<void>(
+        settings: RouteSettings(name: name),
+        builder: (_) => const SizedBox(),
+      ),
+      null,
+    );
+  }
+  expect(inspector.navigatorInspector.entries.length, 4);
+});
+```
+
+**T-c（AC-4 + AC-3）— 修改既有測試**：`test/observers/navigator_observer_test.dart:109` 的硬編 `'flutter_inspector_dashboard'` 改為 `kInspectorDashboardRoute`。**這不是放寬斷言**——常數的值與原字面值完全相同，測試語意零變化，只是把測試端也接到單一來源上（AC-3）。其餘 7 個既有測試一字不改。
+
+**T-d（守 AC-5，防回歸）— 新檔 `test/observers/inspector_route_filter_test.dart`**：端到端 widget test，掛真實 observer 到真實 Navigator，逐一開啟 6 個 inspector route name，斷言 `entries` 全程為空，且同一個 Navigator 上的使用者 route 照常記錄。
+
+```dart
+testWidgets('no inspector-owned route reaches the entries buffer',
+    (tester) async {
+  final inspector = FlutterInspector();
+  await tester.pumpWidget(
+    MaterialApp(
+      navigatorObservers: [inspector.navigatorObserver],
+      home: const SizedBox(),
+    ),
+  );
+  final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+
+  const names = [
+    kInspectorDashboardRoute,
+    kInspectorLogDetailRoute,
+    kInspectorNetworkDetailRoute,
+    kInspectorTableRowsRoute,
+    kInspectorCellDetailsRoute,
+    kInspectorExportReportRoute,
+  ];
+
+  for (final name in names) {
+    navigator.push(
+      MaterialPageRoute<void>(
+        settings: RouteSettings(name: name),
+        builder: (_) => const SizedBox(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    navigator.pop();
+    await tester.pumpAndSettle();
+  }
+
+  expect(inspector.navigatorInspector.entries, isEmpty);
+
+  // The same observer still records the host app's own navigation.
+  navigator.push(
+    MaterialPageRoute<void>(
+      settings: const RouteSettings(name: '/user-page'),
+      builder: (_) => const SizedBox(),
+    ),
+  );
+  await tester.pumpAndSettle();
+  expect(inspector.navigatorInspector.entries.length, 1);
+});
+```
+
+此測試同時覆蓋 push 與 pop（AC-1 第二條），且因為它斷言的是**常數清單**，未來新增 detail view 時只要作者宣告了常數卻忘了接線，測試不會保護；但只要作者**沒**宣告常數（即完全繞過收斂入口），A 類會被 assert 擋下、B 類會在下方 T-e 被擋下。
+
+**T-e（守 AC-5 的 UI 端，B 類 assert 缺口的補償）— 新增 2 則 widget test**，併入 `test/observers/inspector_route_filter_test.dart`：驗證 2 處 bottom sheet 實際掛上了名稱。用最小成本做法——直接斷言掛了 observer 的 app 中開啟該 sheet 後 `entries` 為空。
+
+```dart
+testWidgets('opening the export sheet does not pollute entries',
+    (tester) async { /* pump ExportReportSheet.show + assert entries isEmpty */ });
+```
+
+`table_rows_view` 的 cell details sheet 需要 `DatabaseBrowserSource`，成本較高；若在實作時發現需要建 mock source 才能觸發，改以 `routeSettings` 的靜態驗證替代（斷言 `_showCellDetails` 的 route name），並在 PR 說明中記錄。**先嘗試端到端，落地不可行才降級。**
+
+**明確不需修改的測試（規格 §5.3 逐條回覆，已實查全文）**：
+
+| 測試檔 | 實查結論 |
+|---|---|
+| `test/ui/tabs/console_tab_test.dart` | ✅ **不需修改**。全檔 13 則測試僅斷言 `find.byType(LogDetailView/NetworkDetailView)` 與 tile 顏色、排序，**無任何一則觸及 route name 或 `navigatorInspector.entries`**。且其 `MaterialApp` 未掛 observer。 |
+| `test/ui/export_report_sheet_test.dart` | ✅ **不需修改**。斷言集中在 sheet 內的文字、勾選狀態與 share channel 內容，未觸及 route。其 `pumpSheet` 的 `MaterialApp` 未掛 observer。 |
+| `navigator_tab_test.dart`、`navigator_active_stack_test.dart`、`navigator_stack_resolver_test.dart`、`navigator_inspector_test.dart`、`models/navigator_entry_test.dart` | ✅ 讀取端 / 不經 observer 過濾，不受影響。 |
+
+**結論：本次修復不需放寬或修改任何既有斷言。** 唯一的既有測試改動是 T-c 的字面值 → 常數替換，值不變。
+
+---
+
+## 2. 檔案異動總覽
+
+| 檔案 | 動作 | 淨變更規模 |
+|---|---|---|
+| `lib/src/observers/inspector_route_names.dart` | **新增** | ~45 行（常數 + helper + 註解） |
+| `lib/src/observers/navigator_observer.dart` | 修改 | 1 行邏輯 + 1 行 import |
+| `lib/src/ui/dashboard/dashboard_modal.dart` | 修改 | 1 行 + import |
+| `lib/src/ui/dashboard/tabs/console_tab.dart` | 修改 | 2 處 + import |
+| `lib/src/ui/dashboard/tabs/network_tab.dart` | 修改 | 1 處 + import |
+| `lib/src/ui/dashboard/tabs/database_tab.dart` | 修改 | 1 處 + import |
+| `lib/src/ui/dashboard/tabs/database/table_rows_view.dart` | 修改 | 1 行 + import |
+| `lib/src/ui/dashboard/export_report_sheet.dart` | 修改 | 1 行 + import |
+| `test/observers/navigator_observer_test.dart` | 修改 | +2 測試、1 行常數替換 |
+| `test/observers/inspector_route_filter_test.dart` | **新增** | ~80 行 |
+| `CHANGELOG.md` | 修改 | 1 條 bug fix |
+
+**新增檔案數：2（1 lib + 1 test）。** 無新增依賴、無新增 export。
+
+**`lib/flutter_inspector_kit.dart` 不動**：實查其 export 清單（11 行）不含 `src/observers/` 與 `src/ui/dashboard/`。`inspector_route_names.dart` 保持內部檔案，**不加入 export**——使用者不需要也不該直接呼叫 `pushInspectorRoute`（規格 §4「不改公開 API 形狀」）。測試以 `package:flutter_inspector_kit/src/...` 深路徑 import，與既有測試（`navigator_observer_test.dart:2-4`）同慣例。
+
+---
+
+## 3. 任務拆分
+
+任務粒度 2–5 分鐘。相依順序：**T1 → (T2 ‖ T3 ‖ T4 ‖ T5 ‖ T6) → T7 → T8**。
+
+### T1｜建立共用常數與 helper（TDD 起點）
+
+- **複雜度**：`標準`（設計判斷已在 D1/D2 定案，執行為機械性，但是所有後續任務的地基）
+- **寫入 scope**：`lib/src/observers/inspector_route_names.dart`（新檔）
+- **可並行**：❌ 無（所有其他任務的前置）
+- **內容**：依 D1 建立 6 個 route name 常數 + `kInspectorRoutePrefix`；依 D2 建立 `pushInspectorRoute` 含 `assert`。檔頭寫「為何存在」的註解。
+- **驗收**：`dart analyze lib/src/observers/inspector_route_names.dart` 零 issue；`kInspectorDashboardRoute` 的值逐字元等於 `'flutter_inspector_dashboard'`。
+
+---
+
+### T2｜`_isInspectorRoute` 改為前綴比對（🔴 最高風險）
+
+- **複雜度**：`最強推論`（單行改動，但誤寫即造成資料遺失。必須確認 null 走「保留」分支）
+- **寫入 scope**：`lib/src/observers/navigator_observer.dart`
+- **可並行**：✅ 可與 T3–T6 並行（寫入路徑不重疊）
+- **前置**：T1
+- **內容**：依 D4 改為 `route.settings.name?.startsWith(kInspectorRoutePrefix) ?? false`，加 import。四個 `did*` 覆寫一字不改。
+- **驗收**：`flutter test test/observers/navigator_observer_test.dart` — 既有 8 則測試（含 `'ignores inspector dashboard route'`）全綠。
+- **⚠️ 檢查點**：改完自問「使用者 `MaterialPageRoute(builder: ...)` 沒給 name，會被排除嗎？」答案必須是「不會」。
+
+---
+
+### T3｜dashboard_modal 字面值收斂（C 類，#1）
+
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`lib/src/ui/dashboard/dashboard_modal.dart`
+- **可並行**：✅ 與 T2、T4、T5、T6 並行
+- **前置**：T1
+- **內容**：`dashboard_modal.dart:32` 的字面值換成 `kInspectorDashboardRoute`，加相對 import `../../observers/inspector_route_names.dart`。**值不得改變**（規格 §5.2）。
+- **驗收**：`flutter test test/ui/dashboard_modal_test.dart`（若存在）與 `dart analyze` 綠。
+
+---
+
+### T4｜console_tab 兩處改走 helper（A 類，#2 #3）
+
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`lib/src/ui/dashboard/tabs/console_tab.dart`
+- **可並行**：✅
+- **前置**：T1
+- **內容**：D5 表格 #2、#3。`_LogEntryRow.onTap`（171–175 行）與 `_NetworkEntryRow.onTap`（196–203 行）改為 `pushInspectorRoute(...)`。保留尾隨逗號。
+- **驗收**：`flutter test test/ui/tabs/console_tab_test.dart` 全綠（**不修改任何斷言**——實查確認該檔無 route 相關斷言）。
+
+---
+
+### T5｜network_tab + database_tab 改走 helper（A 類，#4 #5）
+
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`lib/src/ui/dashboard/tabs/network_tab.dart`、`lib/src/ui/dashboard/tabs/database_tab.dart`
+- **可並行**：✅
+- **前置**：T1
+- **內容**：D5 表格 #4、#5。#5 順帶把 `Navigator.push(context, ...)` 形式統一掉，並把 builder 參數名 `(context)` 改為 `(_)`（未使用）。
+- **驗收**：`flutter test test/ui/tabs/network_tab_test.dart test/ui/tabs/database_tab_test.dart` 全綠。
+
+---
+
+### T6｜兩處 bottom sheet 掛 routeSettings（B 類，#6 #7）
+
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`lib/src/ui/dashboard/tabs/database/table_rows_view.dart`、`lib/src/ui/dashboard/export_report_sheet.dart`
+- **可並行**：✅
+- **前置**：T1
+- **內容**：D3 + D5 表格 #6、#7。各加一行 `routeSettings: const RouteSettings(name: kInspectorXxxRoute)`，其餘參數（`isScrollControlled` 等）一字不動。**不建立 wrapper 函式。**
+- **驗收**：`flutter test test/ui/export_report_sheet_test.dart test/ui/tabs/database/table_rows_view_test.dart`（後者若存在）全綠，**不修改任何斷言**。
+
+---
+
+### T7｜observer 測試：補 AC-2 缺口 + 常數收斂
+
+- **複雜度**：`標準`（新增測試需正確表達「null 必須被保留」的語意）
+- **寫入 scope**：`test/observers/navigator_observer_test.dart`
+- **可並行**：❌ 與 T8 寫入不同檔可並行，但兩者皆需 T1–T6 完成
+- **前置**：T1、T2
+- **內容**：依 D6 加入 T-a（無名稱 route 仍記錄）、T-b（近似名稱不誤殺）；把第 109 行的硬編字串換成 `kInspectorDashboardRoute`。既有 8 則其餘測試一字不改。
+- **驗收**：該檔 10 則測試全綠。**額外驗證**：暫時把 `_isInspectorRoute` 改成 `name == null || name.startsWith(...)`，T-a 必須失敗；驗證後還原。（確認新測試真的守得住）
+
+---
+
+### T8｜防回歸端到端測試（AC-5）
+
+- **複雜度**：`標準`（新檔、需真實 Navigator 與 observer 接線）
+- **寫入 scope**：`test/observers/inspector_route_filter_test.dart`（新檔）
+- **可並行**：✅ 可與 T7 並行（不同檔）
+- **前置**：T1–T6 全部完成（測的是完整接線後的行為）
+- **內容**：依 D6 的 T-d、T-e。T-d 遍歷 6 個常數斷言 `entries` 為空 + 使用者 route 照常記錄；T-e 至少覆蓋 `ExportReportSheet.show`（cell details sheet 若需 mock source 成本過高，降級為 route name 靜態驗證並在 commit message 註明）。
+- **驗收**：新檔全綠；**負向驗證**：暫時移除 `export_report_sheet.dart` 的 `routeSettings` 一行，T-e 必須失敗；驗證後還原。
+
+---
+
+### T9｜全套測試 + CHANGELOG
+
+- **複雜度**：`快/便宜`
+- **寫入 scope**：`CHANGELOG.md`
+- **可並行**：❌ 最後一步
+- **前置**：T1–T8
+- **內容**：
+  1. `dart format .` + `dart analyze`（零 issue）
+  2. `flutter test`（全套；依既有慣例，`magical_tap_test` 有 10 分鐘 timeout，跑全套時預留時間）
+  3. CHANGELOG 加一條 bug fix：「Inspector 自身的 detail view / bottom sheet 不再被記錄進宿主 app 的 Navigator 軌跡」。無 API 變更、無使用者遷移動作（規格 §5.4）。
+- **驗收**：全套測試綠、analyze 零 issue、AC-1～AC-5 逐條打勾。
+
+---
+
+## 4. 並行執行建議
+
+**Wave 1（序列）**：T1
+
+**Wave 2（5 路並行，寫入路徑互不重疊）**：
+```
+T2  → lib/src/observers/navigator_observer.dart
+T3  → lib/src/ui/dashboard/dashboard_modal.dart
+T4  → lib/src/ui/dashboard/tabs/console_tab.dart
+T5  → lib/src/ui/dashboard/tabs/network_tab.dart, database_tab.dart
+T6  → lib/src/ui/dashboard/tabs/database/table_rows_view.dart, export_report_sheet.dart
+```
+
+**Wave 3（2 路並行）**：T7、T8
+
+**Wave 4（序列）**：T9
+
+### 執行方式選擇
+
+| 方式 | 適用 | 說明 |
+|---|---|---|
+| **A. Subagent-driven（建議）** | 本計畫 | Wave 2 的 5 個任務全是 `快/便宜` 或單行機械改動，適合一次派 5 個 subagent 並行。Wave 3 派 2 個。總計 3 輪往返。**T2 建議由主 session 親自執行**（`最強推論`，最高風險，不外包）。 |
+| **B. Parallel session** | 不建議 | 檔案數少、單檔改動小，跨 session 的協調成本高於收益。Wave 2 的 5 個任務加起來不超過 15 分鐘。 |
+| **C. 全序列** | 保守選項 | T1→T2→…→T9 依序執行。總時長約 30–40 分鐘（含測試）。若對並行寫入有疑慮，此為安全退路。 |
+
+**推薦：A（T2 由主 session 自行執行，T3–T6 派 4 個 subagent 並行，T7/T8 派 2 個並行）。**
+
+---
+
+## 5. 出口檢查（對照規格 AC）
+
+| AC | 由哪個任務保證 |
+|---|---|
+| AC-1 dashboard 內所有 route 不進 entries | T2（過濾規則）+ T3–T6（接線）+ T8（驗證，含 pop） |
+| AC-2 使用者導航不誤殺（🔴） | T2（`?? false` 保留 null）+ T7（T-a、T-b 守住） |
+| AC-3 單一來源 + debug assert | T1（常數與 helper）+ T3–T6（全數走收斂入口）+ T7（測試端也接常數） |
+| AC-4 既有測試不回歸、不放寬斷言 | T4/T5/T6 各自驗收 + T9 全套。實查確認**零則既有斷言需修改**。 |
+| AC-5 新增污染點被擋下 | T1 的 assert（A 類）+ T8（B 類與整體） |
+
+## 6. 明確不做（Out-of-scope 覆述）
+
+不改 `useRootNavigator`、不改 NavigatorTab UI、不動 `NavigatorStackResolver`、不改 `NavigatorEntry`、不加使用者開關、不清理歷史髒資料、不改公開 API 形狀、不 export `inspector_route_names.dart`。

--- a/lib/src/observers/inspector_route_names.dart
+++ b/lib/src/observers/inspector_route_names.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+// Route names for the inspector's own UI. The observer filters on this
+// prefix so inspector navigation never lands in the host app's Navigator
+// history. Producers (dashboard UI) and the consumer (the observer) must
+// share this one definition — a second copy is how the original bug happened.
+
+/// Prefix every inspector-owned route name starts with.
+///
+/// Deliberately verbose and package-qualified: it must not collide with a
+/// host app's own route names, which are typically path-like (`/home`) or
+/// short identifiers. `startsWith` on this prefix is the whole filter.
+const String kInspectorRoutePrefix = 'flutter_inspector_';
+
+/// The dashboard modal itself.
+///
+/// The value is frozen: it shipped on pub.dev and users may already filter
+/// on this exact string in their own NavigatorObserver.
+const String kInspectorDashboardRoute = 'flutter_inspector_dashboard';
+
+const String kInspectorLogDetailRoute = 'flutter_inspector_log_detail';
+const String kInspectorNetworkDetailRoute = 'flutter_inspector_network_detail';
+const String kInspectorTableRowsRoute = 'flutter_inspector_table_rows';
+const String kInspectorCellDetailsRoute = 'flutter_inspector_cell_details';
+const String kInspectorExportReportRoute = 'flutter_inspector_export_report';
+
+/// Pushes an inspector-owned page route, tagged so the navigator observer
+/// can keep it out of the host app's navigation history.
+///
+/// Every page route opened from inside the dashboard must go through here.
+/// [name] must start with [kInspectorRoutePrefix]; a stray name would
+/// silently become the next pollution source, so it fails loudly in debug.
+void pushInspectorRoute(
+  BuildContext context,
+  String name,
+  WidgetBuilder builder,
+) {
+  assert(
+    name.startsWith(kInspectorRoutePrefix),
+    'Inspector route name "$name" must start with '
+    '"$kInspectorRoutePrefix" or the navigator observer will leak it into '
+    'the host app history.',
+  );
+  Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(
+      settings: RouteSettings(name: name),
+      builder: builder,
+    ),
+  );
+}

--- a/lib/src/observers/inspector_route_names.dart
+++ b/lib/src/observers/inspector_route_names.dart
@@ -18,10 +18,19 @@ const String kInspectorRoutePrefix = 'flutter_inspector_';
 /// on this exact string in their own NavigatorObserver.
 const String kInspectorDashboardRoute = 'flutter_inspector_dashboard';
 
+/// The log detail page, opened from a Console row.
 const String kInspectorLogDetailRoute = 'flutter_inspector_log_detail';
+
+/// The network detail page, opened from either the Console or Network tab.
 const String kInspectorNetworkDetailRoute = 'flutter_inspector_network_detail';
+
+/// The table rows page, opened from a Database tab table.
 const String kInspectorTableRowsRoute = 'flutter_inspector_table_rows';
+
+/// The cell details bottom sheet, opened from a table row.
 const String kInspectorCellDetailsRoute = 'flutter_inspector_cell_details';
+
+/// The diagnostic report export bottom sheet.
 const String kInspectorExportReportRoute = 'flutter_inspector_export_report';
 
 /// Pushes an inspector-owned page route, tagged so the navigator observer

--- a/lib/src/observers/navigator_observer.dart
+++ b/lib/src/observers/navigator_observer.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import '../core/flutter_inspector.dart';
 import '../models/navigator_action.dart';
 import '../models/navigator_entry.dart';
+import 'inspector_route_names.dart';
 
 /// An observer that records navigation events into the inspector.
 ///
@@ -14,8 +15,13 @@ class FlutterInspectorNavigatorObserver extends NavigatorObserver {
 
   final FlutterInspector _inspector;
 
+  /// Whether [route] belongs to the inspector's own UI.
+  ///
+  /// A `null` name means the host app pushed an unnamed route — that must be
+  /// recorded, so null resolves to `false` (not filtered). Dropping unnamed
+  /// routes would lose user data, which is worse than the bug this fixes.
   bool _isInspectorRoute(Route<dynamic> route) =>
-      route.settings.name == 'flutter_inspector_dashboard';
+      route.settings.name?.startsWith(kInspectorRoutePrefix) ?? false;
 
   Type? _resolveWidgetType(Route<dynamic> route) {
     final settings = route.settings;

--- a/lib/src/ui/dashboard/dashboard_modal.dart
+++ b/lib/src/ui/dashboard/dashboard_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/flutter_inspector.dart';
+import '../../observers/inspector_route_names.dart';
 import 'export_report_sheet.dart';
 import 'tabs/console_tab.dart';
 import 'tabs/database_tab.dart';
@@ -29,7 +30,7 @@ class DashboardModal extends StatelessWidget {
   }) {
     showGeneralDialog(
       context: context,
-      routeSettings: const RouteSettings(name: 'flutter_inspector_dashboard'),
+      routeSettings: const RouteSettings(name: kInspectorDashboardRoute),
       pageBuilder: (context, animation, secondaryAnimation) {
         return DashboardModal(inspector: inspector, initialIndex: initialIndex);
       },

--- a/lib/src/ui/dashboard/export_report_sheet.dart
+++ b/lib/src/ui/dashboard/export_report_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../core/flutter_inspector.dart';
 import '../../models/diagnostic_info.dart';
 import '../../models/timestamped_entry.dart';
+import '../../observers/inspector_route_names.dart';
 import '../../utils/diagnostic_report.dart';
 import '../../utils/share_text.dart';
 
@@ -19,6 +20,7 @@ class ExportReportSheet extends StatefulWidget {
     return showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
+      routeSettings: const RouteSettings(name: kInspectorExportReportRoute),
       builder: (_) => ExportReportSheet(inspector: inspector),
     );
   }

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -8,6 +8,7 @@ import '../../../models/navigator_entry.dart';
 import '../../../models/network_entry.dart';
 import '../../../models/timestamped_entry.dart';
 import '../../../extensions/log_level_color_extension.dart';
+import '../../../observers/inspector_route_names.dart';
 import '../../theme/theme.dart';
 import 'console/log_detail_view.dart';
 import 'network/network_detail_view.dart';
@@ -169,8 +170,10 @@ class _LogEntryRow extends StatelessWidget {
           ? const Icon(Icons.chevron_right, size: ThemeSize.size18)
           : null,
       onTap: canTap
-          ? () => Navigator.of(context).push(
-              MaterialPageRoute(builder: (_) => LogDetailView(entry: entry)),
+          ? () => pushInspectorRoute(
+              context,
+              kInspectorLogDetailRoute,
+              (_) => LogDetailView(entry: entry),
             )
           : null,
     );
@@ -193,12 +196,12 @@ class _NetworkEntryRow extends StatelessWidget {
       title: Text('${entry.method} ${entry.statusCode ?? '-'} ${entry.url}'),
       subtitle: Text(entry.displayTime),
       trailing: const Icon(Icons.chevron_right, size: ThemeSize.size18),
-      onTap: () => Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => NetworkDetailView(
-            entry: entry,
-            redactSensitiveData: redactSensitiveData,
-          ),
+      onTap: () => pushInspectorRoute(
+        context,
+        kInspectorNetworkDetailRoute,
+        (_) => NetworkDetailView(
+          entry: entry,
+          redactSensitiveData: redactSensitiveData,
         ),
       ),
     );

--- a/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
+++ b/lib/src/ui/dashboard/tabs/database/table_rows_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../../../../models/database_browser_source.dart';
+import '../../../../observers/inspector_route_names.dart';
 import '../../../../utils/table_sort.dart';
 import '../../../theme/theme.dart';
 import '../../../widgets/error_card.dart';
@@ -117,6 +118,7 @@ class _TableRowsViewState extends State<TableRowsView> {
   void _showCellDetails(Object? cell) {
     showModalBottomSheet(
       context: context,
+      routeSettings: const RouteSettings(name: kInspectorCellDetailsRoute),
       builder: (context) => _CellDetailsBottomSheet(cell: cell),
     );
   }

--- a/lib/src/ui/dashboard/tabs/database_tab.dart
+++ b/lib/src/ui/dashboard/tabs/database_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/flutter_inspector.dart';
 import '../../../models/database_browser_source.dart';
+import '../../../observers/inspector_route_names.dart';
 import '../../../sources/operation_log_source.dart';
 import '../../theme/theme.dart';
 import '../../widgets/error_card.dart';
@@ -177,17 +178,11 @@ class _DatabaseTabBody extends StatelessWidget {
               const Icon(Icons.chevron_right, color: ThemeColor.color9E9E9E),
             ],
           ),
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => TableRowsView(
-                  source: selectedSource,
-                  tableName: table.name,
-                ),
-              ),
-            );
-          },
+          onTap: () => pushInspectorRoute(
+            context,
+            kInspectorTableRowsRoute,
+            (_) => TableRowsView(source: selectedSource, tableName: table.name),
+          ),
         );
       },
     );

--- a/lib/src/ui/dashboard/tabs/network_tab.dart
+++ b/lib/src/ui/dashboard/tabs/network_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/flutter_inspector.dart';
 import '../../../models/network_entry.dart';
+import '../../../observers/inspector_route_names.dart';
 import '../../../utils/network_formatters.dart';
 import '../../../utils/network_utils.dart';
 import '../../theme/theme.dart';
@@ -265,12 +266,12 @@ class _EntryTile extends StatelessWidget {
         style: TextStyle(color: entry.error != null ? statusColor : null),
       ),
       trailing: const Icon(Icons.chevron_right, size: ThemeSize.size18),
-      onTap: () => Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => NetworkDetailView(
-            entry: entry,
-            redactSensitiveData: redactSensitiveData,
-          ),
+      onTap: () => pushInspectorRoute(
+        context,
+        kInspectorNetworkDetailRoute,
+        (_) => NetworkDetailView(
+          entry: entry,
+          redactSensitiveData: redactSensitiveData,
         ),
       ),
     );

--- a/test/observers/inspector_route_filter_test.dart
+++ b/test/observers/inspector_route_filter_test.dart
@@ -1,54 +1,148 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/database_browser_source.dart';
-import 'package:flutter_inspector_kit/src/observers/inspector_route_names.dart';
+import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/models/network_entry.dart';
 import 'package:flutter_inspector_kit/src/ui/dashboard/export_report_sheet.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/console_tab.dart';
 import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/database/table_rows_view.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/database_tab.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/network_tab.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// Drives the real dashboard entry points rather than hand-built routes.
+///
+/// Asserting on route names we construct ourselves would only prove the
+/// observer filters those strings — it would still pass if a call site dropped
+/// `pushInspectorRoute` or its `routeSettings`, which is exactly the regression
+/// this file exists to catch.
 void main() {
-  group('inspector route filter (end-to-end)', () {
-    testWidgets('no inspector-owned route reaches the entries buffer', (
-      tester,
+  group('inspector route filter (real dashboard entry points)', () {
+    /// Pumps [child] under an app whose Navigator is observed by [inspector],
+    /// then drops the entry recorded for the initial route so each test starts
+    /// from an empty buffer.
+    Future<void> pumpObserved(
+      WidgetTester tester,
+      FlutterInspector inspector,
+      Widget child,
     ) async {
-      final inspector = FlutterInspector();
       await tester.pumpWidget(
         MaterialApp(
           navigatorObservers: [inspector.navigatorObserver],
-          home: const SizedBox(),
+          home: Scaffold(body: child),
         ),
       );
+      await tester.pumpAndSettle();
+      inspector.clearNavigator();
+    }
+
+    testWidgets('ConsoleTab log row does not record navigation', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      inspector.log('boom', level: LogLevel.error, stackTrace: '#0 main');
+      await pumpObserved(tester, inspector, ConsoleTab(inspector: inspector));
+
+      await tester.tap(find.text('boom'));
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+    });
+
+    testWidgets('ConsoleTab network row does not record navigation', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      inspector.logNetwork(
+        NetworkEntry(method: 'GET', url: 'https://x.test/a', statusCode: 200),
+      );
+      await pumpObserved(tester, inspector, ConsoleTab(inspector: inspector));
+
+      await tester.tap(find.textContaining('https://x.test/a'));
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+    });
+
+    testWidgets('NetworkTab row does not record navigation', (tester) async {
+      final inspector = FlutterInspector();
+      inspector.logNetwork(
+        NetworkEntry(method: 'GET', url: 'https://x.test/b', statusCode: 200),
+      );
+      await pumpObserved(tester, inspector, NetworkTab(inspector: inspector));
+
+      await tester.tap(find.textContaining('https://x.test/b'));
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+    });
+
+    testWidgets('DatabaseTab table row does not record navigation', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      inspector.database(DatabaseOperation.insert, 'users');
+      await pumpObserved(tester, inspector, DatabaseTab(inspector: inspector));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('users'));
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+    });
+
+    testWidgets('TableRowsView cell details sheet does not record navigation', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      await pumpObserved(
+        tester,
+        inspector,
+        TableRowsView(source: _FakeDatabaseBrowserSource(), tableName: 'users'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('hello'));
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+    });
+
+    testWidgets('ExportReportSheet does not record navigation', (tester) async {
+      final inspector = FlutterInspector();
+      await pumpObserved(
+        tester,
+        inspector,
+        Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => ExportReportSheet.show(context, inspector),
+            child: const Text('open'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries, isEmpty);
+    });
+
+    testWidgets('host app navigation is still recorded', (tester) async {
+      final inspector = FlutterInspector();
+      await pumpObserved(tester, inspector, const SizedBox());
       final navigator = tester.state<NavigatorState>(find.byType(Navigator));
 
-      const names = [
-        kInspectorDashboardRoute,
-        kInspectorLogDetailRoute,
-        kInspectorNetworkDetailRoute,
-        kInspectorTableRowsRoute,
-        kInspectorCellDetailsRoute,
-        kInspectorExportReportRoute,
-      ];
-
-      for (final name in names) {
-        navigator.push(
-          MaterialPageRoute<void>(
-            settings: RouteSettings(name: name),
-            builder: (_) => const SizedBox(),
-          ),
-        );
-        await tester.pumpAndSettle();
-        navigator.pop();
-        await tester.pumpAndSettle();
-      }
-
-      // MaterialApp's `home` becomes an initial route named '/' (a host
-      // route, not an inspector one) and is recorded — AC-2 says only
-      // inspector-owned routes get filtered. So the buffer holds exactly
-      // that one entry, none of the inspector routes pushed above.
-      expect(inspector.navigatorInspector.entries.length, 1);
-      expect(inspector.navigatorInspector.entries.first.routeName, '/');
-
-      // The same observer still records the host app's own navigation.
       navigator.push(
         MaterialPageRoute<void>(
           settings: const RouteSettings(name: '/user-page'),
@@ -56,64 +150,16 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      expect(inspector.navigatorInspector.entries.length, 2);
-      expect(
-        inspector.navigatorInspector.entries.first.routeName,
-        '/user-page',
-      );
-    });
 
-    testWidgets('ExportReportSheet.show does not pollute the entries buffer', (
-      tester,
-    ) async {
-      final inspector = FlutterInspector();
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorObservers: [inspector.navigatorObserver],
-          home: Builder(
-            builder: (context) => ElevatedButton(
-              onPressed: () => ExportReportSheet.show(context, inspector),
-              child: const Text('open'),
-            ),
-          ),
-        ),
-      );
-
-      // Drop the '/' initial-route entry: only the sheet's own push (or
-      // lack thereof) is under test here.
-      inspector.clearNavigator();
-
-      await tester.tap(find.text('open'));
+      // Unnamed host route — must never be dropped (name == null).
+      navigator.push(MaterialPageRoute<void>(builder: (_) => const SizedBox()));
       await tester.pumpAndSettle();
 
-      expect(inspector.navigatorInspector.entries, isEmpty);
+      final names = inspector.navigatorInspector.entries
+          .map((e) => e.routeName)
+          .toList();
+      expect(names, containsAll(<String?>['/user-page', null]));
     });
-
-    testWidgets(
-      'TableRowsView cell details sheet does not pollute the entries buffer',
-      (tester) async {
-        final inspector = FlutterInspector();
-        await tester.pumpWidget(
-          MaterialApp(
-            navigatorObservers: [inspector.navigatorObserver],
-            home: TableRowsView(
-              source: _FakeDatabaseBrowserSource(),
-              tableName: 'users',
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        // Drop the '/' initial-route entry: only the cell-details sheet's
-        // own push (or lack thereof) is under test here.
-        inspector.clearNavigator();
-
-        await tester.tap(find.text('hello'));
-        await tester.pumpAndSettle();
-
-        expect(inspector.navigatorInspector.entries, isEmpty);
-      },
-    );
   });
 }
 

--- a/test/observers/inspector_route_filter_test.dart
+++ b/test/observers/inspector_route_filter_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/database_browser_source.dart';
+import 'package:flutter_inspector_kit/src/observers/inspector_route_names.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/export_report_sheet.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/database/table_rows_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('inspector route filter (end-to-end)', () {
+    testWidgets('no inspector-owned route reaches the entries buffer', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: [inspector.navigatorObserver],
+          home: const SizedBox(),
+        ),
+      );
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+
+      const names = [
+        kInspectorDashboardRoute,
+        kInspectorLogDetailRoute,
+        kInspectorNetworkDetailRoute,
+        kInspectorTableRowsRoute,
+        kInspectorCellDetailsRoute,
+        kInspectorExportReportRoute,
+      ];
+
+      for (final name in names) {
+        navigator.push(
+          MaterialPageRoute<void>(
+            settings: RouteSettings(name: name),
+            builder: (_) => const SizedBox(),
+          ),
+        );
+        await tester.pumpAndSettle();
+        navigator.pop();
+        await tester.pumpAndSettle();
+      }
+
+      // MaterialApp's `home` becomes an initial route named '/' (a host
+      // route, not an inspector one) and is recorded — AC-2 says only
+      // inspector-owned routes get filtered. So the buffer holds exactly
+      // that one entry, none of the inspector routes pushed above.
+      expect(inspector.navigatorInspector.entries.length, 1);
+      expect(inspector.navigatorInspector.entries.first.routeName, '/');
+
+      // The same observer still records the host app's own navigation.
+      navigator.push(
+        MaterialPageRoute<void>(
+          settings: const RouteSettings(name: '/user-page'),
+          builder: (_) => const SizedBox(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(inspector.navigatorInspector.entries.length, 2);
+      expect(
+        inspector.navigatorInspector.entries.first.routeName,
+        '/user-page',
+      );
+    });
+
+    testWidgets('ExportReportSheet.show does not pollute the entries buffer', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: [inspector.navigatorObserver],
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => ExportReportSheet.show(context, inspector),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+
+      // Drop the '/' initial-route entry: only the sheet's own push (or
+      // lack thereof) is under test here.
+      inspector.clearNavigator();
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(inspector.navigatorInspector.entries, isEmpty);
+    });
+
+    testWidgets(
+      'TableRowsView cell details sheet does not pollute the entries buffer',
+      (tester) async {
+        final inspector = FlutterInspector();
+        await tester.pumpWidget(
+          MaterialApp(
+            navigatorObservers: [inspector.navigatorObserver],
+            home: TableRowsView(
+              source: _FakeDatabaseBrowserSource(),
+              tableName: 'users',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Drop the '/' initial-route entry: only the cell-details sheet's
+        // own push (or lack thereof) is under test here.
+        inspector.clearNavigator();
+
+        await tester.tap(find.text('hello'));
+        await tester.pumpAndSettle();
+
+        expect(inspector.navigatorInspector.entries, isEmpty);
+      },
+    );
+  });
+}
+
+class _FakeDatabaseBrowserSource implements DatabaseBrowserSource {
+  @override
+  String get name => 'fake';
+
+  @override
+  Future<List<DatabaseTableInfo>> listTables() async => [
+    const DatabaseTableInfo(name: 'users', rowCount: 1),
+  ];
+
+  @override
+  Future<DatabaseTablePage> fetchRows(
+    String tableName, {
+    int limit = 200,
+    int offset = 0,
+  }) async {
+    return const DatabaseTablePage(
+      columns: ['name'],
+      rows: [
+        ['hello'],
+      ],
+      totalRows: 1,
+    );
+  }
+}

--- a/test/observers/navigator_observer_test.dart
+++ b/test/observers/navigator_observer_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
+import 'package:flutter_inspector_kit/src/observers/inspector_route_names.dart';
 import 'package:flutter_inspector_kit/src/observers/navigator_observer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -80,33 +81,52 @@ void main() {
       expect(entry.widgetType, _SamplePage);
     });
 
-    testWidgets(
-      'resolves widgetType from builder',
-      (tester) async {
-        // A real Navigator is required so the observer has a navigator context
-        // from which to run the route builder.
-        await tester.pumpWidget(
-          MaterialApp(
-            navigatorObservers: [observer],
-            home: const SizedBox(),
-          ),
-        );
+    testWidgets('resolves widgetType from builder', (tester) async {
+      // A real Navigator is required so the observer has a navigator context
+      // from which to run the route builder.
+      await tester.pumpWidget(
+        MaterialApp(navigatorObservers: [observer], home: const SizedBox()),
+      );
 
-        final navigator = tester.state<NavigatorState>(find.byType(Navigator));
-        navigator.push(
-          MaterialPageRoute<void>(builder: (_) => const _SamplePage()),
-        );
-        await tester.pumpAndSettle();
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.push(
+        MaterialPageRoute<void>(builder: (_) => const _SamplePage()),
+      );
+      await tester.pumpAndSettle();
 
-        final pushEntry = inspector.navigatorInspector.entries
-            .firstWhere((e) => e.action == NavigatorAction.push);
-        expect(pushEntry.widgetType, _SamplePage);
+      final pushEntry = inspector.navigatorInspector.entries.firstWhere(
+        (e) => e.action == NavigatorAction.push,
+      );
+      expect(pushEntry.widgetType, _SamplePage);
+    });
+
+    test(
+      'records an unnamed user route (name == null must not be dropped)',
+      () {
+        final route = MaterialPageRoute<void>(builder: (_) => const SizedBox());
+        observer.didPush(route, null);
+
+        expect(inspector.navigatorInspector.entries.length, 1);
+        expect(inspector.navigatorInspector.entries.first.routeName, isNull);
       },
     );
 
+    test('records user routes whose names merely resemble the prefix', () {
+      for (final name in ['/flutter', '/inspector', '/home', 'flutter_x']) {
+        observer.didPush(
+          MaterialPageRoute<void>(
+            settings: RouteSettings(name: name),
+            builder: (_) => const SizedBox(),
+          ),
+          null,
+        );
+      }
+      expect(inspector.navigatorInspector.entries.length, 4);
+    });
+
     test('ignores inspector dashboard route', () {
       final route = MaterialPageRoute(
-        settings: const RouteSettings(name: 'flutter_inspector_dashboard'),
+        settings: const RouteSettings(name: kInspectorDashboardRoute),
         builder: (_) => const SizedBox(),
       );
 


### PR DESCRIPTION
## Summary

修復 issue #104：inspector dashboard 內部推送的 detail view 與 bottom sheet，被誤記進**使用者 app 的** Navigator 軌跡。

污染量與排查強度成正比——越是深入追查（反覆開關 detail view、逐筆點進 network entry），NavigatorTab 被灌進越多雜訊，**正好在最需要乾淨導航軌跡時最髒**。最諷刺的一處是 `ExportReportSheet`：開啟匯出面板的動作，會把自己寫進即將被匯出的報告裡。

實測證據（probe test）：

```
ENTRIES: [NavigatorAction.push/NetworkDetailView, NavigatorAction.push/SizedBox]
```

Closes #104

## 修正問題

**根因鏈（三段）**

1. `dashboard_modal.dart` 的 `showGeneralDialog` 未指定 `useRootNavigator`（Flutter 預設 `true`）→ dashboard 掛在宿主 app 的 root Navigator，正是掛載 observer 的那一個
2. dashboard 內的 detail view 以 `Navigator.of(context).push(...)` 推送，context 來自 dashboard 子樹 → 落在同一個被觀察的 Navigator
3. `_isInspectorRoute()` 只比對 `name == 'flutter_inspector_dashboard'`，而這些 detail view 的 route **完全沒帶 `RouteSettings.name`** → 過濾器一律放行，四個覆寫的 early return 全部失效

**動工時的實查修正**：brainstorm 文件記錄 4 處污染點，**實際 grep 到 7 處**——`export_report_sheet.dart` 是文件完全未列到的。這個落差本身就是「逐處補 name」方案失敗的實證：沒人記得 bottom sheet 也是 route。

## 修正方式

**採方案 B（收斂單一命名來源），非方案 A（逐處補 `RouteSettings(name:)`）**

方案 A 是治標——新增任何 detail view 都必須記得補 name，漏一個就再破一次，把正確性寄託在人的記憶上。方案 B 把 7 個散落的判斷點收斂成 1 個。

| 類別 | 處數 | 作法 |
|:-:|:-:|------|
| A | 4 | `MaterialPageRoute` → 走 `pushInspectorRoute` helper（內含 `assert` 前綴檢查） |
| B | 2 | `showModalBottomSheet` → 各加一行 `routeSettings:` |
| C | 1 | `showGeneralDialog` → 字面值收斂為常數（**值不變**） |

**B 類刻意不包 wrapper**：兩處的 `showModalBottomSheet` 參數已經不同（只有一處有 `isScrollControlled`），wrapper 得決定透傳哪十餘個參數，比多寫一行 `routeSettings:` 差。「單一來源」的實質是共用同一份常數，不是同一個函式——強行統一是為統一而統一。

**核心改動只有一行**：

```dart
route.settings.name?.startsWith(kInspectorRoutePrefix) ?? false
```

`name == null` 走 `?? false` = **不排除** = 照常記錄。這是整個修復最關鍵的取捨：使用者 app 用 `MaterialPageRoute(builder: ...)` 未設 name 是常見寫法，若被誤殺就是**資料遺失，比原 bug 更嚴重**。

**前綴值不是自由選擇**：`'flutter_inspector_dashboard'` 已發布至 pub.dev，使用者可能已硬編此字串過濾，其值被凍結，故前綴必須是它的真前綴。

## 破壞性

無公開 API 變更、無使用者遷移動作。

- `FlutterInspectorNavigatorObserver` 未直接 export（僅經 `navigatorObserver` getter 型別可達），`_isInspectorRoute` 是私有方法
- 四個 `did*` 覆寫簽章零改動
- `kInspectorDashboardRoute` 的**值**維持 `'flutter_inspector_dashboard'` 不變
- `inspector_route_names.dart` 保持內部檔案，未加入 export
- 使用者自掛的 observer 現在會收到帶前綴的名稱而非 `null`——這是嚴格的資訊增益（原本無從分辨，現在可自行過濾）

**不做**：不改 `useRootNavigator`（改變掛載拓撲的風險遠大於修復本身，且不需要）、不改 NavigatorTab UI、不動 `NavigatorStackResolver`、不清理歷史已污染的 entries（舊 entry 的 `routeName` 是 `null`，事後無從分辨是 inspector 的還是使用者自己沒設 name 的，硬猜就會誤刪使用者資料）。

## 驗證

- **全套 430 則測試通過**，`dart analyze` 無新增問題（2 個既有 Radio deprecation info 與本次無關）
- **零既有斷言被修改或放寬**——唯一既有測試改動是字面值 → 常數替換，值不變
- 新增 `test/observers/inspector_route_filter_test.dart`：3 支端到端測試，7 處污染點**全部有真實 widget tree 覆蓋**，無一降級為靜態驗證
- 補上既有測試的裸露缺口：原有 8 則測試全用具名路由，**沒有一則驗證「無名稱 route 仍被記錄」**——負向驗證時發現既有的 `resolves widgetType from builder` 一直隱性依賴這個未被斷言的行為

**負向驗證（實作與審查各獨立跑一次）**

| 破壞方式 | 結果 |
|------|:-:|
| `?? false` → `?? true` | 3 tests failed ✅ |
| 移除 cell details 的 `routeSettings` | 1 test failed，訊息精準指向 ✅ |

審查階段另以獨立探針實測 `didReplace` / `didRemove`（邏輯與其他兩個覆寫不同）與無名稱 host route 的 push+pop，並自行 grep 確認 `lib/` 內無 `showDialog` / `pushReplacement` / `pushAndRemoveUntil` 等其他形式的漏網推送點。

---

📄 規格：`docs/features/2026-07-26-inspector-route-pollution.md`
📄 計畫：`docs/plans/2026-07-26-inspector-route-pollution.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent inspector UI routes from being recorded in the host app’s navigator history by centralizing route naming and filtering, while preserving user app navigation, including unnamed routes.

Bug Fixes:
- Stop dashboard detail views and bottom sheets (logs, network, database rows, cell details, export sheet) from polluting the host app’s Navigator entries by tagging inspector routes with a shared prefix and filtering them out in the observer.

Enhancements:
- Introduce a shared set of inspector route name constants and a helper for pushing inspector-owned page routes to ensure consistent naming and avoid future route pollution issues.

Documentation:
- Add feature and implementation plan documents describing the inspector route pollution bug, its root causes, and the chosen fix and testing strategy.

Tests:
- Extend navigator observer tests to verify unnamed and prefix-similar user routes are still recorded, and add end-to-end tests to ensure inspector routes and sheets no longer appear in the entries buffer.
- Add tests covering ExportReportSheet and TableRowsView cell details to confirm their bottom sheets don’t write into navigator history.

Chores:
- Update the changelog to document the inspector route pollution fix and its non-breaking nature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增可选的 App 生命周期标记：在 Console 记录 `resumed/inactive/paused/detached`（新版本还包含 `hidden`），并附带当前最顶层页面信息；默认禁用，`detach()` 后停止观察。
- **问题修复**
  - 修复 Inspector Dashboard 的详情页、底部弹窗与导出面板路由误计入宿主应用导航记录；宿主应用导航行为不受影响，未命名的用户路由仍会正常记录。
- **测试**
  - 补强导航过滤回归测试，覆盖日志/网络/数据库/单元格详情/导出面板等场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->