### PR TITLE
feat(ui): show error-count badges on Console and Network tabs

### DIFF
--- a/docs/features/2026-08-07-dashboard-error-badge.md
+++ b/docs/features/2026-08-07-dashboard-error-badge.md
@@ -1,0 +1,215 @@
+# Dashboard 錯誤計數 Badge（§P6）
+
+> 來源：`docs/brainstorm/2026-08-05-features-brainstorm.md` §P6（Tier 3，effort low，排查價值 ⭐⭐⭐）
+
+## 問題
+
+Dashboard 的 TabBar 只有 4 個純文字標籤（`Console` / `Network` / `Navigator` /
+`Database`），沒有任何數量提示。使用者開啟 dashboard 後，得逐 tab 點進去、
+掃視列表，才知道「這次操作到底有沒有炸東西」。
+
+實際排查情境更糟：真正想知道的是「**有沒有**錯誤」這個是非題，
+但目前的互動成本是「切 4 個 tab + 每個 tab 捲動掃視」。
+資訊已經全在 buffer 裡，只是沒有被摘要到最上層。
+
+## 使用者故事
+
+> 作為在真機上排查問題的開發者，我想在 dashboard 一打開時，
+> 就從 tab 標籤上直接看到「Network 有 3 筆失敗、Console 有 5 筆錯誤」，
+> 不必逐 tab 點進去確認，能立刻決定先看哪一個 tab。
+
+## 核心設計決策
+
+### 背景：brainstorm 的原始構想不成立
+
+§P6 寫「用 `ValueListenableBuilder` 監聽 buffer 變化，局部重建」。
+實查後確認**這個基礎設施不存在**：
+
+| 檢查項 | 現況 |
+|---|---|
+| `lib/` 內的 `ValueNotifier` / `ChangeNotifier` / `Listenable` | **零個**（全檔搜尋無命中） |
+| `RingBuffer` | 純資料容器，`add` / `clear` 不發任何通知 |
+| `InspectorRegistry` | 只是四個 inspector 的持有者，無通知機制 |
+| 四個 tab 的資料更新方式 | 一律 `void _refresh() => setState(() {})`，綁在手動 refresh 按鈕上 |
+
+所以「監聽 buffer」在本專案是一項**架構新增**，不是「沿用既有機制」。
+effort 從 low 被低估的部分就在這裡。
+
+### 三條路線與取捨
+
+| 路線 | 做法 | 判定 |
+|---|---|---|
+| **(A) 開啟時快照** | badge 在 `DashboardModal.build` 算一次，之後不變 | ❌ 否決 |
+| **(B) 上抬 refresh** | `DashboardModal` 改 StatefulWidget，各 tab refresh 一併通知上層重算 | ❌ 否決 |
+| **(C) revision notifier** | registry/inspector 層加 `ValueNotifier<int>`，`add` 時遞增，badge 監聽 | ✅ **採用** |
+
+### 採用 (C)：引入單一 revision notifier
+
+**理由：**
+
+1. **只有 (C) 讓 badge 的語意是誠實的。** badge 是一個「常駐在畫面最上層的數字」，
+   使用者對它的預期就是「現在的值」。(A) 與 (B) 都會產生「badge 顯示 0，
+   但 Network tab 裡躺著 3 筆紅色失敗」的狀態——這是**主動誤導**，
+   比沒有 badge 更糟。加一個會說謊的指示器，不如不加。
+
+2. **這不是想像出來的問題。** dashboard 是**長駐開著**的：使用者開著 dashboard、
+   切到 app 操作、再切回來看結果，是本工具最主要的使用流程。
+   在這個流程裡，資料一定會在 dashboard 生命週期內變動。(A) 的快照
+   從第二秒起就是錯的。
+
+3. **(C) 是唯一「消滅特殊情況」的設計。** (B) 需要在 4 個 tab 各接一條
+   回呼線，往後每新增一個 tab、每新增一個會改動 buffer 的入口
+   （clear all、bookmark、replay…）都要記得補接。這是典型的
+   「靠人記得」的設計，必然會漏。(C) 把通知收斂到資料寫入的**唯一路徑**，
+   新增任何寫入端都自動正確，不需要接線。
+
+**被否決路線的致命問題：**
+
+- **(A) 開啟時快照的致命問題**：資訊不一致且無法自我修正。使用者按了 tab 內的
+   refresh、按了 clear all，或只是切出去操作再切回來——badge 全部維持舊值。
+   此時 badge 不只是「不夠即時」，而是**與同畫面上的列表互相矛盾**。
+   一個和旁邊列表打架的數字，會直接摧毀使用者對整個 dashboard 的信任。
+   零架構改動買到的是負值。
+
+- **(B) 上抬 refresh 的致命問題**：它把「資料變了」錯誤地綁定到
+   「使用者按了按鈕」。實查確認除了 4 個 refresh 按鈕外，
+   `ConsoleTab` 有 clear-all（一次清四個 buffer）、`NetworkTab` 有 clear-all，
+   而 app 執行期的網路請求、log 寫入**根本不經過任何 UI 事件**。
+   (B) 能覆蓋的只有「使用者剛好按了 refresh」這一種情況，
+   其餘全部漏掉——付出 4 條接線的成本，只買到 (A) 的品質。
+   這是三者中 CP 值最差的一條。
+
+### (C) 的實作邊界（避免它膨脹成大改）
+
+採用 (C) 不代表要把整個 package 重寫成 reactive。**明確限縮：**
+
+- 只新增**一個** revision counter，代表「任一 buffer 被寫入或清除過」，
+  **不做**細分到 per-inspector 的多個 notifier。badge 收到通知後重算四個
+  count 的成本是 O(n)、n ≤ 500，且僅在 dashboard 開啟時發生，
+  完全不需要為此做精細化拆分。
+- **不改動**現有四個 tab 的手動 refresh 行為。兩套模型並存是刻意的：
+  tab 內列表維持手動 refresh（避免捲動位置在使用者閱讀時被抽掉，
+  這是既有的正確設計），只有 badge 走即時更新。
+  兩者職責不同——列表要**穩定**，摘要要**即時**。
+
+### 已知的實作陷阱（必須在 STAGE 0b 處理）
+
+實查發現兩個 brainstorm 未提及、會直接影響設計的事實：
+
+1. **`NetworkInspector.onAdd` 是單一插槽，且已被佔用。**
+   `network_inspector.dart:18` 宣告 `NetworkAddListener? onAdd`，
+   `flutter_inspector.dart:242` 在 `showNetworkNotification` 為 true 時
+   將它指派給 `NetworkNotifier`。若 badge 直接複用 `onAdd`，
+   **會覆蓋掉網路通知功能**（或反之被覆蓋），視初始化順序而定。
+   revision counter 不可掛在 `onAdd` 上，必須是獨立的通知點。
+
+2. **另外三個 inspector 完全沒有通知鉤子。**
+   `LogInspector.add` / `NavigatorInspector` / `DatabaseInspector`
+   都是直接 `_buffer.add(entry)`，沒有任何 callback。
+
+## 驗收條件
+
+### Badge 顯示規則
+
+1. Badge 依附在 `Console` 與 `Network` 兩個 tab 的標籤上。
+2. 對應 count 為 `0` 時，**該 tab 不顯示 badge**（標籤外觀與現況完全一致）。
+3. count `> 0` 時顯示該數字。
+4. `Navigator` / `Database` / 自訂 tab **不顯示 badge**（見範圍邊界）。
+
+### Count 語意（可測試的定義）
+
+5. **Network tab 的 count** = `inspector.networkEntries.where((e) => e.isFailed).length`。
+   **必須沿用 `NetworkEntry.isFailed`**（`network_entry.dart:109`，
+   定義為 `(statusCode ?? 0) >= 400 || error != null || errorType != null`）。
+   **嚴禁**在 badge 端重新實作失敗判定——該判定已由 PR #101 收斂為單一來源，
+   目前有四個消費端統一走它，新增第五個分歧實作會使收斂前功盡棄。
+
+6. **Console tab 的 count** = **僅計算 `LogEntry` 中 level 為 `error` 或 `warning` 的筆數**，
+   即 `logInspector.entriesAtLevel(LogLevel.error).length +
+   logInspector.entriesAtLevel(LogLevel.warning).length`。
+
+   **此定義需要明文釐清，因為 Console tab 實際上是混合時間軸**
+   （`mergedTimeline` 合併 log / network / nav / db 四種來源，預設全選）。
+   刻意**不**把 timeline 裡的失敗 network 計入 Console badge，理由：
+   - 失敗的 network 已由 Network badge 表達。兩邊都算會**重複計數**，
+     使用者看到 `Console 3 / Network 3` 會誤以為總共有 6 個問題。
+   - 兩個 badge 各自對應一個明確的、不重疊的資料來源，語意才可預測。
+
+7. Badge 的 count 在 dashboard 開啟期間，於任一 buffer 新增或清除後**自動更新**，
+   不需使用者按 refresh。
+
+### 可測試斷言
+
+8. Widget test：注入 2 筆 `isFailed` 的 network entry → Network tab 顯示 `2`。
+9. Widget test：全部 network entry 皆成功 → Network tab 無 badge。
+10. Widget test：注入 1 筆 `error` + 1 筆 `warning` + 3 筆 `info` log
+    → Console tab 顯示 `2`。
+11. Widget test：無任何資料（`FlutterInspector()` 空實例）→ 兩個 tab 皆無 badge，
+    且既有的 `dashboard_modal_test.dart` 四項斷言全數維持通過。
+12. Widget test：dashboard 已渲染後再寫入一筆失敗請求 → 不觸發任何 refresh 操作，
+    pump 後 badge 由 `0`（無 badge）變為 `1`。此為 (C) 相對於 (A)/(B) 的核心差異，
+    必須有對應測試。
+13. Widget test：清除 buffer 後 badge 消失。
+14. Unit test：revision counter 在四種 `add` 與四種 `clear` 後皆遞增。
+15. Unit test：badge 的通知機制**不影響** `NetworkInspector.onAdd`——
+    同時設定 `onAdd` 與 badge 監聽，兩者都要收到通知
+    （對應上述陷阱 1，防止網路通知功能被靜默破壞）。
+
+## 範圍邊界
+
+**做：**
+
+- 在資料層新增單一 revision notifier，於四個 buffer 的寫入/清除路徑遞增
+- `DashboardModal` / `_DashboardTabBar` 接上該 notifier，重算並渲染 badge
+- Console / Network 兩個 tab 的 badge
+
+**不做（out of scope）：**
+
+- **不加** Navigator / Database / 自訂 tab 的 badge。前兩者沒有「錯誤」語意
+  （導航事件與 DB 操作本身無成敗），自訂 tab 的內容由 host 提供、
+  package 無從得知其錯誤定義。
+- **不改**四個 tab 內部列表的手動 refresh 行為（刻意保留，見上文）。
+- **不做** badge 點擊行為（例如點 badge 自動套用錯誤篩選）。Network tab
+  已有 `_ErrorSummaryBanner` 提供分組篩選，職責不重複。
+- **不改** `NetworkEntry.isFailed` 的定義，也不新增任何替代的失敗判定。
+- **不把** revision notifier 對外公開為 public API（見風險分析）。
+- **不做** badge 的上限截斷（如 `99+`）。buffer 上限預設 500，
+  現階段直接顯示實際數字；真有寬度問題再說。
+- **不**引入任何新的第三方相依（狀態管理套件一律不加，
+  符合專案「本 package 無跨畫面共享狀態」的既定方針）。
+
+## 風險與破壞性分析
+
+### 公開 API
+
+本 package 已發布至 pub.dev **v2.0.0**，公開 API 破壞不可接受。
+
+| 項目 | 影響 |
+|---|---|
+| `FlutterInspector` 建構式參數 | **不變**（badge 無需設定項，恆常啟用） |
+| `FlutterInspector` 既有 getter | **不變** |
+| `DashboardModal` 建構式 | **不變**（`inspector` / `initialIndex` / `key` 維持） |
+| `NetworkInspector.onAdd` | **不變**，且須有測試證明未被 badge 機制搶佔 |
+| revision notifier | **不對外公開**，僅內部使用，避免成為需長期維護的 API 承諾 |
+
+結論：**無公開 API 破壞**，屬 minor 版本可涵蓋的加法變更。
+
+### 既有測試
+
+- `test/ui/dashboard_modal_test.dart` 有 4 項斷言，其中兩項為
+  `expect(find.byType(Tab), findsNWidgets(4))` 與 `findsNWidgets(5)`。
+  若 badge 的實作方式改變 `Tab` widget 的數量或結構，這兩項會失敗。
+  **驗收條件 11 明列此測試須維持通過**——badge 應包裹 `Tab` 的內容，
+  而非替換或增生 `Tab` 本身。
+- `test/inspectors/network_inspector_test.dart` 有 2 項 `onAdd` 相關測試
+  （`:49`、`:111`），對應上述陷阱 1，必須維持通過。
+- 四個 tab 的既有測試不受影響（tab 內部行為不變）。
+
+### 其他風險
+
+| 風險 | 說明 |
+|---|---|
+| **通知風暴** | 高頻 log 寫入會高頻觸發 badge 重算（O(n)、n ≤ 500）。僅在 dashboard 開啟時有訂閱者，關閉時無成本。若實測有掉幀，STAGE 0b 需評估節流；現階段不預先優化。 |
+| **Material 3 依賴** | 本 package 未自行設定 `useMaterial3`，主題由 host app 決定。`Badge` 在 M2 主題下的外觀需確認可接受，或改用自繪的輕量標記。STAGE 0b 需驗證。 |
+| **兩套更新模型並存** | badge 即時、列表手動，是刻意取捨（摘要要即時、列表要穩定）。風險是後續開發者誤以為整個 dashboard 已 reactive 而做出不一致的擴充——需在程式碼註解明示此邊界。 |
+| **記憶體洩漏** | dashboard 關閉時若未解除訂閱，`FlutterInspector` 為 app 全域長生命週期物件，會持有已 dispose 的 widget。必須有對應的 dispose 處理。 |

