### PR TITLE
chore(release): bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-## Unreleased
-
-### Fixed
-* **Inspector routes no longer pollute the Navigator tab**: opening a detail view or bottom sheet inside the dashboard (log/network details, table rows, cell details, the export sheet) was recorded as navigation in the *host app's* history, so the more thoroughly you investigated, the noisier the Navigator tab became — the export sheet even wrote itself into the report it was about to produce. Every route the dashboard opens is now tagged with a shared prefix that the observer filters on. Host app navigation is untouched, including unnamed routes.
+## 1.8.0
 
 ### Added
 * **App lifecycle markers**: `FlutterInspector(captureLifecycleEvents: true)` records every app lifecycle transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) as an `info` Console log, so crashes and stalled network calls can be read against whether the app was in the foreground. Each entry names the current top-most page (e.g. `App lifecycle: resumed · HomePage (/home)`) so repeated home/back switches stay distinguishable without cross-referencing the Navigator tab. Opt-in and disabled by default; `detach()` removes the observer.
+
+### Changed
+* **Error rows are tinted in the merged Timeline**: error-level logs and failed network calls now carry a faint red row background in the Console tab, so they're spottable while scrolling instead of relying on text colour alone. Warnings keep their orange text but stay un-tinted, so a warning-heavy app doesn't wash the whole list out.
+
+### Fixed
+* **Inspector routes no longer pollute the Navigator tab**: opening a detail view or bottom sheet inside the dashboard (log/network details, table rows, cell details, the export sheet) was recorded as navigation in the *host app's* history, so the more thoroughly you investigated, the noisier the Navigator tab became — the export sheet even wrote itself into the report it was about to produce. Every route the dashboard opens is now tagged with a shared prefix that the observer filters on. Host app navigation is untouched, including unnamed routes.
 
 ## 1.7.1
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 | Feature | Description | Use Case Example |
 |---|---|---|
 | 🪵 **Console** | Capture logs across five severity levels (`verbose` / `debug` / `info` / `warning` / `error`), with optional structured data and stack traces | QA says "tapping checkout does nothing" — open Console, spot a red error entry in the timeline; tap in to see the structured error detail, response body, and full stack trace to understand what went wrong |
-| 🧵 **Merged Timeline** | Console tab interleaves logs, network, navigation, and database events on one timestamp-sorted timeline, with per-source filter chips | Continuing the checkout case — switch the source chip to "All" and scroll back along the timeline to inspect the request that got 401: check what token was in the `Authorization` header, what params were sent, and compare with backend expectations to pinpoint why the server rejected it — all without switching tabs or manually comparing timestamps |
+| 🧵 **Merged Timeline** | Console tab interleaves logs, network, navigation, and database events on one timestamp-sorted timeline, with per-source filter chips; error logs and failed network calls carry a faint red row tint so they stand out while scrolling | Continuing the checkout case — switch the source chip to "All" and scroll back along the timeline to inspect the request that got 401: check what token was in the `Authorization` header, what params were sent, and compare with backend expectations to pinpoint why the server rejected it — all without switching tabs or manually comparing timestamps |
 | 📡 **Network** | Intercept HTTP traffic via Dio; inspect structured request/response details; search/filter by URL, method, or status; share as cURL | A page shows up completely blank — open the Network tab to find the API returned an error, so there's no data to display; tap in to inspect request params and response body, then copy as a runnable cURL command and paste it into a bug ticket for the backend team to reproduce |
 | 🔄 **Network Replay** | Resend a captured request using the original Dio instance (same headers, base URL, interceptors); replayed entries are auto-labeled | Re-trigger a failed API call on-device to verify a server-side hotfix without restarting the app or rebuilding the user flow |
 | 🚨 **Structured Network Errors** | Failed requests show an **Exception Details** section distinguishing transport-layer failures (device offline / DNS / timeout) from server-side errors (4xx/5xx), with copyable stack traces | Instantly tell whether "Failed" means the device lost connectivity or the server returned 500 — no more guessing during QA |
