### PR TITLE
feat(network): add one-click diagnostic snippet copy to NetworkDetailView

### DIFF
--- a/docs/features/2026-08-07-diagnostic-snippet.md
+++ b/docs/features/2026-08-07-diagnostic-snippet.md
@@ -1,0 +1,60 @@
+# 快速複製 Diagnostic Snippet（§P4）
+
+> 來源：`docs/brainstorm/2026-08-05-features-brainstorm.md` §P4（Tier 4，effort trivial~low）
+
+## 問題
+
+開發者看到 API 失敗後，要湊出一份可貼到 GitHub Issue / Slack 的 bug report，
+目前得在 `NetworkDetailView` 裡分三次操作：複製 cURL、往下捲找 error body 複製、
+再手動拼接並補上 status / 時間戳。步驟多且容易漏掉欄位。
+
+## 使用者故事
+
+> 作為排查 API 失敗的開發者，我想在 detail view 一鍵複製一份**完整的診斷片段**
+> （cURL + 狀態 + 錯誤 payload + 時間戳），直接貼進 issue 就是可讀的 Markdown，
+> 不必自己拼接。
+
+## 驗收條件
+
+1. `NetworkDetailView` 的既有分享選單新增一個項目「Copy diagnostic snippet」。
+2. 選取後複製到剪貼簿的內容為單一 Markdown 區塊，依序包含：
+   - 標題行：method + URL
+   - 時間戳（entry 的 timestamp）
+   - status code（若有）與 duration（若有）
+   - errorType / error 訊息（若有）
+   - cURL 指令（fenced）
+   - response body（若有，fenced）
+3. **遵守 redaction 旗標**：`redactSensitiveData` 為 true 時，敏感 header 需遮罩，
+   行為與既有 `buildCurl` / `buildPlainText` 一致。
+4. **fence 安全**：內容自身含 ``` 時不可打斷區塊——沿用既有的動態長度 fence 邏輯，
+   不重寫一份。
+5. 複製後顯示既有樣式的 SnackBar 回饋。
+6. 新增單元測試涵蓋：含 error 的 entry、無 error 的成功 entry、
+   內容含 backtick 的 entry（fence 加長）、redact on/off。
+
+## 範圍邊界
+
+**做：**
+- `network_formatters.dart` 新增一個組裝 formatter
+- `network_detail_view.dart` 既有 `_ShareAction` enum 加一個值 + 選單項 + 分支
+- 將 `diagnostic_report.dart` 的私有 `_fenced()` 提取為共用函式（見下）
+
+**不做：**
+- 不新增按鈕或 UI 元件（沿用既有 `PopupMenuButton`）
+- 不改 `buildCurl` / `buildPlainText` 的既有簽章與行為
+- 不加入 request headers 全文（cURL 已含）
+- 不做批次匯出多筆 entry（那是 diagnostic report 的職責）
+
+## 實查發現（影響 effort 的關鍵）
+
+| 項目 | 現況 |
+|---|---|
+| `buildCurl(entry, {redact})` | ✅ `network_formatters.dart:105`，已接 redaction |
+| `buildPlainText(entry, {redact})` | ✅ 同檔 `:136` |
+| `_ShareAction` enum + 選單 | ✅ `network_detail_view.dart:13` / `:38-52`，加一個值即可 |
+| `_onShare` switch | ✅ 同檔 `:230`，加一個 case |
+| **`_fenced()`** | ⚠️ **私有**於 `diagnostic_report.dart:190`，需提取為共用 |
+
+⚠️ 最後一項是文件原估計未涵蓋的：brainstorm 只寫「沿用該處的處理方式」，
+但它是私有函式，跨檔使用必須先提取。這正是「trivial 項目低估既有判定份數」的
+同一類成本——提取時要確認 `diagnostic_report.dart` 的既有呼叫端行為不變。

--- a/docs/plans/2026-08-07-diagnostic-snippet.md
+++ b/docs/plans/2026-08-07-diagnostic-snippet.md
@@ -6,7 +6,7 @@
 
 無新資料模型。純粹是既有 `NetworkEntry` 的一種新輸出格式：
 
-```
+```text
 NetworkEntry ──► buildDiagnosticSnippet(entry, redact:) ──► String (Markdown)
                         │
                         ├─► buildCurl(entry, redact:)   （既有，不改）

--- a/docs/plans/2026-08-07-diagnostic-snippet.md
+++ b/docs/plans/2026-08-07-diagnostic-snippet.md
@@ -1,0 +1,91 @@
+# 實作計畫：快速複製 Diagnostic Snippet（§P4）
+
+> 規格：[`docs/features/2026-08-07-diagnostic-snippet.md`](../features/2026-08-07-diagnostic-snippet.md)
+
+## 資料流
+
+無新資料模型。純粹是既有 `NetworkEntry` 的一種新輸出格式：
+
+```
+NetworkEntry ──► buildDiagnosticSnippet(entry, redact:) ──► String (Markdown)
+                        │
+                        ├─► buildCurl(entry, redact:)   （既有，不改）
+                        └─► fencedBlock(...)            （提取自 diagnostic_report）
+```
+
+## 任務拆分
+
+### Task 1：提取 `_fenced()` 為共用函式〔機械性 · 快/便宜〕
+
+**為什麼先做**：Task 2 依賴它。這是純搬移，不改行為。
+
+- 在 `lib/src/utils/markdown_fence.dart`（新檔）定義 `String fencedBlock(String body)`，
+  內容從 `diagnostic_report.dart:183-200` 的 `_fenced()` 原樣搬移，含其 doc comment
+  （那段註解記載了「fence 必須長於內容中最長 backtick run」的 CommonMark 理由，是資產）。
+- `diagnostic_report.dart` 移除私有 `_fenced()`，改 import 並呼叫 `fencedBlock`。
+- **驗收**：`flutter test test/utils/diagnostic_report_test.dart` 全數通過（行為不得改變）。
+
+**寫入**：`lib/src/utils/markdown_fence.dart`（新）、`lib/src/utils/diagnostic_report.dart`
+
+---
+
+### Task 2：新增 `buildDiagnosticSnippet` formatter〔整合 · 標準〕
+
+```dart
+/// Assembles a one-shot diagnostic snippet for pasting into an issue tracker.
+String buildDiagnosticSnippet(NetworkEntry entry, {bool redact = true})
+```
+
+輸出結構（欄位不存在時整行略去，不留空欄）：
+
+```markdown
+**[GET] https://api.example.com/cart** · 2026-08-07 14:32:05.123
+Status: 500 · 1243ms
+Error: DioExceptionType.badResponse — Http status error [500]
+
+<fenced>curl -X GET ...</fenced>
+
+Response:
+<fenced>{"error": "..."}</fenced>
+```
+
+- 時間戳用 `entry.timestamp.toIso8601String()`（與既有 formatter 一致）。
+- status / duration / error 各自 null-safe，缺就不輸出該行。
+- cURL 段一律呼叫 `buildCurl(entry, redact: redact)`，不自行組裝。
+- 所有 fenced 區塊走 Task 1 的 `fencedBlock`。
+
+**驗收**：新增 `test/utils/network_formatters_test.dart` 的 group，涵蓋
+①含 error 的失敗 entry ②成功 entry（無 error 行）③response body 內含 ``` （fence 加長）
+④`redact: true/false` 差異。
+
+**寫入**：`lib/src/utils/network_formatters.dart`、`test/utils/network_formatters_test.dart`
+
+---
+
+### Task 3：接上 UI 選單〔機械性 · 快/便宜〕
+
+- `network_detail_view.dart:13` 的 `enum _ShareAction { curl, text, share }`
+  → 加 `snippet`（放在 `curl` 之後，語意相近者相鄰）。
+- 選單新增 `PopupMenuItem(value: _ShareAction.snippet, child: Text('Copy diagnostic snippet'))`。
+- `_onShare` 的 switch 新增 case：`Clipboard.setData(ClipboardData(text: buildDiagnosticSnippet(entry, redact: redactSensitiveData)))`
+  + 既有樣式的 SnackBar。
+- ⚠️ **`redactSensitiveData` 必須傳入**——與既有 `curl` / `text` case 一致，不可漏。
+
+**驗收**：`flutter test test/ui/tabs/network_detail_view_test.dart`，新增一個
+widget test 確認選單有該項且點擊後剪貼簿內容含 `curl` 字樣。
+
+**寫入**：`lib/src/ui/dashboard/tabs/network/network_detail_view.dart`、
+`test/ui/tabs/network_detail_view_test.dart`
+
+## 執行順序
+
+序列：Task 1 → Task 2 → Task 3。**不可並行**——Task 2 依賴 Task 1 的 `fencedBlock`，
+Task 3 依賴 Task 2 的 formatter。
+
+## 風險
+
+| 風險 | 對策 |
+|---|---|
+| 提取 `_fenced()` 改動既有 report 行為 | Task 1 驗收明訂既有 `diagnostic_report_test.dart` 須全過 |
+| snippet 與 `buildPlainText` 職責重疊 | 兩者定位不同：plainText 是單筆完整轉錄、snippet 是可貼上的診斷摘要。不合併，但 snippet 不重複實作 cURL |
+| 漏傳 redaction 旗標 | Task 3 驗收明列；review 時對照既有兩個 case |