--- a/docs/plans/2026-08-07-dashboard-error-badge.md
+++ b/docs/plans/2026-08-07-dashboard-error-badge.md
@@ -1,0 +1,441 @@
+# 實作計畫：Dashboard 錯誤計數 Badge（§P6）
+
+> Spec（唯一需求真實來源）：`docs/features/2026-08-07-dashboard-error-badge.md`
+> 本文件只寫 **How**。需求爭議一律回 spec，不在此重新討論。
+
+---
+
+## 一、資料結構與資料流
+
+### 1.1 關鍵實查結論：唯一寫入路徑是 `RingBuffer`，不是 inspector
+
+Spec 採用路線 (C)（單一 revision notifier），但「notifier 掛哪一層」是本次最關鍵的設計判斷。
+實查四個 inspector 後，事實如下：
+
+| inspector | 寫入方式 | 通知鉤子 |
+|---|---|---|
+| `LogInspector.add` | `_buffer.add(entry)` | 無 |
+| `NavigatorInspector.add` | `_buffer.add(entry)` | 無 |
+| `DatabaseInspector.add` | `_buffer.add(entry)` | 無 |
+| `NetworkInspector.add` | `_buffer.replace(...)` 或 `_buffer.add(...)` | `onAdd`（**已被 `NetworkNotifier` 佔用**） |
+
+四者的共同點：**每一次資料變動都必然穿過 `RingBuffer` 的 `add` / `replace` / `clear` 三個方法**。
+且全 `lib/` 只有這四個 `RingBuffer` 實例（已驗證，`grep RingBuffer lib/` 僅命中四個 inspector 的欄位宣告），
+沒有任何其他消費端會被誤觸發。
+
+### 1.2 方案比較
+
+| 方案 | 做法 | 判定 |
+|---|---|---|
+| **(甲) registry 持有 notifier，四個 inspector 回呼** | `InspectorRegistry` 建 `ValueNotifier`，四個 inspector 各加一個 `VoidCallback? onChanged` 欄位，registry 建構時接線 | ❌ |
+| **(乙) `FlutterInspector` 持有 notifier，在 8 個公開方法遞增** | `log()` / `logNetwork()` / `database()` / navigator observer + 四個 `clearXxx()` 各加一行 | ❌ |
+| **(丙) `RingBuffer` 持有 notifier，registry 注入同一個實例** | `RingBuffer` 建構式收一個 `VoidCallback? onMutate`，在 `add` / `replace` / `clear` 尾端呼叫。`InspectorRegistry` 建立**一個** `ValueNotifier<int>`，把同一個遞增回呼交給四個 inspector 轉傳給各自的 buffer | ✅ **採用** |
+
+**採用 (丙) 的理由：**
+
+1. **它是唯一「消滅特殊情況」的位置。** spec §核心設計決策第 3 點要求「把通知收斂到資料寫入的唯一路徑，
+   新增任何寫入端都自動正確，不需要接線」。`RingBuffer` **就是**那個唯一路徑。
+   (甲) 與 (乙) 都只是把接線從 4 條變成 4 條——(甲) 要在四個 inspector 各補一個 `onChanged` 欄位與呼叫點，
+   (乙) 要在 8 個方法各補一行。兩者都是「靠人記得」的設計，日後新增 `NetworkInspector.remove()`、
+   或任何直接動 buffer 的方法時必然會漏。(丙) 漏不掉，因為繞過 `RingBuffer` 就等於沒有資料。
+
+2. **(丙) 的 diff 最小。** `RingBuffer` 加 1 個 optional 欄位 + 3 行呼叫；
+   四個 inspector 各改 1 行建構式；registry 加 1 個 notifier + 1 個私有遞增方法。
+   (甲) 要動的行數是它的兩倍以上，而且新增了「inspector 有 onChanged 欄位」這個永久的概念負擔。
+
+3. **`replace` 也被涵蓋，這是 (甲)/(乙) 會漏的真實 bug。**
+   `NetworkInspector.add(entry, replaces: pending)` 是 pending → completed 的轉換路徑。
+   **失敗的請求正是走這條路徑產生的**（pending 時 `statusCode == null` 故 `isFailed == false`，
+   completed 時才帶 4xx/5xx 或 `error`）。若 notifier 只掛在 inspector 的 `add` 進入點，
+   語意上仍會通知，但 (丙) 在 `RingBuffer` 層天然涵蓋 `replace`，語意更精確：
+   **「buffer 內容變了」才通知，而不是「有人呼叫了 add」**。
+
+4. **零公開 API 破壞。** `RingBuffer` 的新參數是 optional named（`RingBuffer(capacity, {this.onMutate})`），
+   既有 `RingBuffer<int>(3)` 呼叫全數不變 → `test/core/ring_buffer_test.dart` 13 項測試零改動通過。
+
+**確認不與 `NetworkInspector.onAdd` 衝突：**
+`onAdd` 是 `NetworkInspector` 上的 public 欄位，由 `_initNetworkNotifier` 指派；
+`onMutate` 是 `RingBuffer` 上的建構式參數，由 `InspectorRegistry` 在建構時注入。
+**兩者是不同物件的不同欄位，永不互相覆寫**，也不存在初始化順序問題
+（`onMutate` 在 buffer 建構時就定案，`onAdd` 之後才由非同步的 `_initNetworkNotifier` 指派）。
+`NetworkInspector.add` 的尾端 `onAdd?.call(...)` 一行完全不動。
+
+### 1.3 資料流
+
+```
+LogInspector.add ─┐
+NavigatorInsp.add ─┤
+DatabaseInsp.add  ─┼─→ RingBuffer.add / replace / clear ─→ onMutate?.call()
+NetworkInsp.add   ─┘                                            │
+                                                                ▼
+                                     InspectorRegistry._revision (ValueNotifier<int>)
+                                                  revision.value++
+                                                                │
+                                                    （僅 dashboard 開啟時有訂閱者）
+                                                                ▼
+                                        _DashboardTabBar (StatefulWidget)
+                                          addListener → setState → 重算 count
+                                                                │
+                                                                ▼
+                                    Badge(isLabelVisible: count > 0) 包住 Tab 的 child
+```
+
+### 1.4 count 計算
+
+兩個 count 在 `_DashboardTabBar.build` 內即時重算（O(n)、n ≤ 500，且只在 dashboard 開啟時發生）：
+
+```dart
+// Network：必須沿用 NetworkEntry.isFailed，嚴禁重新實作失敗判定（spec 驗收條件 5）
+final networkErrorCount =
+    inspector.networkEntries.where((e) => e.isFailed).length;
+
+// Console：僅計 log 的 error + warning，刻意不含 timeline 裡的 network（spec 驗收條件 6）
+final consoleErrorCount =
+    inspector.logInspector.entriesAtLevel(LogLevel.error).length +
+    inspector.logInspector.entriesAtLevel(LogLevel.warning).length;
+```
+
+`FlutterInspector` 已公開 `networkEntries` 與 `logInspector` 兩個 getter，**不需新增任何 public API**。
+
+### 1.5 revision notifier 的公開範圍
+
+Spec 明列「不對外公開為 public API」。作法：
+- `InspectorRegistry` 的欄位命名為 `revision`，型別 `ValueListenable<int>`（對外唯讀），
+  內部另存 `ValueNotifier<int>` 私有欄位。
+- `InspectorRegistry` 本身位於 `lib/src/`，且 `FlutterInspector.registry` getter 已標 `@visibleForTesting`。
+  因此 `revision` 天然不在 package 的公開 API 表面上——**不需要在 `FlutterInspector` 上新增任何 getter**。
+- UI 端經由既有的 `@visibleForTesting` 的 `inspector.registry.revision` 取用。
+  這是 package 內部程式碼存取 package 內部型別，符合 spec 的「僅內部使用」約束。
+
+---
+
+## 二、Material 3 `Badge` 可用性驗證（spec 風險項）
+
+**結論：可用，M2 主題下無問題，採用 `Badge` widget，不需自繪替代方案。**
+
+實查 `flutter/lib/src/material/badge.dart`（本機 SDK 3.41.9）：
+
+1. **`Badge` 原始碼裡沒有任何 `useMaterial3` 分支。** 只存在 `_BadgeDefaultsM3`，
+   無論 `useMaterial3` 為 true/false 都走同一份 defaults。
+2. `_BadgeDefaultsM3` 只依賴三個東西：`colorScheme.error`、`colorScheme.onError`、
+   `textTheme.labelSmall`。這三者在 M2 的 `ThemeData` 中**同樣存在且有預設值**
+   （`ColorScheme` 與 `TextTheme` 並非 M3 專屬）。
+3. `isLabelVisible: false` 時 `build` 直接 `return child ?? const SizedBox()`——
+   **不產生 `Stack`、不產生任何額外可見 widget**，這正好是驗收條件 2（count 為 0 時外觀與現況完全一致）
+   的免費實作，不需要自己寫 `if (count > 0)` 條件分支。
+
+> 註：專案 `.claude/rules/flutter-styles.md` 標示 Flutter 3.35，實機為 3.41.9。
+> `Badge` 的上述行為在兩版本間一致（無 `useMaterial3` 分支的設計自 3.16 導入 M3 defaults 起即如此），
+> 不構成版本風險。
+
+**Tab 計數安全性：** `Badge` 包在 `Tab` 的 **child** 上，即
+`Tab(child: Badge(...child: Text('Console')))`。`Tab` widget 本身數量不變（4 或 5），
+`find.byType(Tab)` 的 `findsNWidgets(4)` / `findsNWidgets(5)` 維持通過。
+
+> ⚠️ 實作注意：現況是 `const Tab(text: 'Console')`。改用 `child:` 後，
+> `Tab` 的 `text` 與 `child` 是互斥的（`Tab` 建構式 assert 兩者不可同時給）。
+> 帶 badge 的兩個 tab 改用 `child:`，`Navigator` / `Database` / 自訂 tab **維持原樣不動**
+> （spec 驗收條件 4：不顯示 badge）。
+> `find.text('Console')` 仍會命中（`Text('Console')` 仍在樹中），既有斷言安全。
+
+---
+
+## 三、檔案異動清單
+
+### 修改
+
+| 檔案 | 異動要點 |
+|---|---|
+| `lib/src/core/ring_buffer.dart` | 建構式加 optional named `this.onMutate`：`RingBuffer(this.capacity, {this.onMutate})`。新增欄位 `final VoidCallback? onMutate;`（需 `import 'package:flutter/foundation.dart';` 取得 `VoidCallback`）。在 `add` 尾端、`replace` 成功回傳前、`clear` 尾端各加 `onMutate?.call();`。**`replace` 回傳 `false` 的路徑不呼叫**（buffer 沒變就不該通知）。文件註解說明此鉤子的用途與「這是資料變動的唯一路徑」的邊界。 |
+| `lib/src/inspectors/log_inspector.dart` | 建構式加 `VoidCallback? onMutate`，轉傳給 `RingBuffer(bufferSize, onMutate: onMutate)`。 |
+| `lib/src/inspectors/network_inspector.dart` | 同上（`bufferCapacity`）。**`onAdd` 欄位與 `add` 尾端的 `onAdd?.call` 一行不動。** |
+| `lib/src/inspectors/navigator_inspector.dart` | 同上。 |
+| `lib/src/inspectors/database_inspector.dart` | 同上。 |
+| `lib/src/core/inspector_registry.dart` | 新增私有 `final ValueNotifier<int> _revision = ValueNotifier(0);`；公開唯讀 `ValueListenable<int> get revision => _revision;`；私有方法 `void _bump() => _revision.value++;`。建構式改為 body 形式（因為 `_bump` 需在四個 inspector 建構前可用——用 tear-off `_bump` 即可，Dart 允許在初始化列表引用 instance method tear-off？**不允許**，故建構式改成一般 body：先宣告四個 `late final` inspector 欄位，在 body 內 `log = LogInspector(bufferSize: bufferSize, onMutate: _bump);` …）。詳見任務 3 的實作註記。 |
+| `lib/src/ui/dashboard/dashboard_modal.dart` | `_DashboardTabBar` 由 `StatelessWidget` 改為 `StatefulWidget`，新增 `inspector` 欄位；`initState` 中 `widget.inspector.registry.revision.addListener(_onRevisionChanged)`，`dispose` 中 `removeListener`；`_onRevisionChanged` 為 `setState(() {})`。`build` 內重算兩個 count，Console / Network 兩個 `Tab` 改用 `child: Badge(...)`。`DashboardModal` **維持 `StatelessWidget`**（見下方 §四.2）。新增 `_TabLabel`（或直接內嵌）獨立 widget 承載 badge。 |
+
+### 新增
+
+| 檔案 | 用途 |
+|---|---|
+| `test/ui/dashboard_error_badge_test.dart` | 驗收條件 8–13 的 widget test（6 個案例）。 |
+| `test/core/inspector_registry_revision_test.dart` | 驗收條件 14–15 的 unit test。 |
+
+### 不動
+
+- `test/core/ring_buffer_test.dart`（13 項，optional 參數保證零改動通過）
+- `test/ui/dashboard_modal_test.dart`（4 項，驗收條件 11 要求維持通過）
+- `test/inspectors/network_inspector_test.dart`（10 項，含 2 項 `onAdd`）
+- `lib/src/core/flutter_inspector.dart`（**完全不改**——`clearXxx()` 走 `_registry.X.clear()` → `RingBuffer.clear` → 自動通知；`_initNetworkNotifier` 不受影響）
+- 四個 tab 的 `_refresh()` 手動更新行為
+
+---
+
+## 四、記憶體洩漏：訂閱責任歸屬
+
+Spec 風險項明列此點。責任分配如下：
+
+### 4.1 訂閱方：`_DashboardTabBar`（唯一）
+
+- **只有 `_DashboardTabBar` 訂閱**，因為只有它需要 badge。
+- `initState` → `addListener(_onRevisionChanged)`
+- `dispose` → `removeListener(_onRevisionChanged)`（**必須在 `super.dispose()` 之前**，
+  符合 `.claude/rules/flutter-styles.md` §7.4 資源管理紀律）
+- 監聽的 callback 用**具名方法**而非 inline closure，否則 `removeListener` 因物件不等而移除失敗
+  ——這是本次最容易寫錯、且靜默失敗的一點，實作時必須用 `_onRevisionChanged` 具名 tear-off。
+
+### 4.2 被訂閱方：`InspectorRegistry._revision`（永不 dispose）
+
+- `FlutterInspector` 是 app 全域長生命週期物件，其 `_registry` 與 `_revision` 隨行程存活。
+- **刻意不呼叫 `_revision.dispose()`**：`FlutterInspector` 沒有 dispose 生命週期
+  （`detach()` 只卸載 overlay 與 lifecycle observer，物件本身仍可繼續使用並重新 `attach`）。
+  dispose 一個之後還會被 `addListener` 的 notifier 會直接拋錯。
+  需在程式碼註解明示：**「此 notifier 與 inspector 同生命週期，故意不 dispose；
+  洩漏防護由訂閱端（`_DashboardTabBar.dispose`）的 `removeListener` 負責」**。
+- 洩漏方向確認：`ValueNotifier` 持有 listener closure → closure 持有 `_DashboardTabBarState`。
+  只要 `removeListener` 有執行，強引用即斷開，dashboard 關閉後無殘留。
+
+### 4.3 為何 `DashboardModal` 維持 `StatelessWidget`
+
+`DashboardModal` 本身不讀 revision，只把 `inspector` 往下傳（它早已這麼做）。
+把它改成 Stateful 只是為了「持有一個它不用的訂閱」，屬無謂改動，且會擴大既有測試的風險面。
+**訂閱下沉到真正需要它的 `_DashboardTabBar`**，是最小且最正確的位置。
+
+---
+
+## 五、任務拆分
+
+複雜度標註：`快/便宜`（1–2 檔、機械性）／`標準`（多檔整合）／`最強推論`（設計判斷、跨層）
+
+---
+
+### T1 — `RingBuffer` 加 `onMutate` 鉤子（TDD）
+
+- **目標**：讓 `RingBuffer` 在 `add` / `replace`(成功) / `clear` 後呼叫可選回呼。
+- **寫入 scope**：`lib/src/core/ring_buffer.dart`、`test/core/ring_buffer_test.dart`（**僅追加**新 group，不動既有 13 項）
+- **複雜度**：`快/便宜`
+- **步驟**：
+  1. 先在 `test/core/ring_buffer_test.dart` 追加 group `'RingBuffer onMutate'`，4 個案例：
+     `add 觸發`、`clear 觸發`、`replace 成功時觸發`、`replace 失敗時不觸發`。跑測試確認紅燈。
+  2. 實作：建構式簽章 `RingBuffer(this.capacity, {this.onMutate})`，
+     欄位 `final VoidCallback? onMutate;`，三處呼叫點。綠燈。
+- **驗收**：新 4 案例通過；既有 13 案例零改動全通過。
+- **依賴**：無（起點）
+
+---
+
+### T2 — 四個 inspector 轉傳 `onMutate`（TDD）
+
+- **目標**：四個 inspector 建構式接受 `VoidCallback? onMutate` 並轉傳給各自 buffer。
+- **寫入 scope**：`lib/src/inspectors/log_inspector.dart`、`network_inspector.dart`、
+  `navigator_inspector.dart`、`database_inspector.dart`
+- **複雜度**：`快/便宜`（機械性，四個檔案同一個改法）
+- **步驟**：
+  1. 在 `test/inspectors/network_inspector_test.dart` 追加 1 案例：
+     `'onMutate and onAdd both fire independently'`——同時設 `onAdd` 與傳入 `onMutate`，
+     `add` 一筆後兩者皆收到通知。此即 spec 驗收條件 15 的 inspector 層版本。
+  2. 四個檔案各改建構式一行。
+- **驗收**：新案例通過；`network_inspector_test.dart` 既有 10 項（含 2 項 `onAdd`）全通過；
+  四個 inspector 既有測試全通過。
+- **依賴**：**必須在 T1 之後**（依賴 `RingBuffer` 的新簽章）
+
+---
+
+### T3 — `InspectorRegistry` 持有 revision notifier（TDD）
+
+- **目標**：registry 建立單一 `ValueNotifier<int>`，四個 inspector 的任何變動都令其遞增。
+- **寫入 scope**：`lib/src/core/inspector_registry.dart`、
+  **新增** `test/core/inspector_registry_revision_test.dart`
+- **複雜度**：`最強推論`（跨層接線 + 建構式初始化順序的 Dart 限制）
+- **實作註記（關鍵）**：
+  Dart **不允許**在建構式初始化列表（`:` 之後）引用 `this` 的 instance method tear-off。
+  現況四個 inspector 是在初始化列表中建立的，必須改寫。兩種寫法擇一，**推薦後者**：
+  - (a) 四個欄位改 `late final`，建構式改為 body 形式。
+  - (b) **推薦**：`_revision` 宣告為 `final ValueNotifier<int> _revision = ValueNotifier(0);`
+    （欄位初始化器，在初始化列表前完成），初始化列表中傳入 closure
+    `onMutate: () => _revision.value++`——但 closure 捕獲 `this` 同樣不被允許。
+    **故實際採 (a)**：四個欄位 `late final`，建構式 body 內建立四個 inspector 並傳 `onMutate: _bump`。
+
+  最終形式（signature 層級）：
+  ```dart
+  class InspectorRegistry {
+    InspectorRegistry({int bufferSize = 500}) {
+      log = LogInspector(bufferSize: bufferSize, onMutate: _bump);
+      network = NetworkInspector(bufferCapacity: bufferSize, onMutate: _bump);
+      navigator = NavigatorInspector(bufferCapacity: bufferSize, onMutate: _bump);
+      database = DatabaseInspector(bufferCapacity: bufferSize, onMutate: _bump);
+    }
+
+    late final LogInspector log;
+    late final NetworkInspector network;
+    late final NavigatorInspector navigator;
+    late final DatabaseInspector database;
+
+    final ValueNotifier<int> _revision = ValueNotifier<int>(0);
+
+    /// Bumped on every mutation of any of the four buffers. Read-only to callers.
+    ValueListenable<int> get revision => _revision;
+
+    void _bump() => _revision.value++;
+  }
+  ```
+  註解需寫明：此 notifier 與 inspector 同生命週期，故意不 dispose（見 §四.2）。
+- **驗收**：對應 spec 驗收條件 **14**、**15**。
+- **依賴**：**必須在 T2 之後**
+
+---
+
+### T4 — `_DashboardTabBar` 改 Stateful 並訂閱 revision
+
+- **目標**：TabBar 訂閱 revision、正確解除訂閱，且不改變現有渲染結果。
+- **寫入 scope**：`lib/src/ui/dashboard/dashboard_modal.dart`
+- **複雜度**：`標準`
+- **步驟**：
+  1. `_DashboardTabBar` → `StatefulWidget`，新增 `final FlutterInspector inspector;`。
+  2. `DashboardModal.build` 傳入 `inspector: inspector`。
+  3. `initState` / `dispose` 接線（具名 `_onRevisionChanged`，`removeListener` 在 `super.dispose()` 前）。
+  4. **此步驟先不加 badge**——tabs 內容維持原樣。
+- **驗收**：`test/ui/dashboard_modal_test.dart` 4 項全通過（`Tab` 數量與文字皆未變）。
+  這是刻意的中繼檢查點：先證明「改 Stateful + 訂閱」本身零破壞，再疊 badge。
+- **依賴**：**必須在 T3 之後**（依賴 `registry.revision`）
+
+---
+
+### T5 — Badge 渲染（TDD）
+
+- **目標**：Console / Network 兩個 tab 依 count 顯示 badge。
+- **寫入 scope**：`lib/src/ui/dashboard/dashboard_modal.dart`、
+  **新增** `test/ui/dashboard_error_badge_test.dart`
+- **複雜度**：`標準`
+- **步驟**：
+  1. 先寫 `test/ui/dashboard_error_badge_test.dart` 的 6 個案例（見 §六），紅燈。
+  2. `_DashboardTabBarState.build` 內計算兩個 count（公式見 §1.4）。
+  3. Console / Network 的 `Tab` 改為：
+     ```dart
+     Tab(
+       child: Badge(
+         isLabelVisible: consoleErrorCount > 0,
+         label: Text('$consoleErrorCount'),
+         child: const Text('Console'),
+       ),
+     )
+     ```
+     `Navigator` / `Database` / 自訂 tab 完全不動（維持 `const Tab(text: ...)`）。
+  4. 依 `.claude/rules/flutter-styles.md` §7.1，若 badge 包裝出現重複，
+     提取為獨立類別 `_BadgeTabLabel extends StatelessWidget`（**不可用 helper method**）。
+     兩處重複即達提取門檻，建議直接提取。
+  5. 在 `_DashboardTabBar` 的 class 註解寫明 spec 的「兩套更新模型並存」邊界：
+     badge 即時、tab 內列表維持手動 refresh，這是刻意取捨，勿據此把整個 dashboard 改成 reactive。
+- **驗收**：對應 spec 驗收條件 **1、2、3、4、8、9、10、11、12、13**。
+- **依賴**：**必須在 T4 之後**
+
+---
+
+### T6 — 全套驗證
+
+- **目標**：確認零破壞。
+- **寫入 scope**：無（唯讀）
+- **複雜度**：`快/便宜`
+- **步驟**：
+  1. `rtk flutter analyze`（須零 issue）
+  2. `dart format --set-exit-if-changed lib/ test/`
+  3. `rtk flutter test`
+     - ⚠️ **`test/ui/magical_tap_test.dart` 有既知的 10 分鐘 timeout**，全套執行前先確認是否要排除。
+  4. 逐項對照 spec 驗收條件 1–15 打勾。
+- **依賴**：**必須在 T5 之後**
+
+---
+
+### 並行性總結
+
+**全部 6 個任務為嚴格序列鏈：T1 → T2 → T3 → T4 → T5 → T6。**
+
+不存在可並行的分支。原因：這是一條由下而上的單一垂直切片
+（`RingBuffer` → inspector → registry → widget → 測試），每一層的簽章都是下一層的前提。
+硬拆並行只會製造 merge 衝突與 stub 成本，不划算。
+
+唯一的「內部並行」機會在 **T2**：四個 inspector 檔案彼此獨立，
+可用單次多檔編輯一併完成，但它們同屬一個任務、無需分派給不同 session。
+
+**執行方式建議**：
+- **subagent-driven（推薦）**：任務鏈短（6 步）、序列、單一垂直切片，
+  由單一 implementer 一路做完最省協調成本。T4 是天然的中繼驗證點。
+- **parallel session**：**不建議**。無獨立分支可切，並行只會增加同檔衝突。
+
+---
+
+## 六、測試計畫
+
+### 6.1 `test/core/ring_buffer_test.dart`（追加 group，T1）
+
+| 案例名稱 | 內容 |
+|---|---|
+| `'onMutate fires on add'` | 傳入計數 closure，`add` 兩次 → 計數為 2 |
+| `'onMutate fires on clear'` | `add` 後 `clear` → 計數含 clear 那次 |
+| `'onMutate fires on successful replace'` | `replace` 命中 → 計數 +1 |
+| `'onMutate does not fire when replace misses'` | `replace` 未命中（回傳 false）→ 計數不變 |
+
+### 6.2 `test/inspectors/network_inspector_test.dart`（追加 1 案例，T2）
+
+| 案例名稱 | 對應驗收條件 |
+|---|---|
+| `'onMutate and onAdd both fire independently'` | **15**（inspector 層）——同時設 `onAdd` 與 `onMutate`，`add` 一筆後兩者皆被呼叫，證明 badge 機制未搶佔 `onAdd` |
+
+### 6.3 `test/core/inspector_registry_revision_test.dart`（新檔，T3）
+
+group `'InspectorRegistry revision'`：
+
+| 案例名稱 | 對應驗收條件 |
+|---|---|
+| `'revision starts at 0'` | — |
+| `'revision bumps on log add'` | 14 |
+| `'revision bumps on network add'` | 14 |
+| `'revision bumps on navigator add'` | 14 |
+| `'revision bumps on database add'` | 14 |
+| `'revision bumps on each of the four clears'` | 14（一個案例涵蓋四種 clear，逐次斷言遞增） |
+| `'revision bumps on network replace'` | 14 延伸（pending → completed 路徑，(丙) 方案的關鍵優勢） |
+| `'badge notification does not steal NetworkInspector.onAdd'` | **15**（registry 層）——在 registry 的 network inspector 上設 `onAdd`，`add` 一筆後 `onAdd` 與 `revision` 兩者皆生效 |
+
+測資依 `.claude/rules/flutter-styles.md` §8.2，若需共用 entry 樣本則放同檔的 `_Data` 類別；
+本檔測資極簡（單筆 `NetworkEntry(method: 'GET', url: '/1')` 之類），可直接內嵌。
+
+### 6.4 `test/ui/dashboard_error_badge_test.dart`（新檔，T5）
+
+group `'DashboardModal error badges'`：
+
+| 案例名稱 | 對應驗收條件 | 要點 |
+|---|---|---|
+| `'Network tab shows 2 when two entries failed'` | **8** | 注入 2 筆 `isFailed`（如 `statusCode: 500`）+ 若干成功 → `find.text('2')` 命中；且 `find.byType(Tab)` 仍為 4 |
+| `'Network tab shows no badge when all requests succeeded'` | **9** | 全 `statusCode: 200` → 無 badge。斷言用 `find.byType(Badge)` 搭配 `isLabelVisible` 的效果：改以「找不到數字文字」+ `Badge` 不渲染 label 來驗證 |
+| `'Console tab shows 2 for one error and one warning'` | **10** | 1 error + 1 warning + 3 info → 顯示 `2`（證明 info 不計入） |
+| `'empty inspector renders no badges on either tab'` | **11** | `FlutterInspector()` 空實例 → 兩個 tab 皆無 badge |
+| `'badge appears without any refresh when a failed request arrives'` | **12** ⭐ | **核心案例**：先 `pumpWidget` 渲染完成（此時無 badge）→ 直接 `inspector.logNetwork(NetworkEntry(..., statusCode: 500))` → `await tester.pump()` → `find.text('1')` 命中。**全程不觸發任何 refresh 按鈕**。這是路線 (C) 相對 (A)/(B) 的唯一差異證明 |
+| `'badge disappears after the buffer is cleared'` | **13** | 有 badge 狀態 → `inspector.clearNetwork()` → `pump()` → badge 消失 |
+
+**驗收條件 11 的後半**（既有 4 項斷言維持通過）由 T4/T6 直接執行
+`test/ui/dashboard_modal_test.dart` 驗證，**不重複實作**。
+
+**Badge 存在性斷言技巧**：`Badge` 在 `isLabelVisible: false` 時仍是樹中的一個 `Badge` widget
+（它 build 出 `child`），所以 `find.byType(Badge)` **不能**用來判斷「有沒有 badge」。
+正確斷言方式是找 badge 的數字文字（`find.text('2')`），
+或用 `tester.widget<Badge>(...).isLabelVisible` 直接讀旗標。測試中採前者為主、後者為輔。
+
+---
+
+## 七、風險與回退
+
+| # | 風險 | 機率 | 徵兆 | 對策／回退 |
+|---|---|---|---|---|
+| R1 | **T3 建構式初始化順序**：`_bump` 是 instance method，不能在初始化列表引用 | 高（已預見） | 編譯錯誤 `Can't access 'this' in a field initializer` | 已在 T3 給出解法（四個欄位改 `late final` + 建構式 body）。若 `late final` 造成其他問題，退回方案：`_revision` 改為 `static`? **不可**（會跨實例污染）；改用 `_bump` 包成獨立的頂層閉包持有 registry 參考亦可，但 `late final` 是最笨最清楚的做法 |
+| R2 | **`removeListener` 靜默失敗** | 中 | 無編譯錯誤、無測試失敗，但 dashboard 反覆開關後累積 listener | 強制使用**具名方法 tear-off**（`_onRevisionChanged`），禁止 inline closure。可在 T5 追加一個測試：pump dashboard → pumpWidget 換成空白 widget → 觸發 `inspector.log(...)` → 確認不拋 `setState called after dispose` |
+| R3 | **`Tab` 的 `text` 與 `child` 互斥** | 中 | assert 失敗 | 已在 §二標註。改用 `child:` 時必須移除 `text:` |
+| R4 | **既有 `dashboard_modal_test.dart` 的 `Tab` 計數失敗** | 低 | `findsNWidgets(4)` 失敗 | T4 已設為中繼驗證點——先只改 Stateful 不加 badge 並跑該測試，把「改結構」與「加 badge」兩個風險源分開。若 T5 後才失敗，即可斷定是 badge 包裝方式錯誤（增生了 `Tab`），改回包 child |
+| R5 | **通知風暴掉幀** | 低 | 高頻 log 時 dashboard 卡頓 | Spec 明示「現階段不預先優化」。若實測有問題，最小介入是在 `_onRevisionChanged` 加一個 frame 級去抖（`SchedulerBinding.instance.addPostFrameCallback` 合併），**不改資料層** |
+| R6 | **`ring_buffer_test.dart` 意外需要改動** | 極低 | 既有 13 項紅燈 | optional named 參數保證不會發生。若真發生，代表簽章寫成了 positional required——立即改回 optional named |
+
+**最可能出錯的一步：T3**（R1 已預見且已給解法）。
+**破壞面最大的一步：T5**（動到既有測試覆蓋的 widget 樹）——用 T4 的中繼驗證點隔離風險。
+
+**整體回退成本**：本次改動全為加法（optional 參數、新欄位、新測試檔），
+唯一的結構改動是 `_DashboardTabBar` Stateless → Stateful 與兩個 `Tab` 的 `text:` → `child:`。
+任一步失敗都可單獨 `git revert` 該 commit 而不影響前序任務，故建議 **T1–T5 各自獨立 commit**。