@@ -20,9 +20,10 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 | 🩺 **Diagnostic Report** | Export a single Markdown report — device/app header, current route stack, and the logs / network / navigation / database sections — filtered by time window (5m / 1h / all), source, and an optional errors-only toggle; straight to the share sheet, nothing written to disk | QA reproduces a bug and, instead of screenshotting four tabs and hand-typing the OS version, taps Export once and pastes a complete report into the Jira ticket |
 | 🌐 **WebView Inline Debugging** | Bridge a WebView's own `console.*`, `window.onerror`/`unhandledrejection`, and `fetch`/`XMLHttpRequest` activity into the same Console and Network tabs used for native logs and Dio traffic — dependency-free, wire your own `webview_flutter` or `flutter_inappwebview` to `WebViewBridgeAdapter` | A hybrid screen misbehaves and you can't tell if the bug is in Flutter or the embedded web page — see the WebView's JS errors and its `fetch`/`XHR` calls inline in Console/Network, tagged by origin, so you know instantly which side to fix without attaching Chrome DevTools to the WebView |
 | 🛡️ **Sensitive-Data Redaction** | Secure by default — sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`) are masked in every share/export path | Safely share network logs with teammates or attach them to Jira tickets without leaking tokens or session cookies |
-| 🧭 **Navigator** | Track route pushes, pops, and replacements automatically; toggle between **Event History** (raw log) and **Active Stack** (live route-stack visualization) | Verify deep-link routing, confirm back-stack correctness, or diagnose "why did the user land on this screen?" during a QA walkthrough |
+| 🧭 **Navigator** | Track route pushes, pops, and replacements automatically; toggle between **Event History** (raw log) and **Active Stack** (live route-stack visualization). The dashboard's own routes are filtered out, so investigating never pollutes the history | Verify deep-link routing, confirm back-stack correctness, or diagnose "why did the user land on this screen?" during a QA walkthrough — and since opening detail views doesn't write into the history, the stack you read after ten minutes of digging is still your app's, not a log of your own investigation |
 | 🗄️ **Database** | Record insert / update / delete / query operations with affected-row counts and payloads; browse real tables via pluggable `DatabaseBrowserSource` (SQLite / ObjectBox adapters provided) | Verify that a "Save" action actually wrote the expected rows; browse local SQLite tables on-device without pulling the `.db` file |
 | 🛑 **Uncaught Error Capture** *(opt-in)* | Automatically turn uncaught errors into `error`-level Console logs via three Flutter hooks (build/layout/paint, async, `ErrorWidget`); chains existing handlers — never swallows errors | An unawaited `Future` throws deep inside a third-party package — no `try/catch` anywhere near it. Uncaught error capture logs it automatically with a full stack trace, so it shows up in Console without any manual instrumentation |
+| ⏱️ **App Lifecycle Markers** *(opt-in)* | Record every `resumed` / `inactive` / `paused` / `detached` transition as an `info` Console log, each naming the top-most page at that moment, interleaved into the merged Timeline | A batch of requests fails with timeouts that nobody can reproduce at a desk — read the Timeline and an `App lifecycle: paused · CheckoutPage` marker sits right before them, so the OS froze the network while the user switched away; the backend was never at fault. Equally useful in reverse: confirming a "refresh on resume" actually fires, and on which page |
 | 🔔 **Live Notification** *(opt-in)* | A system notification summarising the latest API call and the running total; tap to jump straight to the Network tab | Monitor API traffic in real-time while navigating the app — no need to keep the dashboard open; also useful for verifying whether the number of API calls per operation is reasonable (e.g., a single page load triggering dozens of calls hints at redundant requests) |
 | 👆 **Magical Tap & Floating Button** | Open the dashboard with a hidden multi-tap gesture or a draggable in-app FAB | Embed in a release build as a hidden diagnostic entry point — when QA or users hit an issue, trigger the inspector on the spot for initial error triage without rebuilding a debug version or tracing through source code |
 | 🧩 **Custom Tab** | Inject your own widget as a 5th dashboard tab via `FlutterInspector(customTab: ..., customTabTitle: ...)` — sits alongside Console / Network / Navigator / Database | Surface app-specific debug tooling right next to the built-in inspectors — a feature-flag toggle panel, the current auth/session state, or a "clear cache" button — so your team's ad-hoc diagnostics live in one place instead of a separate debug screen |
@@ -47,7 +48,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.7.1
+  flutter_inspector_kit: ^1.8.0
 ```
 
 Then run `flutter pub get`.
