### PR TITLE
refactor(core): remove BuildContext from openDashboard

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,7 +53,7 @@ class MyApp extends StatelessWidget {
 
             if (context == null) return;
 
-            inspector.openDashboard(context);
+            inspector.openDashboard();
           },
           child: child ?? const SizedBox.shrink(),
         );

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -208,7 +208,7 @@ class FlutterInspector {
       );
     }
     _overlayManager = InspectorOverlayManager(
-      onFabTap: (context) => openDashboard(context),
+      onFabTap: (_) => openDashboard(),
     );
     _registry = InspectorRegistry(bufferSize: bufferSize);
     _uncaughtErrorHandler = UncaughtErrorHandler(onLog: log);
@@ -351,16 +351,16 @@ class FlutterInspector {
   ///
   /// [initialIndex] selects the starting tab: Console (0), Network (1),
   /// Navigator (2), Database (3).
-  void openDashboard(BuildContext context, {int initialIndex = 0}) {
+  void openDashboard({int initialIndex = 0}) {
+    final context = navigatorKey?.currentContext;
+    if (context == null) return;
     DashboardModal.show(context, this, initialIndex: initialIndex);
   }
 
   /// Opens the dashboard on the Network tab in response to a notification tap.
   /// Requires [navigatorKey] to have a mounted context; otherwise a no-op.
   void _openNetworkFromNotification() {
-    final context = navigatorKey?.currentContext;
-    if (context == null) return;
-    openDashboard(context, initialIndex: 1);
+    openDashboard(initialIndex: 1);
   }
 
   /// Clears all console logs.


### PR DESCRIPTION
## Summary
Refactors `openDashboard` to no longer require `BuildContext` as a parameter. It now directly fetches the context via `navigatorKey?.currentContext`.

## 修正問題/修正方式
- **Problem**: `openDashboard` previously required a `BuildContext` parameter, forcing callers to supply it even though `navigatorKey` is already globally available and holds the valid application context.
- **Fix**: Removed the `BuildContext` parameter from `openDashboard()` and its usages. It now retrieves the context directly from `navigatorKey?.currentContext`, returning early if null. This simplifies the API and aligns it with how other internal methods (like `_openNetworkFromNotification`) operate.

## 驗證
- 確保所有測試皆通過 (`flutter analyze` & `flutter test` ✅)
- 確保 example 應用中的呼叫同步更新

## Summary by Sourcery

重构 inspector 仪表盘（dashboard）API，使其从全局 `navigatorKey` 派生上下文，而不是要求传入 `BuildContext` 参数。

增强内容：
- 从 `openDashboard` 中移除 `BuildContext` 参数，改为在内部使用 `navigatorKey.currentContext`。
- 简化 inspector overlay 和示例应用的回调，使其在调用 `openDashboard` 时无需再传入 `BuildContext`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the inspector dashboard API to derive context from the global navigator key instead of requiring a BuildContext parameter.

Enhancements:
- Remove the BuildContext parameter from openDashboard and have it use navigatorKey.currentContext internally.
- Simplify inspector overlay and example app callbacks to call openDashboard without passing a BuildContext.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能更新**
  * 打开仪表盘的操作现在不再需要传入上下文，使用起来更简便。
  * 点击通知后仍可直接进入对应页面，并保留打开 Network 标签的行为。

* **Bug 修复**
  * 当当前上下文不可用时，打开仪表盘会安全地直接退出，减少异常风险。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->