--- a/lib/src/core/inspector_registry.dart
+++ b/lib/src/core/inspector_registry.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../inspectors/database_inspector.dart';
 import '../inspectors/log_inspector.dart';
 import '../inspectors/navigator_inspector.dart';
@@ -7,23 +9,39 @@ import '../models/timestamped_entry.dart';
 /// Internal registry holding instances of the four fixed inspectors.
 class InspectorRegistry {
   /// Creates a registry with inspectors initialized to the given [bufferSize].
-  InspectorRegistry({int bufferSize = 500})
-    : log = LogInspector(bufferSize: bufferSize),
-      network = NetworkInspector(bufferCapacity: bufferSize),
-      navigator = NavigatorInspector(bufferCapacity: bufferSize),
-      database = DatabaseInspector(bufferCapacity: bufferSize);
+  ///
+  /// Each inspector's [onMutate] is wired to [_bump], so [revision] increments
+  /// on every mutation of any of the four buffers.
+  InspectorRegistry({int bufferSize = 500}) {
+    log = LogInspector(bufferSize: bufferSize, onMutate: _bump);
+    network = NetworkInspector(bufferCapacity: bufferSize, onMutate: _bump);
+    navigator = NavigatorInspector(bufferCapacity: bufferSize, onMutate: _bump);
+    database = DatabaseInspector(bufferCapacity: bufferSize, onMutate: _bump);
+  }
 
   /// Inspector for console logs.
-  final LogInspector log;
+  late final LogInspector log;
 
   /// Inspector for network requests.
-  final NetworkInspector network;
+  late final NetworkInspector network;
 
   /// Inspector for navigation events.
-  final NavigatorInspector navigator;
+  late final NavigatorInspector navigator;
 
   /// Inspector for database operations.
-  final DatabaseInspector database;
+  late final DatabaseInspector database;
+
+  // Not disposed: this registry (and the inspector that owns it) is a
+  // long-lived, app-scoped object with no dispose lifecycle. Leak protection
+  // is the subscriber's responsibility (see _DashboardTabBar.dispose).
+  final ValueNotifier<int> _revision = ValueNotifier<int>(0);
+
+  /// Bumped on every mutation of any of the four buffers (add, successful
+  /// replace, or clear). Read-only to callers; not part of the package's
+  /// public API surface.
+  ValueListenable<int> get revision => _revision;
+
+  void _bump() => _revision.value++;
 
   /// Merges the four buffers into a single timeline, filtered by [sources] and
   /// sorted by [TimestampedEntry.timestamp] descending (newest first).

--- a/lib/src/core/ring_buffer.dart
+++ b/lib/src/core/ring_buffer.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 /// A fixed-capacity FIFO buffer.
 ///
 /// When [length] reaches [capacity], adding a new item evicts the oldest one.
@@ -9,11 +11,18 @@
 class RingBuffer<T> {
   /// Creates a ring buffer holding at most [capacity] items.
   ///
-  /// [capacity] must be greater than zero.
-  RingBuffer(this.capacity) : assert(capacity > 0, 'capacity must be > 0');
+  /// [capacity] must be greater than zero. [onMutate], if given, is invoked
+  /// after every mutation ([add], a successful [replace], or [clear]) — this
+  /// is the single choke point all buffer writes pass through, regardless of
+  /// which inspector owns the buffer.
+  RingBuffer(this.capacity, {this.onMutate})
+    : assert(capacity > 0, 'capacity must be > 0');
 
   /// Maximum number of retained items.
   final int capacity;
+
+  /// Invoked after every mutation. See constructor doc.
+  final VoidCallback? onMutate;
 
   // Oldest item first, newest last.
   final List<T> _items = <T>[];
@@ -26,6 +35,7 @@ class RingBuffer<T> {
     }
     _items.add(item);
     _cachedItems = null;
+    onMutate?.call();
   }
 
   /// Replaces the first occurrence of [oldItem] (by `==`) with [newItem],
@@ -36,6 +46,7 @@ class RingBuffer<T> {
     if (index < 0) return false;
     _items[index] = newItem;
     _cachedItems = null;
+    onMutate?.call();
     return true;
   }
 
@@ -49,6 +60,7 @@ class RingBuffer<T> {
   void clear() {
     _items.clear();
     _cachedItems = null;
+    onMutate?.call();
   }
 
   /// The current number of buffered items.

--- a/lib/src/core/ring_buffer.dart
+++ b/lib/src/core/ring_buffer.dart
@@ -22,6 +22,9 @@ class RingBuffer<T> {
   final int capacity;
 
   /// Invoked after every mutation. See constructor doc.
+  ///
+  /// Must not call [add], [replace], or [clear] on this same buffer —
+  /// doing so re-enters the mutation that is still on the call stack.
   final VoidCallback? onMutate;
 
   // Oldest item first, newest last.

--- a/lib/src/inspectors/database_inspector.dart
+++ b/lib/src/inspectors/database_inspector.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../core/ring_buffer.dart';
 import '../models/database_entry.dart';
 import '../models/database_operation.dart';
@@ -5,8 +7,9 @@ import '../models/database_operation.dart';
 /// Manages a ring buffer of [DatabaseEntry] items.
 class DatabaseInspector {
   /// Creates a database inspector with the given [bufferCapacity].
-  DatabaseInspector({int bufferCapacity = 500})
-    : _buffer = RingBuffer<DatabaseEntry>(bufferCapacity);
+  /// [onMutate], if given, is forwarded to the underlying [RingBuffer].
+  DatabaseInspector({int bufferCapacity = 500, VoidCallback? onMutate})
+    : _buffer = RingBuffer<DatabaseEntry>(bufferCapacity, onMutate: onMutate);
 
   final RingBuffer<DatabaseEntry> _buffer;
 

--- a/lib/src/inspectors/log_inspector.dart
+++ b/lib/src/inspectors/log_inspector.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../core/ring_buffer.dart';
 import '../models/log_entry.dart';
 import '../models/log_level.dart';
@@ -5,8 +7,9 @@ import '../models/log_level.dart';
 /// Stores console log entries in a bounded buffer for the Console tab.
 class LogInspector {
   /// Creates a log inspector retaining at most [bufferSize] entries.
-  LogInspector({int bufferSize = 500})
-    : _buffer = RingBuffer<LogEntry>(bufferSize);
+  /// [onMutate], if given, is forwarded to the underlying [RingBuffer].
+  LogInspector({int bufferSize = 500, VoidCallback? onMutate})
+    : _buffer = RingBuffer<LogEntry>(bufferSize, onMutate: onMutate);
 
   final RingBuffer<LogEntry> _buffer;
 

--- a/lib/src/inspectors/navigator_inspector.dart
+++ b/lib/src/inspectors/navigator_inspector.dart
@@ -1,11 +1,14 @@
+import 'package:flutter/foundation.dart';
+
 import '../core/ring_buffer.dart';
 import '../models/navigator_entry.dart';
 
 /// Manages a ring buffer of [NavigatorEntry] items.
 class NavigatorInspector {
   /// Creates a navigator inspector with the given [bufferCapacity].
-  NavigatorInspector({int bufferCapacity = 500})
-    : _buffer = RingBuffer<NavigatorEntry>(bufferCapacity);
+  /// [onMutate], if given, is forwarded to the underlying [RingBuffer].
+  NavigatorInspector({int bufferCapacity = 500, VoidCallback? onMutate})
+    : _buffer = RingBuffer<NavigatorEntry>(bufferCapacity, onMutate: onMutate);
 
   final RingBuffer<NavigatorEntry> _buffer;
 

--- a/lib/src/inspectors/network_inspector.dart
+++ b/lib/src/inspectors/network_inspector.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../core/ring_buffer.dart';
 import '../models/network_entry.dart';
 
@@ -8,8 +10,9 @@ typedef NetworkAddListener = void Function(NetworkEntry entry, int totalCount);
 /// Manages a ring buffer of [NetworkEntry] items.
 class NetworkInspector {
   /// Creates a network inspector with the given [bufferCapacity].
-  NetworkInspector({int bufferCapacity = 500})
-    : _buffer = RingBuffer<NetworkEntry>(bufferCapacity);
+  /// [onMutate], if given, is forwarded to the underlying [RingBuffer].
+  NetworkInspector({int bufferCapacity = 500, VoidCallback? onMutate})
+    : _buffer = RingBuffer<NetworkEntry>(bufferCapacity, onMutate: onMutate);
 
   final RingBuffer<NetworkEntry> _buffer;
 

--- a/lib/src/ui/dashboard/dashboard_modal.dart
+++ b/lib/src/ui/dashboard/dashboard_modal.dart
@@ -119,6 +119,16 @@ class _DashboardTabBarState extends State<_DashboardTabBar> {
   }
 
   @override
+  void didUpdateWidget(covariant _DashboardTabBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.inspector == oldWidget.inspector) return;
+    // ignore: invalid_use_of_visible_for_testing_member
+    oldWidget.inspector.registry.revision.removeListener(_onRevisionChanged);
+    // ignore: invalid_use_of_visible_for_testing_member
+    widget.inspector.registry.revision.addListener(_onRevisionChanged);
+  }
+
+  @override
   void dispose() {
     // ignore: invalid_use_of_visible_for_testing_member
     widget.inspector.registry.revision.removeListener(_onRevisionChanged);

--- a/lib/src/ui/dashboard/dashboard_modal.dart
+++ b/lib/src/ui/dashboard/dashboard_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/flutter_inspector.dart';
+import '../../models/log_level.dart';
 import '../../observers/inspector_route_names.dart';
 import 'export_report_sheet.dart';
 import 'tabs/console_tab.dart';
@@ -128,16 +129,50 @@ class _DashboardTabBarState extends State<_DashboardTabBar> {
 
   @override
   Widget build(BuildContext context) {
+    // Network count must reuse NetworkEntry.isFailed — the single source of
+    // truth for "did this call fail" shared with the error-summary banner,
+    // the console timeline and the diagnostic report.
+    final networkErrorCount = widget.inspector.networkEntries
+        .where((e) => e.isFailed)
+        .length;
+    // Console counts only log-level error/warning, not failed network calls
+    // surfaced in the merged timeline — those are already counted by the
+    // Network badge, and double-counting would make the two numbers lie.
+    final consoleErrorCount =
+        widget.inspector.logInspector.entriesAtLevel(LogLevel.error).length +
+        widget.inspector.logInspector.entriesAtLevel(LogLevel.warning).length;
+
     return TabBar(
       isScrollable: true,
       tabAlignment: TabAlignment.start,
       tabs: [
-        const Tab(text: 'Console'),
-        const Tab(text: 'Network'),
+        Tab(
+          child: _BadgeTabLabel(count: consoleErrorCount, label: 'Console'),
+        ),
+        Tab(
+          child: _BadgeTabLabel(count: networkErrorCount, label: 'Network'),
+        ),
         const Tab(text: 'Navigator'),
         const Tab(text: 'Database'),
         if (widget.hasCustomTab) Tab(text: widget.customTabTitle ?? 'Custom'),
       ],
+    );
+  }
+}
+
+/// A tab label with an error-count badge, hidden when [count] is zero.
+class _BadgeTabLabel extends StatelessWidget {
+  const _BadgeTabLabel({required this.count, required this.label});
+
+  final int count;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Badge(
+      isLabelVisible: count > 0,
+      label: Text('$count'),
+      child: Text(label),
     );
   }
 }

--- a/lib/src/ui/dashboard/dashboard_modal.dart
+++ b/lib/src/ui/dashboard/dashboard_modal.dart
@@ -62,6 +62,7 @@ class DashboardModal extends StatelessWidget {
           bottom: PreferredSize(
             preferredSize: const Size.fromHeight(kTextTabBarHeight),
             child: _DashboardTabBar(
+              inspector: inspector,
               hasCustomTab: hasCustomTab,
               customTabTitle: inspector.customTabTitle,
             ),
@@ -81,11 +82,49 @@ class DashboardModal extends StatelessWidget {
   }
 }
 
-class _DashboardTabBar extends StatelessWidget {
-  const _DashboardTabBar({required this.hasCustomTab, this.customTabTitle});
+/// The dashboard's TabBar. Subscribes to [FlutterInspector.registry]'s
+/// revision notifier so the Console/Network error badges update live while
+/// the dashboard is open.
+///
+/// This is the *only* reactive piece of the dashboard: each tab's own list
+/// still refreshes manually (see the tab widgets' refresh buttons). That
+/// split is intentional — a list mid-scroll must not be reflowed underneath
+/// the user, but a summary badge should never lie. Do not extend this
+/// notifier to drive tab list rebuilds.
+class _DashboardTabBar extends StatefulWidget {
+  const _DashboardTabBar({
+    required this.inspector,
+    required this.hasCustomTab,
+    this.customTabTitle,
+  });
 
+  final FlutterInspector inspector;
   final bool hasCustomTab;
   final String? customTabTitle;
+
+  @override
+  State<_DashboardTabBar> createState() => _DashboardTabBarState();
+}
+
+class _DashboardTabBarState extends State<_DashboardTabBar> {
+  @override
+  void initState() {
+    super.initState();
+    // FlutterInspector.registry is @visibleForTesting because it exposes the
+    // full InspectorRegistry surface; revision itself is intentionally not
+    // public API (see feature spec). This is the one non-test call site.
+    // ignore: invalid_use_of_visible_for_testing_member
+    widget.inspector.registry.revision.addListener(_onRevisionChanged);
+  }
+
+  @override
+  void dispose() {
+    // ignore: invalid_use_of_visible_for_testing_member
+    widget.inspector.registry.revision.removeListener(_onRevisionChanged);
+    super.dispose();
+  }
+
+  void _onRevisionChanged() => setState(() {});
 
   @override
   Widget build(BuildContext context) {
@@ -97,7 +136,7 @@ class _DashboardTabBar extends StatelessWidget {
         const Tab(text: 'Network'),
         const Tab(text: 'Navigator'),
         const Tab(text: 'Database'),
-        if (hasCustomTab) Tab(text: customTabTitle ?? 'Custom'),
+        if (widget.hasCustomTab) Tab(text: widget.customTabTitle ?? 'Custom'),
       ],
     );
   }

--- a/test/core/inspector_registry_revision_test.dart
+++ b/test/core/inspector_registry_revision_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_inspector_kit/src/core/inspector_registry.dart';
+import 'package:flutter_inspector_kit/src/models/database_entry.dart';
+import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
+import 'package:flutter_inspector_kit/src/models/network_entry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('InspectorRegistry revision', () {
+    test('revision starts at 0', () {
+      final registry = InspectorRegistry();
+      expect(registry.revision.value, 0);
+    });
+
+    test('revision bumps on log add', () {
+      final registry = InspectorRegistry();
+      registry.log.add(LogEntry(message: 'hi', level: LogLevel.info));
+      expect(registry.revision.value, 1);
+    });
+
+    test('revision bumps on network add', () {
+      final registry = InspectorRegistry();
+      registry.network.add(NetworkEntry(method: 'GET', url: '/1'));
+      expect(registry.revision.value, 1);
+    });
+
+    test('revision bumps on navigator add', () {
+      final registry = InspectorRegistry();
+      registry.navigator.add(
+        NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
+      );
+      expect(registry.revision.value, 1);
+    });
+
+    test('revision bumps on database add', () {
+      final registry = InspectorRegistry();
+      registry.database.add(
+        DatabaseEntry(operation: DatabaseOperation.insert, tableName: 'users'),
+      );
+      expect(registry.revision.value, 1);
+    });
+
+    test('revision bumps on each of the four clears', () {
+      final registry = InspectorRegistry()
+        ..log.add(LogEntry(message: 'hi', level: LogLevel.info))
+        ..network.add(NetworkEntry(method: 'GET', url: '/1'))
+        ..navigator.add(
+          NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
+        )
+        ..database.add(
+          DatabaseEntry(
+            operation: DatabaseOperation.insert,
+            tableName: 'users',
+          ),
+        );
+      expect(registry.revision.value, 4);
+
+      registry.log.clear();
+      expect(registry.revision.value, 5);
+      registry.network.clear();
+      expect(registry.revision.value, 6);
+      registry.navigator.clear();
+      expect(registry.revision.value, 7);
+      registry.database.clear();
+      expect(registry.revision.value, 8);
+    });
+
+    test('revision bumps on network replace', () {
+      final registry = InspectorRegistry();
+      final pending = registry.network.add(
+        NetworkEntry(method: 'GET', url: '/1'),
+      );
+      expect(registry.revision.value, 1);
+
+      registry.network.add(
+        NetworkEntry(method: 'GET', url: '/1', statusCode: 200),
+        replaces: pending,
+      );
+      expect(registry.revision.value, 2);
+    });
+
+    test('badge notification does not steal NetworkInspector.onAdd', () {
+      final registry = InspectorRegistry();
+      final addCalls = <String>[];
+      registry.network.onAdd = (entry, total) => addCalls.add(entry.url);
+
+      registry.network.add(NetworkEntry(method: 'GET', url: '/1'));
+
+      expect(addCalls, ['/1']);
+      expect(registry.revision.value, 1);
+    });
+  });
+}

--- a/test/core/ring_buffer_test.dart
+++ b/test/core/ring_buffer_test.dart
@@ -83,4 +83,38 @@ void main() {
       expect(buffer.items, [10]);
     });
   });
+
+  group('RingBuffer onMutate', () {
+    test('onMutate fires on add', () {
+      var count = 0;
+      final buffer = RingBuffer<int>(3, onMutate: () => count++);
+      buffer.add(1);
+      buffer.add(2);
+      expect(count, 2);
+    });
+
+    test('onMutate fires on clear', () {
+      var count = 0;
+      final buffer = RingBuffer<int>(3, onMutate: () => count++)..add(1);
+      count = 0;
+      buffer.clear();
+      expect(count, 1);
+    });
+
+    test('onMutate fires on successful replace', () {
+      var count = 0;
+      final buffer = RingBuffer<int>(3, onMutate: () => count++)..add(1);
+      count = 0;
+      buffer.replace(1, 10);
+      expect(count, 1);
+    });
+
+    test('onMutate does not fire when replace misses', () {
+      var count = 0;
+      final buffer = RingBuffer<int>(3, onMutate: () => count++)..add(1);
+      count = 0;
+      buffer.replace(9, 90);
+      expect(count, 0);
+    });
+  });
 }

--- a/test/inspectors/network_inspector_test.dart
+++ b/test/inspectors/network_inspector_test.dart
@@ -120,5 +120,19 @@ void main() {
 
       expect(calls, [('/1', 1), ('/1', 1)]);
     });