@@ -369,7 +370,7 @@ Available levels: `verbose`, `debug`, `info`, `warning`, `error`.
 
 ### Read the merged timeline
 
-The **Console** tab already interleaves logs, network, navigation, and database events on a single timeline (newest first), with a filter chip per source. You can also read that same merged view programmatically:
+The **Console** tab already interleaves logs, network, navigation, and database events on a single timeline (newest first), with a filter chip per source. Error-level logs and failed network calls are given a faint red row background so they're spottable while scrolling a long timeline — warnings keep their orange text but stay un-tinted, so a warning-heavy app doesn't wash the whole list out. You can also read that same merged view programmatically:
 
 ```dart
 // All sources, newest first.
@@ -433,6 +434,8 @@ The Navigator tab offers two views, toggled via chips at the top:
 
 - **Event History**: the raw log of push/pop/replace/remove events (the original behavior).
 - **Active Stack**: the current route stack, derived live from the event history and rendered top-first as vertical cards — the topmost card (the current screen) is highlighted. Shows "Empty stack history" when no routes have been recorded yet.
+
+The dashboard's own routes — log/network detail views, table and cell details, the export sheet — are excluded from this history, so investigating a bug never shows up as navigation in your app's route stack. Your app's routes are recorded exactly as before, including unnamed ones.
 
 ### Track database operations
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,7 +12,7 @@
 | 功能 | 說明 | 使用情境範例 |
 |---|---|---|
 | 🪵 **Console** | 擷取五種嚴重程度（`verbose` / `debug` / `info` / `warning` / `error`）的 log，可選帶結構化資料與 stack trace | QA 回報「點結帳沒反應」——打開 Console，在時間軸上一眼看到紅色錯誤項目；點進去查看結構化錯誤細節、response body 與完整 stack trace，理解到底哪裡出錯 |
-| 🧵 **Merged Timeline** | Console 分頁把 logs、network、navigation 與 database 事件交錯排在同一條依時間戳排序的時間軸上，並提供各來源的 filter chip | 延續結帳案例——把來源 chip 切到「All」，沿時間軸往回捲，檢視那個拿到 401 的請求：看 `Authorization` header 帶了什麼 token、送了哪些參數，和後端預期比對，精準定位伺服器為何拒絕——全程不用切分頁或手動比對時間戳 |
+| 🧵 **Merged Timeline** | Console 分頁把 logs、network、navigation 與 database 事件交錯排在同一條依時間戳排序的時間軸上，並提供各來源的 filter chip；error 等級的 log 與失敗的 network 呼叫會帶淡紅底色，捲動長時間軸時一眼就能認出 | 延續結帳案例——把來源 chip 切到「All」，沿時間軸往回捲，檢視那個拿到 401 的請求：看 `Authorization` header 帶了什麼 token、送了哪些參數，和後端預期比對，精準定位伺服器為何拒絕——全程不用切分頁或手動比對時間戳 |
 | 📡 **Network** | 透過 Dio 攔截 HTTP 流量；檢視結構化的 request/response 細節；依 URL、method 或 status 搜尋／篩選；以 cURL 分享 | 某個頁面整片空白——打開 Network 分頁發現 API 回了錯誤，所以根本沒資料可顯示；點進去檢視 request 參數與 response body，再複製成可直接執行的 cURL 指令，貼進 bug ticket 讓後端團隊重現 |
 | 🔄 **Network Replay** | 用原始的 Dio 實例重送一個已擷取的請求（沿用相同 headers、base URL、interceptors）；重送的項目會自動標記 | 在裝置上重觸一個失敗的 API 呼叫，驗證伺服器端的 hotfix，不必重啟 App 或重走一遍使用者流程 |
 | 🚨 **Structured Network Errors** | 失敗的請求會顯示 **Exception Details** 區塊，區分傳輸層失敗（裝置離線／DNS／逾時）與伺服器端錯誤（4xx/5xx），並附可複製的 stack trace | 立刻分辨「Failed」到底是裝置斷線還是伺服器回了 500——QA 期間不必再靠猜 |
@@ -20,9 +20,10 @@
 | 🩺 **Diagnostic Report** | 匯出單一份 Markdown 報告——裝置／App 標頭、當前 route stack，以及 logs / network / navigation / database 各區段——可依時間窗（5m / 1h / all）、來源與可選的僅錯誤開關篩選；直接送進分享面板，不寫入磁碟 | QA 重現 bug 後，不用截四個分頁的圖再手打 OS 版本，按一次 Export 就把完整報告貼進 Jira ticket |
 | 🌐 **WebView Inline Debugging** | 把 WebView 自身的 `console.*`、`window.onerror`/`unhandledrejection` 與 `fetch`/`XMLHttpRequest` 活動橋接進與原生 log、Dio 流量共用的同一個 Console 與 Network 分頁——零相依，自行把你的 `webview_flutter` 或 `flutter_inappwebview` 接到 `WebViewBridgeAdapter` | 混合式頁面出狀況，你分不清 bug 在 Flutter 還是內嵌網頁——直接在 Console/Network 內看到 WebView 的 JS 錯誤與 `fetch`/`XHR` 呼叫，並依 origin 標記，立刻知道該修哪一側，不必把 Chrome DevTools 掛到 WebView 上 |
 | 🛡️ **Sensitive-Data Redaction** | 預設即安全——敏感 headers（`Authorization`、`Cookie`、`Set-Cookie`、`X-Api-Key`）在每一條分享／匯出路徑上都會被遮罩 | 放心把 network log 分享給隊友或附進 Jira ticket，不會外洩 token 或 session cookie |
-| 🧭 **Navigator** | 自動追蹤 route 的 push、pop 與 replace；可在 **Event History**（原始 log）與 **Active Stack**（即時 route-stack 視覺化）之間切換 | 驗證 deep-link 路由、確認 back-stack 正確性，或在 QA 走查時診斷「使用者為什麼會落到這個畫面？」 |
+| 🧭 **Navigator** | 自動追蹤 route 的 push、pop 與 replace；可在 **Event History**（原始 log）與 **Active Stack**（即時 route-stack 視覺化）之間切換。dashboard 自身的 route 會被濾掉，查 bug 不會反過來污染這份歷史 | 驗證 deep-link 路由、確認 back-stack 正確性，或在 QA 走查時診斷「使用者為什麼會落到這個畫面？」——而且因為點開詳情頁不會寫進歷史，翻查十分鐘後看到的 stack 仍然是你 App 的，不是你自己查問題的軌跡 |
 | 🗄️ **Database** | 記錄 insert / update / delete / query 操作，含受影響筆數與 payload；透過可插拔的 `DatabaseBrowserSource` 瀏覽真實資料表（已提供 SQLite / ObjectBox adapter） | 驗證「儲存」動作是否真的寫進預期的資料列；在裝置上直接瀏覽本地 SQLite 資料表，不必把 `.db` 檔拉出來 |
 | 🛑 **Uncaught Error Capture** *(需 opt-in)* | 透過三個 Flutter hook（build/layout/paint、async、`ErrorWidget`）自動把未捕捉的錯誤轉成 `error` 等級的 Console log；串接既有 handler——絕不吞錯 | 某個未 await 的 `Future` 在第三方套件深處拋錯——附近完全沒有 `try/catch`。Uncaught error capture 自動連同完整 stack trace 記錄下來，不用任何手動埋點就出現在 Console |
+| ⏱️ **App Lifecycle Markers** *(需 opt-in)* | 把每一次 `resumed` / `inactive` / `paused` / `detached` 轉換記錄成 `info` 等級的 Console log，各自標註當下最上層的頁面，並交錯進合併時間軸 | 一批請求以 timeout 失敗，在辦公桌前卻怎麼都重現不了——翻時間軸，`App lifecycle: paused · CheckoutPage` 這筆就卡在它們前面，代表使用者切走了、OS 把網路凍結，根本不是後端的問題。反過來也好用：確認「回到前景就刷新」真的有觸發，而且是在哪一頁觸發 |
 | 🔔 **Live Notification** *(需 opt-in)* | 一則系統通知摘要最新一筆 API 呼叫與累計總數；點一下直接跳到 Network 分頁 | 在 App 內導覽時即時監看 API 流量——不必一直開著 dashboard；也適合驗證每個操作的 API 呼叫數是否合理（例如單一頁面載入就觸發數十筆呼叫，暗示有重複請求） |
 | 👆 **Magical Tap & Floating Button** | 用隱藏的多次點擊手勢，或可拖曳的 App 內 FAB 打開 dashboard | 內嵌進 release build 作為隱藏的診斷入口——當 QA 或使用者遇到問題，當場觸發 inspector 做初步錯誤分流，不必重建 debug 版或翻原始碼 |
 | 🧩 **Custom Tab** | 透過 `FlutterInspector(customTab: ..., customTabTitle: ...)` 注入你自己的 widget 作為第 5 個 dashboard 分頁——與 Console / Network / Navigator / Database 並列 | 把 App 專屬的偵錯工具擺在內建 inspector 旁邊——feature-flag 開關面板、當前 auth/session 狀態、或「清快取」按鈕——讓團隊的臨時診斷全集中在一處，不必另開一個 debug 畫面 |
@@ -47,7 +48,7 @@
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.7.1
+  flutter_inspector_kit: ^1.8.0
 ```
 
 接著執行 `flutter pub get`。