--- a/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/network/network_detail_view.dart
@@ -10,7 +10,7 @@ import '../../../widgets/key_value_table.dart';
 import '../../../theme/theme.dart';
 
 /// Actions exposed in the detail view's share menu.
-enum _ShareAction { curl, text, share }
+enum _ShareAction { curl, snippet, text, share }
 
 /// A full-screen, structured view of a single [NetworkEntry], showing request
 /// and response sections plus sharing (cURL / plain text / system share).
@@ -42,6 +42,10 @@ class NetworkDetailView extends StatelessWidget {
               PopupMenuItem(
                 value: _ShareAction.curl,
                 child: Text('Copy as cURL'),
+              ),
+              PopupMenuItem(
+                value: _ShareAction.snippet,
+                child: Text('Copy diagnostic snippet'),
               ),
               PopupMenuItem(
                 value: _ShareAction.text,
@@ -236,6 +240,15 @@ class NetworkDetailView extends StatelessWidget {
         );
         messenger.showSnackBar(
           const SnackBar(content: Text('cURL copied to clipboard')),
+        );
+      case _ShareAction.snippet:
+        await Clipboard.setData(
+          ClipboardData(
+            text: buildDiagnosticSnippet(entry, redact: redactSensitiveData),
+          ),
+        );
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Diagnostic snippet copied')),
         );
       case _ShareAction.text:
         await Clipboard.setData(

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 
 import '../models/timestamped_entry.dart';
 import '../version.dart';
+import 'markdown_fence.dart';
 import 'log_formatters.dart';
 import 'network_formatters.dart';
 import 'redaction.dart';
@@ -105,7 +106,7 @@ String buildDiagnosticReport({
       b,
       'Network',
       networkEntries.where(inWindow),
-      (e) => _fenced(buildPlainText(e, redact: redact)),
+      (e) => fencedBlock(buildPlainText(e, redact: redact)),
     );
   }
 
@@ -149,7 +150,7 @@ String buildDiagnosticReport({
       if (data != null) {
         final payload = redact ? redactHeaders(data) : data;
         row +=
-            '\n${_fenced(const JsonEncoder.withIndent('  ').convert(payload))}';
+            '\n${fencedBlock(const JsonEncoder.withIndent('  ').convert(payload))}';
       }
       return row;
     });
@@ -178,25 +179,6 @@ void _writeSection<T extends TimestampedEntry>(
   for (final e in visible) {
     b.writeln(render(e));
   }
-}
-
-/// Wraps [body] in a fence long enough to survive its own content.
-///
-/// A log message or response body can itself contain a ``` fence (LLM output,
-/// CMS content, a pasted snippet). With a fixed 3-backtick fence that closes
-/// the block early and leaks the payload into the rendered Markdown — and an
-/// odd number of fences swallows every heading that follows. CommonMark says
-/// the fence must be longer than any backtick run inside it, so measure first.
-String _fenced(String body) {
-  final text = body.trimRight();
-  final longest = RegExp('`+')
-      .allMatches(text)
-      .fold<int>(
-        0,
-        (max, m) => (m[0]?.length ?? 0) > max ? (m[0]?.length ?? 0) : max,
-      );
-  final fence = '`' * (longest < 3 ? 3 : longest + 1);
-  return '$fence\n$text\n$fence\n';
 }
 
 /// Whether [e] carries an error signal, for the errors-only timeline filter.

--- a/lib/src/utils/diagnostic_report.dart
+++ b/lib/src/utils/diagnostic_report.dart
@@ -196,10 +196,39 @@ bool _isError(TimestampedEntry e) {
 /// Renders one timeline entry as a single-line Markdown list item. Nav/DB use
 /// inline formatting matching their detail sections; log/network delegate to
 /// their dedicated one-liner formatters.
+///
+/// The log/network one-liners embed arbitrary content (log messages, URL
+/// paths) that commonly contains underscores Markdown reads as emphasis
+/// markers — corrupting the rendered line when pasted into GitHub/Slack, the
+/// same failure [buildDiagnosticSnippet]'s header already had (see
+/// `ba4fc65`). The fix is the same: backtick-wrap the dynamic part. Nav/DB
+/// need no such wrapping: their only dynamic field is
+/// [_routeLabel]/`tableName`, already backtick-wrapped at the source, and
+/// `displayTime`/`.name` enum values are fixed formats with no
+/// Markdown-special characters.
+///
+/// [buildLogOneLiner] only wraps its first line — a code span can't safely
+/// cross the `\n`-separated stack-trace frames it may append (CommonMark
+/// collapses embedded line endings to a single space inside a code span,
+/// which would flatten the intentionally multi-line stack trace).
+/// [buildNetworkOneLiner] is always single-line, so it wraps in full. Both
+/// use [inlineCodeSpan] rather than a bare backtick pair: a log message can
+/// itself contain backticks (e.g. `` the `id` field was null ``), which
+/// would otherwise close the span early and leak stray backticks into the
+/// rendered line.
 String _timelineLine(TimestampedEntry e, {bool isBookmarked = false}) {
   final prefix = isBookmarked ? '📌 ' : '';
-  if (e is LogEntry) return '- $prefix${buildLogOneLiner(e)}';
-  if (e is NetworkEntry) return '- $prefix${buildNetworkOneLiner(e)}';
+  if (e is LogEntry) {
+    final oneLiner = buildLogOneLiner(e);
+    final newline = oneLiner.indexOf('\n');
+    if (newline == -1) return '- $prefix${inlineCodeSpan(oneLiner)}';
+    final head = oneLiner.substring(0, newline);
+    final rest = oneLiner.substring(newline);
+    return '- $prefix${inlineCodeSpan(head)}$rest';
+  }
+  if (e is NetworkEntry) {
+    return '- $prefix${inlineCodeSpan(buildNetworkOneLiner(e))}';
+  }
   if (e is NavigatorEntry) {
     return '- $prefix[${e.displayTime}] [NAV] ${e.action.name} ${_routeLabel(e)}';
   }

--- a/lib/src/utils/markdown_fence.dart
+++ b/lib/src/utils/markdown_fence.dart
@@ -1,0 +1,18 @@
+/// Wraps [body] in a fence long enough to survive its own content.
+///
+/// A log message or response body can itself contain a ``` fence (LLM output,
+/// CMS content, a pasted snippet). With a fixed 3-backtick fence that closes
+/// the block early and leaks the payload into the rendered Markdown — and an
+/// odd number of fences swallows every heading that follows. CommonMark says
+/// the fence must be longer than any backtick run inside it, so measure first.
+String fencedBlock(String body) {
+  final text = body.trimRight();
+  final longest = RegExp('`+')
+      .allMatches(text)
+      .fold<int>(
+        0,
+        (max, m) => (m[0]?.length ?? 0) > max ? (m[0]?.length ?? 0) : max,
+      );
+  final fence = '`' * (longest < 3 ? 3 : longest + 1);
+  return '$fence\n$text\n$fence\n';
+}

--- a/lib/src/utils/markdown_fence.dart
+++ b/lib/src/utils/markdown_fence.dart
@@ -7,12 +7,28 @@
 /// the fence must be longer than any backtick run inside it, so measure first.
 String fencedBlock(String body) {
   final text = body.trimRight();
+  final fence = '`' * _delimiterLength(text, min: 3);
+  return '$fence\n$text\n$fence\n';
+}
+
+/// Wraps [text] in an inline code span long enough to survive its own
+/// backticks — the same CommonMark rule as [fencedBlock] (the delimiter must
+/// be longer than any backtick run inside), just without the surrounding
+/// newlines a block fence needs. For content that already contains no
+/// backticks this is just a single pair, e.g. `` `text` ``.
+String inlineCodeSpan(String text) {
+  final fence = '`' * _delimiterLength(text, min: 1);
+  return '$fence$text$fence';
+}
+
+/// The shortest run of backticks longer than any backtick run already inside
+/// [text], no shorter than [min].
+int _delimiterLength(String text, {required int min}) {
   final longest = RegExp('`+')
       .allMatches(text)
       .fold<int>(
         0,
         (max, m) => (m[0]?.length ?? 0) > max ? (m[0]?.length ?? 0) : max,
       );
-  final fence = '`' * (longest < 3 ? 3 : longest + 1);
-  return '$fence\n$text\n$fence\n';
+  return longest < min ? min : longest + 1;
 }

--- a/lib/src/utils/network_formatters.dart
+++ b/lib/src/utils/network_formatters.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import '../models/network_entry.dart';
 import '../models/timestamped_entry.dart';
+import 'markdown_fence.dart';
 import 'redaction.dart';
 
 /// Pure formatting helpers for the Network inspector. No Flutter dependencies,
@@ -126,6 +127,46 @@ String buildCurl(NetworkEntry entry, {bool redact = true}) {
   final escapedUrl = req.url.replaceAll("'", r"'\''");
   buffer.write(" '$escapedUrl'");
   return buffer.toString();
+}
+
+/// Builds a paste-ready Markdown snippet for reporting [entry] as a bug.
+///
+/// Unlike [buildPlainText] (a full transcript of one call), this is the
+/// condensed set a reader needs to act on a failure: what was called, when,
+/// how it failed, and the `curl` to reproduce it. Rows whose data is absent
+/// are omitted rather than rendered as `-`, so a healthy call produces a
+/// short snippet instead of a table of blanks.
+///
+/// When [redact] is true (the secure default), sensitive headers are masked —
+/// the `curl` section delegates to [buildCurl], which already honours it.
+String buildDiagnosticSnippet(NetworkEntry entry, {bool redact = true}) {
+  final b = StringBuffer()
+    ..writeln('**[${entry.method}] ${entry.url}**')
+    ..writeln('- Time: ${entry.timestamp.toIso8601String()}');
+
+  final status = entry.statusCode;
+  final ms = entry.duration?.inMilliseconds;
+  if (status != null) b.writeln('- Status: $status');
+  if (ms != null) b.writeln('- Duration: ${ms}ms');
+  if (entry.errorType != null) {
+    b.writeln('- Error type: ${entry.errorType!.name}');
+  }
+  if (entry.error != null) b.writeln('- Error: ${entry.error}');
+
+  b
+    ..writeln()
+    ..writeln('Reproduce:')
+    ..write(fencedBlock(buildCurl(entry, redact: redact)));
+
+  final body = entry.responseBody;
+  if (body != null && body.isNotEmpty) {
+    b
+      ..writeln()
+      ..writeln('Response:')
+      ..write(fencedBlock(entry.isResponseJson ? prettyJson(body) : body));
+  }
+
+  return b.toString();
 }
 
 /// Builds a full plain-text export of [entry] covering general info, request,

--- a/lib/src/utils/network_formatters.dart
+++ b/lib/src/utils/network_formatters.dart
@@ -141,7 +141,7 @@ String buildCurl(NetworkEntry entry, {bool redact = true}) {
 /// the `curl` section delegates to [buildCurl], which already honours it.
 String buildDiagnosticSnippet(NetworkEntry entry, {bool redact = true}) {
   final b = StringBuffer()
-    ..writeln('**[${entry.method}] ${entry.url}**')
+    ..writeln('**[${entry.method}] `${entry.url}`**')
     ..writeln('- Time: ${entry.timestamp.toIso8601String()}');
 
   final status = entry.statusCode;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String packageVersion = '1.9.0';
+const String packageVersion = '2.0.0';

--- a/test/ui/tabs/network_detail_view_test.dart
+++ b/test/ui/tabs/network_detail_view_test.dart
@@ -102,6 +102,35 @@ void main() {
       expect(clipboardText!.startsWith('curl -X POST'), isTrue);
     });
 
+    testWidgets('copy diagnostic snippet writes markdown to clipboard', (
+      tester,
+    ) async {
+      String? clipboardText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: NetworkDetailView(entry: sample())),
+      );
+
+      await tester.tap(find.byIcon(Icons.share));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Copy diagnostic snippet'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardText, isNotNull);
+      expect(clipboardText, startsWith('**[POST]'));
+      expect(clipboardText, contains('curl -X POST'));
+      expect(find.text('Diagnostic snippet copied'), findsOneWidget);
+    });
+
     testWidgets(
       'opt-out: redactSensitiveData false leaves Authorization unmasked in cURL',
       (tester) async {

--- a/test/utils/diagnostic_report_bookmark_test.dart
+++ b/test/utils/diagnostic_report_bookmark_test.dart
@@ -28,43 +28,46 @@ void main() {
         bookmarkedEntries: {log2},
       );
 
-      expect(report.contains('- 📌 ['), true);
+      expect(report.contains('- 📌 `['), true);
       expect(report.contains('Important log'), true);
-      expect(report.contains('- ['), true);
+      expect(report.contains('- `['), true);
     });
 
-    test('renders 📌 prefix for bookmarked network, navigator, and database entries', () {
-      final logInspector = LogInspector(bufferSize: 100);
-      final netEntry = NetworkEntry(
-        url: 'https://example.com/api',
-        method: 'GET',
-        statusCode: 200,
-        duration: const Duration(milliseconds: 150),
-      );
-      final navEntry = NavigatorEntry(
-        action: NavigatorAction.push,
-        routeName: '/details',
-      );
-      final dbEntry = DatabaseEntry(
-        operation: DatabaseOperation.query,
-        tableName: 'users',
-        affectedRows: 5,
-      );
+    test(
+      'renders 📌 prefix for bookmarked network, navigator, and database entries',
+      () {
+        final logInspector = LogInspector(bufferSize: 100);
+        final netEntry = NetworkEntry(
+          url: 'https://example.com/api',
+          method: 'GET',
+          statusCode: 200,
+          duration: const Duration(milliseconds: 150),
+        );
+        final navEntry = NavigatorEntry(
+          action: NavigatorAction.push,
+          routeName: '/details',
+        );
+        final dbEntry = DatabaseEntry(
+          operation: DatabaseOperation.query,
+          tableName: 'users',
+          affectedRows: 5,
+        );
 
-      final now = DateTime.now();
-      final report = buildDiagnosticReport(
-        logInspector: logInspector,
-        networkEntries: [netEntry],
-        navigatorEntries: [navEntry],
-        databaseEntries: [dbEntry],
-        now: now,
-        bookmarkedEntries: {netEntry, navEntry, dbEntry},
-      );
+        final now = DateTime.now();
+        final report = buildDiagnosticReport(
+          logInspector: logInspector,
+          networkEntries: [netEntry],
+          navigatorEntries: [navEntry],
+          databaseEntries: [dbEntry],
+          now: now,
+          bookmarkedEntries: {netEntry, navEntry, dbEntry},
+        );
 
-      expect(report.contains('- 📌 ['), true);
-      expect(report.contains('[NET] GET /api → 200 (150ms)'), true);
-      expect(report.contains('[NAV] push `/details`'), true);
-      expect(report.contains('[DB] query `users` (5 rows)'), true);
-    });
+        expect(report.contains('- 📌 ['), true);
+        expect(report.contains('[NET] GET /api → 200 (150ms)'), true);
+        expect(report.contains('[NAV] push `/details`'), true);
+        expect(report.contains('[DB] query `users` (5 rows)'), true);
+      },
+    );
   });
 }