+
+    test('onMutate and onAdd both fire independently', () {
+      var mutateCount = 0;
+      final addCalls = <String>[];
+      final withMutate = NetworkInspector(
+        bufferCapacity: 3,
+        onMutate: () => mutateCount++,
+      )..onAdd = (entry, total) => addCalls.add(entry.url);
+
+      withMutate.add(NetworkEntry(method: 'GET', url: '/1'));
+
+      expect(mutateCount, 1);
+      expect(addCalls, ['/1']);
+    });
   });
 }

--- a/test/ui/dashboard_error_badge_test.dart
+++ b/test/ui/dashboard_error_badge_test.dart
@@ -5,6 +5,18 @@ import 'package:flutter_inspector_kit/src/models/network_entry.dart';
 import 'package:flutter_inspector_kit/src/ui/dashboard/dashboard_modal.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// Locates the [Tab] labelled [tabLabel] and asserts whether [countText]
+/// (the badge number) is nested under it specifically — not just anywhere
+/// in the tree. Without this, a Console/Network badge swap would still
+/// pass a bare `find.text(countText)` assertion.
+Finder _badgeCountUnderTab(String tabLabel, String countText) {
+  final tab = find.ancestor(
+    of: find.text(tabLabel),
+    matching: find.byType(Tab),
+  );
+  return find.descendant(of: tab, matching: find.text(countText));
+}
+
 void main() {
   group('DashboardModal error badges', () {
     testWidgets('Network tab shows 2 when two entries failed', (tester) async {
@@ -21,7 +33,8 @@ void main() {
         MaterialApp(home: DashboardModal(inspector: inspector)),
       );
 
-      expect(find.text('2'), findsOneWidget);
+      expect(_badgeCountUnderTab('Network', '2'), findsOneWidget);
+      expect(_badgeCountUnderTab('Console', '2'), findsNothing);
       expect(find.byType(Tab), findsNWidgets(4));
     });
 
@@ -58,7 +71,8 @@ void main() {
         MaterialApp(home: DashboardModal(inspector: inspector)),
       );
 
-      expect(find.text('2'), findsOneWidget);
+      expect(_badgeCountUnderTab('Console', '2'), findsOneWidget);
+      expect(_badgeCountUnderTab('Network', '2'), findsNothing);
     });
 
     testWidgets('empty inspector renders no badges on either tab', (
@@ -85,14 +99,15 @@ void main() {
           MaterialApp(home: DashboardModal(inspector: inspector)),
         );
 
-        expect(find.text('1'), findsNothing);
+        expect(_badgeCountUnderTab('Network', '1'), findsNothing);
 
         inspector.logNetwork(
           NetworkEntry(method: 'GET', url: '/fail', statusCode: 500),
         );
         await tester.pump();
 
-        expect(find.text('1'), findsOneWidget);
+        expect(_badgeCountUnderTab('Network', '1'), findsOneWidget);
+        expect(_badgeCountUnderTab('Console', '1'), findsNothing);
       },
     );
 
@@ -113,5 +128,44 @@ void main() {
       final badges = tester.widgetList<Badge>(find.byType(Badge));
       expect(badges.every((b) => !b.isLabelVisible), isTrue);
     });