@@ -369,7 +370,7 @@ inspector.log(
 
 ### 讀取合併後的時間軸
 
-**Console** 分頁本身就已把 logs、network、navigation 與 database 事件交錯排在單一時間軸上（最新在前），並為每個來源提供一個 filter chip。你也可以用程式化方式讀取這份相同的合併檢視：
+**Console** 分頁本身就已把 logs、network、navigation 與 database 事件交錯排在單一時間軸上（最新在前），並為每個來源提供一個 filter chip。error 等級的 log 與失敗的 network 呼叫會被加上淡紅色的列底色，捲動長時間軸時容易辨識——warning 維持原本的橘色文字但不上底色，避免 warning 一多就把整份列表洗成一片紅。你也可以用程式化方式讀取這份相同的合併檢視：
 
 ```dart
 // All sources, newest first.
@@ -404,6 +405,27 @@ final inspector = FlutterInspector(captureUncaughtErrors: true);
 
 被擷取的錯誤會以紅色 log 出現在 **Console** 分頁。點任何帶 stack trace 或結構化資料的 log 即可打開詳情頁，內含可複製的 stack trace 與結構化 payload，並附複製／分享動作。
 
+### App 生命週期標記（需 opt-in）
+
+啟用 **lifecycle capture**，把每一次前景／背景轉換記錄成 `info` 等級的 Console log，這樣崩潰或卡住的請求就能對照當下 App 是否在前景來判讀：
+
+```dart
+final inspector = FlutterInspector(captureLifecycleEvents: true);
+```
+
+它**預設停用**，而 `detach()` 會把 observer 移除。每一次轉換（`resumed` / `inactive` / `paused` / `detached`，Flutter 3.13+ 另有 `hidden`）都會成為一筆項目，並自動被合併時間軸與 network、navigation、database 事件交錯排列。
+
+每筆項目還會標註當前最上層的頁面，讓反覆的 home／back 切換在 Console 裡仍可區分，不必跳到 Navigator 分頁比對：
+
+```text
+App lifecycle: resumed · HomePage (/home)
+App lifecycle: paused · CheckoutPage
+```
+
+頁面名稱是依導覽歷史盡力還原的結果；無法解析時（歷史為空）就單純省略該後綴。
+
+> 這個 observer 是用 `WidgetsBinding.instance.addObserver` 註冊的，它是往清單追加——你 App 自己的 `WidgetsBindingObserver` 仍會照常收到各自的 callback。
+
 ### 追蹤 navigation
 
 這裡不用做任何事——只要你把 `inspector.navigatorObserver` 註冊進 `navigatorObservers`（見 [初始化](#初始化)），route 就會被自動追蹤。push、pop 與 replace 全都會出現在 Navigator 分頁。
@@ -412,6 +434,8 @@ Navigator 分頁提供兩種檢視，透過頂端的 chip 切換：
 
 - **Event History**：push/pop/replace/remove 事件的原始 log（原本的行為）。
 - **Active Stack**：當前的 route stack，從 event history 即時推導，以垂直卡片由上而下呈現——最上方的卡片（當前畫面）會被標亮。尚未記錄任何 route 時顯示「Empty stack history」。
+
+dashboard 自己開啟的 route——log／network 詳情頁、資料表與 cell 詳情、匯出面板——都不會被計入這份歷史，所以查 bug 的動作不會反過來污染你 App 的 route stack。你 App 自己的 route 記錄方式完全不變，包含未命名的 route。
 
 ### 追蹤 database 操作
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String packageVersion = '1.7.1';
+const String packageVersion = '1.8.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 1.7.1
+version: 1.8.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary
[#106](https://github.com/Yomiamy/flutter_inspector_kit/issues/106) Release: Version 1.8.0

**[修正問題]**
發布新版 `1.8.0`，把自 `v1.7.1` 以來合併入 `main` 的三項使用者可見變更打包發行：App 生命週期標記、Console 錯誤列高亮、以及 inspector 自身路由污染 Navigator tab 的修正。過程中另外發現兩處文件缺口：`README.zh-TW.md` 缺少 v1.7.1 之後新增的生命週期章節，且中英文 Features 表都漏了 App Lifecycle Markers 這一列。

**[修正方式]**
1. **`pubspec.yaml`**：版號更新為 `1.8.0`。
2. **`lib/src/version.dart`**：`packageVersion` 同步為 `1.8.0`（此處與 pubspec 是各自獨立的字串，容易漏改）。
3. **`README.md`**：
   - 安裝版號改為 `^1.8.0`。
   - Features 表新增 **App Lifecycle Markers** 一列（本次主要新功能，先前只存在於 Usage 章節）。
   - Merged Timeline 一列補上錯誤列底色說明；Navigator 一列補上「dashboard 自身路由已被濾掉」，並讓使用情境反映這項修正。
   - Usage 的 Navigator 與 merged timeline 章節同步補述。
4. **`README.zh-TW.md`**：同步上述全部四項，另補回缺漏的「App 生命週期標記（需 opt-in）」完整章節，與英文版對齊。
5. **`CHANGELOG.md`**：`## Unreleased` 定版為 `## 1.8.0`，依 Added / Changed / Fixed 重排，並補上先前漏記的 Console 錯誤高亮。

**[驗證]**
- `flutter analyze`：僅 2 則既有的 `deprecated_member_use` info（`export_report_sheet.dart` 的 Radio `groupValue`/`onChanged`），非本次引入。
- `flutter test`：434 個測試全數通過。
- 四處版號（pubspec / version.dart / 中英 README）一致皆為 `1.8.0`；中英 Features 表各 16 項功能、欄位對齊。

## Summary by Sourcery

Release version 1.8.0 with updated documentation for new lifecycle and timeline behaviors.

New Features:
- Document and expose App Lifecycle Markers as an opt-in feature that logs lifecycle transitions with page context in the merged timeline.

Enhancements:
- Clarify merged timeline behavior by documenting tinted error rows in Console for better visual scanning.
- Update Navigator feature description so inspector-internal routes are explicitly excluded from the app’s recorded navigation history.
- Align English and Traditional Chinese README feature tables and usage sections with the current capabilities.

Build:
- Bump package version to 1.8.0 in pubspec and internal version constant.

Documentation:
- Update English and Traditional Chinese READMEs to reference version 1.8.0 and include App Lifecycle Markers and timeline tinting behavior in feature and usage sections.
- Finalize CHANGELOG entry for 1.8.0, detailing lifecycle markers, timeline tinting, and Navigator route filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增可选的 App 生命​​周期标记，将前后台状态变化及页面上下文整合到合并时间轴。
- **改进**
  - 错误日志与失败网络请求使用淡红背景，便于长列表中快速识别。
  - 仪表板自身页面不再污染应用导航历史。
- **文档**
  - 更新功能说明、使用示例及安装版本信息。
- **版本**
  - 发布 1.8.0。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->