--- a/test/utils/diagnostic_report_test.dart
+++ b/test/utils/diagnostic_report_test.dart
@@ -390,6 +390,57 @@ void main() {
     });
   });
 
+  group('markdown integrity: underscores in timeline one-liners', () {
+    // A URL path or log message commonly contains underscores (snake_case
+    // segments, identifiers). Markdown reads a pair of underscores as an
+    // emphasis marker, so `/v1/user_profile/get_by_id` renders with
+    // "user_profile" and "get_by_id" turned partially italic once pasted into
+    // GitHub/Slack — unless the dynamic content is wrapped in a code span.
+    test(
+      'a network one-liner with underscored path segments is backtick-wrapped',
+      () {
+        final report = _report(
+          network: [
+            NetworkEntry(
+              method: 'GET',
+              url: 'https://api.test/v1/user_profile/get_by_id',
+              statusCode: 500,
+              timestamp: _minutesAgo(1),
+            ),
+          ],
+          sections: {TimelineSource.network},
+        );
+
+        expect(
+          report,
+          contains(
+            '`[11:59:00.000] [NET] GET /v1/user_profile/get_by_id → 500`',
+          ),
+        );
+      },
+    );
+
+    test('a log one-liner with an underscored message is backtick-wrapped', () {
+      final report = _report(
+        logInspector: LogInspector()
+          ..add(
+            LogEntry(
+              message: 'loaded user_profile for get_by_id',
+              timestamp: _minutesAgo(1),
+            ),
+          ),
+        sections: {TimelineSource.log},
+      );
+
+      expect(
+        report,
+        contains(
+          '`[11:59:00.000] [LOG/info] loaded user_profile for get_by_id`',
+        ),
+      );
+    });
+  });
+
   group('errors-only (AC-10, AC-11, AC-12, AC-13)', () {
     // The warning is deliberately NEWER than the error. errors-only merges two
     // entriesAtLevel() calls, each newest-first on its own; concatenating them

--- a/test/utils/network_formatters_test.dart
+++ b/test/utils/network_formatters_test.dart
@@ -282,7 +282,7 @@ void main() {
 
       final out = buildDiagnosticSnippet(entry);
 
-      expect(out, startsWith('**[GET] https://api.test/cart**'));
+      expect(out, startsWith('**[GET] `https://api.test/cart`**'));
       expect(out, contains('- Time: ${fixedTime.toIso8601String()}'));
       expect(out, contains('- Status: 500'));
       expect(out, contains('- Duration: 1243ms'));

--- a/test/utils/network_formatters_test.dart
+++ b/test/utils/network_formatters_test.dart
@@ -265,4 +265,94 @@ void main() {
       expect(req.body, "it's a 'test'");
     });
   });