+
+    testWidgets(
+      'rebuilding with a new inspector re-subscribes to its revision',
+      (tester) async {
+        final oldInspector = FlutterInspector();
+        oldInspector.logNetwork(
+          NetworkEntry(method: 'GET', url: '/old-fail', statusCode: 500),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(home: DashboardModal(inspector: oldInspector)),
+        );
+        expect(find.text('1'), findsOneWidget);
+
+        final newInspector = FlutterInspector();
+        // Same widget position/type with no key: State is preserved and
+        // didUpdateWidget fires instead of a fresh initState.
+        await tester.pumpWidget(
+          MaterialApp(home: DashboardModal(inspector: newInspector)),
+        );
+        // The new inspector starts empty, so its badge must be gone.
+        expect(find.text('1'), findsNothing);
+
+        // Mutating the *new* inspector must update the badge...
+        newInspector.logNetwork(
+          NetworkEntry(method: 'GET', url: '/new-fail', statusCode: 500),
+        );
+        await tester.pump();
+        expect(find.text('1'), findsOneWidget);
+
+        // ...while the *old* inspector must no longer be listened to.
+        oldInspector.logNetwork(
+          NetworkEntry(method: 'GET', url: '/old-fail-2', statusCode: 500),
+        );
+        await tester.pump();
+        expect(find.text('1'), findsOneWidget);
+        expect(find.text('2'), findsNothing);
+      },
+    );
   });
 }