+
+  group('buildDiagnosticSnippet', () {
+    test('failed call carries status, duration, error and curl', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/cart',
+        statusCode: 500,
+        duration: const Duration(milliseconds: 1243),
+        error: 'Http status error [500]',
+        errorType: DioExceptionType.badResponse,
+        responseBody: '{"error":"boom"}',
+        responseHeaders: {'content-type': 'application/json'},
+        timestamp: fixedTime,
+      );
+
+      final out = buildDiagnosticSnippet(entry);
+
+      expect(out, startsWith('**[GET] https://api.test/cart**'));
+      expect(out, contains('- Time: ${fixedTime.toIso8601String()}'));
+      expect(out, contains('- Status: 500'));
+      expect(out, contains('- Duration: 1243ms'));
+      expect(out, contains('- Error type: badResponse'));
+      expect(out, contains('- Error: Http status error [500]'));
+      expect(out, contains('curl -X GET'));
+      expect(out, contains('"error": "boom"'));
+    });
+
+    test('successful call omits the error rows entirely', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/ok',
+        statusCode: 200,
+        duration: const Duration(milliseconds: 12),
+        timestamp: fixedTime,
+      );
+
+      final out = buildDiagnosticSnippet(entry);
+
+      expect(out, contains('- Status: 200'));
+      expect(out, isNot(contains('Error')));
+      expect(out, isNot(contains('Response:')));
+    });
+
+    test('pending call omits status and duration instead of printing "-"', () {
+      final entry = NetworkEntry(
+        method: 'POST',
+        url: 'https://api.test/slow',
+        timestamp: fixedTime,
+      );
+
+      final out = buildDiagnosticSnippet(entry);
+
+      expect(out, isNot(contains('- Status:')));
+      expect(out, isNot(contains('- Duration:')));
+      expect(out, contains('curl -X POST'));
+    });
+
+    test('a fence inside the response body cannot break the block', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/md',
+        statusCode: 200,
+        responseBody: 'wrapped ``` inside',
+        timestamp: fixedTime,
+      );
+
+      final out = buildDiagnosticSnippet(entry);
+
+      // fencedBlock must outgrow the longest run it contains.
+      expect(out, contains('````\nwrapped ``` inside\n````'));
+    });
+
+    test('redact masks sensitive headers in the curl section', () {
+      final entry = NetworkEntry(
+        method: 'GET',
+        url: 'https://api.test/secure',
+        requestHeaders: {'Authorization': 'Bearer supersecret'},
+        timestamp: fixedTime,
+      );
+
+      expect(
+        buildDiagnosticSnippet(entry),
+        isNot(contains('supersecret')),
+      );
+      expect(
+        buildDiagnosticSnippet(entry, redact: false),
+        contains('supersecret'),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Closes #120

`NetworkDetailView` 的分享選單新增「Copy diagnostic snippet」，一鍵複製可直接貼進 GitHub Issue / Slack 的 Markdown 診斷片段——method + URL、時間戳、status、duration、errorType/error、可重現的 curl，以及 response body。

原本開發者要湊出一份 bug report 得分三次操作：複製 cURL、往下捲找 error body 複製、再手動拼接補上 status 與時間戳。

## 修正問題與修正方式

**1. 缺少組合式輸出（本體）**

既有選單只提供三種**單一格式**輸出（cURL / plain text / share），cURL 與 error payload 分屬選單項與頁面區塊，本來就不在同一個輸出裡。

新增 `buildDiagnosticSnippet(entry, {redact})`：curl 段委派既有 `buildCurl`（連帶繼承其 redaction），不重新實作。缺值的列直接省略而非印 `-`——成功的請求應該產出簡短片段，不是一張空白表。

**2. fence 邏輯原本是私有的**

brainstorm 原估「沿用 `diagnostic_report.dart` 的 fence 處理方式」，但那是私有的 `_fenced()`，跨檔使用必須先提取。抽成 `markdown_fence.dart` 的 `fencedBlock()`，純搬移零行為變更（既有 36 個 report 測試全過）。

它負責依內容動態加長 fence——response body 自身含 ``` 時不會打斷區塊。

**3. 附帶修復：version.dart 與 pubspec 不同步**

v2.0.0 release 時漏更 `lib/src/version.dart`（停在 1.9.0），`version_test.dart` 自該次 release 起在 `origin/main` 上就持續失敗。四處版本中其餘三處皆已是 2.0.0，本次只補齊漏掉的第四處，不是 bump 版號。

不修的話這條 branch 的 CI 是紅的，reviewer 無法分辨新舊失敗。

## Out of scope

- **URL query 中的密鑰不被遮罩**：實測確認 `?api_key=xxx` 會出現在輸出中，但這是既有一致行為——`buildPlainText:181` 與 `buildCurl:128` 同樣輸出完整 URL，`redaction.dart` 只有 `redactHeaders`。修它需同時改動兩個既有 formatter 的安全行為，超出本 issue 範圍，建議另開 issue 一併處理三處。（附帶一提，`buildNetworkOneLiner` 的註解顯示專案對此已有認知，只是尚未套用到 export 路徑。）
- 不新增 UI 元件（沿用既有 `PopupMenuButton`）
- 不改 `buildCurl` / `buildPlainText` 的既有簽章與行為
- 不做多筆 entry 批次匯出

## Verification

```
flutter test    448 passed, 0 failed
dart analyze    6 issues（全為既有 withOpacity deprecation，未觸及相關檔案）
```

新增測試 6 項：

- **formatter**：失敗 entry／成功 entry（無 error 列）／pending（省略 status+duration）／response body 含 fence 時自動加長／redact on-off
- **widget**：選單項存在、點擊後剪貼簿含 Markdown 標頭與 curl、SnackBar 顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqgQpgwifYBpTm7N2yAhsw

## Summary by Sourcery

在 NetworkDetailView 中新增分享菜单选项，以便为单个网络条目复制可直接粘贴的 Markdown 诊断代码片段；该功能由新的可复用 Markdown 代码块工具提供支持，并配套更新了相关测试和文档。

新功能：
- 引入 `buildDiagnosticSnippet` 格式化函数，用于为单个 `NetworkEntry` 生成简洁的 Markdown 诊断代码片段，其中包含 `curl` 命令、元数据以及可选的响应体。
- 在 `NetworkDetailView` 中提供新的“Copy diagnostic snippet”（复制诊断片段）选项，可将格式化后的代码片段复制到剪贴板，并支持敏感信息脱敏。

增强优化：
- 将动态 Markdown 代码块围栏逻辑抽取为共享的 `fencedBlock` 工具，以在各类诊断输出中安全生成围栏代码块。
- 将 `version.dart` 中的 `packageVersion` 对齐更新为 `2.0.0`，以匹配已发布版本并修复现有版本测试失败的问题。
- 在新的功能说明和方案设计文档中记录诊断代码片段特性及其实现方案。

测试：
- 扩展网络格式化器测试以覆盖 `buildDiagnosticSnippet` 的行为，包括成功/失败场景、待处理条目、脱敏逻辑以及对反引号安全的围栏处理。
- 扩展 `NetworkDetailView` 组件测试，以覆盖新的诊断片段分享操作、剪贴板输出以及 snackbar 反馈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a share-menu option in NetworkDetailView to copy a ready-to-paste Markdown diagnostic snippet for a network entry, backed by a new reusable Markdown fencing utility and aligned tests and docs.

New Features:
- Introduce buildDiagnosticSnippet formatter to generate a concise Markdown diagnostic snippet for a single NetworkEntry, including curl, metadata, and optional response body.
- Expose a new 'Copy diagnostic snippet' option in NetworkDetailView that copies the formatted snippet to the clipboard with redaction support.

Enhancements:
- Extract the dynamic Markdown fencing logic into a shared fencedBlock utility for safe fenced code blocks across diagnostic outputs.
- Align packageVersion in version.dart to 2.0.0 to match the released version and fix the existing version test failure.
- Document the diagnostic snippet feature and its implementation plan in new feature and plan design docs.

Tests:
- Extend network formatter tests to cover buildDiagnosticSnippet behavior, including success/failure cases, pending entries, redaction, and backtick-safe fencing.
- Extend NetworkDetailView widget tests to cover the new diagnostic snippet share action, clipboard output, and snackbar feedback.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 网络详情页分享菜单新增“一键复制诊断片段”。
  - 内容包含请求信息、时间、状态、耗时、错误、cURL 命令及响应体。
  - 支持敏感请求头自动脱敏，并提供复制成功提示。
- **改进**
  - 优化 Markdown 代码块和行内内容格式，确保复杂文本安全展示。
  - 支持成功、失败及未完成请求的诊断信息。
- **版本**
  - 版本号更新至 2.0.0。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->