--- a/test/ui/dashboard_error_badge_test.dart
+++ b/test/ui/dashboard_error_badge_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/models/network_entry.dart';
+import 'package:flutter_inspector_kit/src/ui/dashboard/dashboard_modal.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DashboardModal error badges', () {
+    testWidgets('Network tab shows 2 when two entries failed', (tester) async {
+      final inspector = FlutterInspector();
+      inspector.logNetwork(NetworkEntry(method: 'GET', url: '/ok'));
+      inspector.logNetwork(
+        NetworkEntry(method: 'GET', url: '/fail1', statusCode: 500),
+      );
+      inspector.logNetwork(
+        NetworkEntry(method: 'GET', url: '/fail2', statusCode: 404),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: DashboardModal(inspector: inspector)),
+      );
+
+      expect(find.text('2'), findsOneWidget);
+      expect(find.byType(Tab), findsNWidgets(4));
+    });
+
+    testWidgets('Network tab shows no badge when all requests succeeded', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      inspector.logNetwork(
+        NetworkEntry(method: 'GET', url: '/ok1', statusCode: 200),
+      );
+      inspector.logNetwork(
+        NetworkEntry(method: 'GET', url: '/ok2', statusCode: 200),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: DashboardModal(inspector: inspector)),
+      );
+
+      final badges = tester.widgetList<Badge>(find.byType(Badge));
+      expect(badges.every((b) => !b.isLabelVisible), isTrue);
+    });
+
+    testWidgets('Console tab shows 2 for one error and one warning', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+      inspector.log('error msg', level: LogLevel.error);
+      inspector.log('warning msg', level: LogLevel.warning);
+      inspector.log('info 1', level: LogLevel.info);
+      inspector.log('info 2', level: LogLevel.info);
+      inspector.log('info 3', level: LogLevel.info);
+
+      await tester.pumpWidget(
+        MaterialApp(home: DashboardModal(inspector: inspector)),
+      );
+
+      expect(find.text('2'), findsOneWidget);
+    });
+
+    testWidgets('empty inspector renders no badges on either tab', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector();
+
+      await tester.pumpWidget(
+        MaterialApp(home: DashboardModal(inspector: inspector)),
+      );
+
+      final badges = tester.widgetList<Badge>(find.byType(Badge));
+      expect(badges.every((b) => !b.isLabelVisible), isTrue);
+      expect(find.byType(Tab), findsNWidgets(4));
+      expect(find.text('Console'), findsOneWidget);
+    });
+
+    testWidgets(
+      'badge appears without any refresh when a failed request arrives',
+      (tester) async {
+        final inspector = FlutterInspector();
+
+        await tester.pumpWidget(
+          MaterialApp(home: DashboardModal(inspector: inspector)),
+        );
+
+        expect(find.text('1'), findsNothing);
+
+        inspector.logNetwork(
+          NetworkEntry(method: 'GET', url: '/fail', statusCode: 500),
+        );
+        await tester.pump();
+
+        expect(find.text('1'), findsOneWidget);
+      },
+    );
+
+    testWidgets('badge disappears after the buffer is cleared', (tester) async {
+      final inspector = FlutterInspector();
+      inspector.logNetwork(
+        NetworkEntry(method: 'GET', url: '/fail', statusCode: 500),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: DashboardModal(inspector: inspector)),
+      );
+      expect(find.text('1'), findsOneWidget);
+
+      inspector.clearNetwork();
+      await tester.pump();
+
+      final badges = tester.widgetList<Badge>(find.byType(Badge));
+      expect(badges.every((b) => !b.isLabelVisible), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Dashboard TabBar 的 Console / Network 兩個 tab 加上錯誤計數 badge，count 為 0 時自動隱藏。

Closes #122

## 修正問題

原始構想（brainstorm §P6）假設可以直接用 `ValueListenableBuilder` 監聽 buffer 變化，但實查發現 `lib/` 內零個 `ValueNotifier`——四個 tab（Console / Network / Navigator / Database）全靠手動 refresh 按鈕觸發 `setState`。若 badge 沿用這套快照式或手動 refresh 機制，會出現「badge 顯示 0，但 Network tab 裡實際躺著 3 筆失敗請求」的自相矛盾狀態，比完全不加 badge 還糟。

## 修正方式

- **引入單一 revision notifier**：`RingBuffer` 新增 `onMutate` callback，在 `add` / 成功的 `replace` / `clear` 後觸發——這是四個 buffer 唯一的寫入咽喉，通知邏輯收斂在這一點，未來新增任何寫入路徑都會自動正確廣播，不必逐一補接線。`InspectorRegistry` 把四個 inspector 的 `onMutate` 都接到內部 `ValueNotifier<int> _revision`，對外只曝露唯讀的 `ValueListenable<int> revision`。
- **`_DashboardTabBar` 改為 `StatefulWidget`**：在 `initState`/`dispose` 訂閱／取消訂閱 `revision`，變動時 `setState` 重算兩個 badge 的計數。刻意只讓 TabBar 這一層是 reactive，各 tab 內部列表仍維持手動 refresh——列表捲動中被強制重排會打斷使用者操作，但摘要用的 badge 不該說謊，兩者的取捨不同。
- **避開 `NetworkInspector.onAdd` 這個坑**：它是單一插槽且已被既有的 `NetworkNotifier` 佔用，若複用會靜默蓋掉既有的網路通知功能。因此走獨立的 `onMutate` 通道，並補了測試鎖住兩者可以共存、互不干擾。
- **count 語意**：
  - Network badge 沿用 `NetworkEntry.isFailed`（PR #101 已收斂的單一判定來源），不新增分歧的失敗判斷邏輯。
  - Console badge 只計算 `LogEntry` 的 error + warning 層級，刻意排除合併時間軸裡的失敗 network 請求，避免與 Network badge 重複計數同一筆錯誤。

### 已知技術債（非本 PR 造成，誠實列出）

- `test/version_test.dart` 目前失敗：`pubspec.yaml` 已是 `2.0.0`，但 `lib/src/version.dart` 仍停在 `1.9.0`。這在 `main` 上同樣會失敗，與本 PR 無關，建議另開 issue 追蹤。
- `dashboard_modal.dart` 新增兩處 `// ignore: invalid_use_of_visible_for_testing_member`，因為訂閱 `revision` 需要透過 `FlutterInspector.registry`（`@visibleForTesting`），而 `revision` 本身刻意不納入 public API。Review 時建議改用 `@internal` getter 更乾淨，但經與使用者確認後決定維持現況，留待後續處理。

## Test plan

- [x] 相關 5 個測試檔：42/42 通過（`ring_buffer_test.dart`、`inspector_registry_revision_test.dart`、`network_inspector_test.dart`、`dashboard_error_badge_test.dart` 等）
- [x] 全套測試：458 通過（排除既有 10 分鐘 timeout 的 `magical_tap_test.dart`，與本 PR 無關）
- [x] `flutter analyze`：零新增 issue
- [x] 既有 27 項測試零改動全過（`ring_buffer` 13 項 / `dashboard_modal` 4 項 / `network_inspector` 10 項），確認未破壞既有行為
- [x] 變異測試驗證：暫時註解掉 `addListener` 後，驗收條件 12 對應的測試準確轉紅，證明測試本身有偵測力

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqgQpgwifYBpTm7N2yAhsw

## Summary by Sourcery

在仪表盘的 Console 和 Network 选项卡中添加实时更新的错误计数徽章，该功能由检查器注册表中的新修订通知器提供支持。

新功能：
- 在 Console 和 Network 选项卡上显示错误计数徽章，并在仪表盘打开期间实时更新。

改进：
- 在 `RingBuffer` 上引入 `onMutate` 回调，并通过检查器向下传递，使 `InspectorRegistry` 能够为缓冲区变更暴露统一的修订版 `ValueListenable`。
- 将仪表盘的 `TabBar` 改为有状态组件，并将其订阅到检查器注册表的修订版，以在不改变现有标签刷新行为的前提下重新计算徽章计数。
- 在 `docs/features` 和 `docs/plans` 下的新规范中记录仪表盘错误徽章功能及其实现方案。

文档：
- 添加功能和实现设计文档，描述仪表盘错误计数徽章、数据流以及验收标准。

测试：
- 添加关于 `RingBuffer.onMutate` 行为以及 `InspectorRegistry.revision` 在 add/clear/replace 操作及与 `NetworkInspector.onAdd` 共存情况下更新的单元测试。
- 添加组件测试，验证仪表盘错误徽章的可见性、计数和实时更新，而无需手动刷新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add live-updating error-count badges to the dashboard Console and Network tabs backed by a new revision notifier in the inspector registry.

New Features:
- Display error-count badges on the Console and Network tabs that update while the dashboard is open.

Enhancements:
- Introduce an onMutate callback on RingBuffer and propagate it through inspectors so InspectorRegistry can expose a unified revision ValueListenable for buffer mutations.
- Make the dashboard TabBar stateful and subscribe it to the inspector registry revision to recompute badge counts without altering existing tab refresh behavior.
- Document the dashboard error badge feature and implementation plan in new specs under docs/features and docs/plans.

Documentation:
- Add feature and implementation design documents describing the dashboard error-count badges, data flow, and acceptance criteria.

Tests:
- Add unit tests for RingBuffer.onMutate behavior and InspectorRegistry.revision updates across add/clear/replace operations and coexistence with NetworkInspector.onAdd.
- Add widget tests verifying dashboard error badges’ visibility, counts, and live updates without requiring manual refresh.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 仪表盘新增 Console 与 Network 错误数量徽章。
  - Console 统计错误和警告日志，Network 统计失败请求。
  - 数据新增、替换或清除后，徽章会即时更新；数量为零时自动隐藏。
  - 切换检查器后，徽章仍能正确显示当前数据。

- **测试**
  - 增加错误计数、实时更新、清空后隐藏及检查器切换测试。
  - 验证网络数据相关回调可同时正常工作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->