### PR TITLE
chore(release): bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,40 @@
+## 2.1.0
+
+### Added
+* **Dashboard error badges**: The Console and Network tabs now show a badge with the current error count, so problems are visible without opening each tab. Badges update live as new entries arrive.
+
+### Fixed
+* **`navigatorKey` is now declared `required`**, matching the behaviour that [2.0.0](#200) already introduced. The parameter has been mandatory since the dashboard started routing through it, but the constructor still accepted its omission — so the failure surfaced as a dashboard that silently would not open, rather than as an error. It is now caught at compile time. Code that already passes a `navigatorKey` is unaffected.
+* **Reported package version**: `FlutterInspector.version` and the header of every exported diagnostic report reported `1.9.0` on the 2.0.0 release. The version constant is now in sync with the published package version.
+
+### Docs
+* **`navigatorKey` wiring is now shown in both READMEs' Initialize example** — previously neither did, so following them produced an inspector whose dashboard could not open. Both now also note that passing the same key to `MaterialApp` is required and not compiler-checkable.
+* The Traditional Chinese README additionally had a stale `openDashboard(context)` call (an API removed in 2.0.0) and an outdated install version — both corrected.
+* The 2.0.0 entry below has been expanded: it described the `openDashboard` signature change but not the resulting `navigatorKey` requirement.
+
 ## 2.0.0
+
+### BREAKING CHANGES
+* **`openDashboard()` no longer takes a `BuildContext`, and `navigatorKey` became mandatory as a result.** The dashboard now resolves its context from `navigatorKey` instead of receiving one at the call site, so an inspector constructed without that key cannot open the dashboard at all — magical tap, floating button, and notification tap each become a silent no-op.
+
+  The constructor still accepted its omission in this release, so the requirement was enforced only at runtime, without an error explaining the failure. It is declared `required` from 2.1.0 onward.
+
+  **Migration** — pass a key to the inspector, and the *same* key to your `MaterialApp`:
+
+  ```dart
+  final navigatorKey = GlobalKey<NavigatorState>();
+
+  final inspector = FlutterInspector(navigatorKey: navigatorKey);
+
+  MaterialApp(navigatorKey: navigatorKey, /* ... */);
+  ```
+
+  Also drop the argument at every call site: `openDashboard(context)` → `openDashboard()`.
+
+  > This entry was expanded in 2.1.0. It originally read only "Removed the `BuildContext` parameter … as it is no longer required for opening the inspector", which described the signature change but omitted that the context requirement had moved to `navigatorKey` rather than disappeared.
 
 ### Added
 * **Timeline Bookmark**: Long-press any timeline entry in the Console tab to bookmark it. A push-pin indicator is displayed, and a new "Bookmarks" filter chip allows isolating bookmarked entries. Diagnostic reports now prefix bookmarked entries with a 📌 icon.
-
-### Changed
-* **openDashboard method**: Removed the `BuildContext` parameter from the `openDashboard` method as it is no longer required for opening the inspector.
 
 ## 1.9.0
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,18 @@ Then run `flutter pub get`.
 
 ### Initialize
 
-Create a single shared `FlutterInspector` instance and wire it into your app. Register the navigator observer to track routes, and wrap your app in `FlutterInspectorMagicalTap` so a hidden gesture can open the dashboard from anywhere.
+Create a single shared `FlutterInspector` instance and wire it into your app. A `navigatorKey` is **required** — the inspector routes to the dashboard through it — so create one, pass it to the inspector, and pass **the same key** to your `MaterialApp`. Then register the navigator observer to track routes, and wrap your app in `FlutterInspectorMagicalTap` so a hidden gesture can open the dashboard from anywhere.
 
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
 
+// 1. One key, shared by the inspector and the MaterialApp.
+final navigatorKey = GlobalKey<NavigatorState>();
+
 final inspector = FlutterInspector(
+  // Required: the dashboard is opened through this key.
+  navigatorKey: navigatorKey,
   // Optional: configure threshold for marking requests as "🐢 SLOW" (defaults to 2s)
   slowRequestThreshold: const Duration(seconds: 3),
 );
@@ -76,9 +81,11 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      // 1. Track navigation events
+      // 2. The same key — without this the dashboard has no context to open in.
+      navigatorKey: navigatorKey,
+      // 3. Track navigation events
       navigatorObservers: [inspector.navigatorObserver],
-      // 2. A hidden gesture opens the dashboard from anywhere
+      // 4. A hidden gesture opens the dashboard from anywhere
       builder: (context, child) {
         return FlutterInspectorMagicalTap(
           onTap: () => inspector.openDashboard(),
@@ -92,6 +99,8 @@ class MyApp extends StatelessWidget {
 ```
 
 That's it? Yes, that's it.
+
+> **Both halves are required.** `navigatorKey` is a compile-time requirement on the constructor, but passing it to `MaterialApp` is not something the compiler can check. Miss that second step and the key never gets a mounted context, so `openDashboard()` silently does nothing — via magical tap, floating button, or notification tap alike.
 
 ### Floating button
 
@@ -273,20 +282,16 @@ Once enabled, the inspector requests notification permission for you when it ini
 - **iOS / macOS**: displays a foreground banner when a new API call arrives, throttled the same way as Android. **This requires one line of setup in your `AppDelegate` — see [Required iOS / macOS setup](#required-ios--macos-setup) below.** Without it, iOS silently suppresses the foreground banner (the entry is still delivered to Notification Center).
 - The notification uses a dedicated high-priority Android channel (`flutter_inspector_network_v2`) — if you upgrade from an earlier version, the old notification channel is automatically deleted and will not appear in system settings.
 
-To make **tapping the notification open the dashboard on the Network tab**, pass a `navigatorKey` that is also wired into your `MaterialApp`:
+**Tapping the notification opens the dashboard on the Network tab** — this uses the same required `navigatorKey` you already wired up in [Initialize](#initialize), so there is nothing extra to configure:
 
 ```dart
-final navigatorKey = GlobalKey<NavigatorState>();
-
 final inspector = FlutterInspector(
+  navigatorKey: navigatorKey, // required — already set up during Initialize
   showNetworkNotification: true,
-  navigatorKey: navigatorKey,
 );
-
-MaterialApp(navigatorKey: navigatorKey, /* ... */);
 ```
 
-Without a `navigatorKey` the notification still shows; tapping it is simply a no-op since there is no navigation context to route from.
+As with any dashboard entry point, the tap only routes if that same key was also passed to your `MaterialApp`.
 
 <details>
 <summary>Android setup (required)</summary>

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Inject your own widget as a 5th dashboard tab, sitting alongside the built-in Co
 
 ```dart
 final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
   customTab: const MyDebugPanel(),
   customTabTitle: 'Flags', // defaults to 'Custom'
 );
@@ -190,10 +191,13 @@ This is controlled by the `redactSensitiveData` constructor flag, which defaults
 
 ```dart
 // Secure by default — sensitive headers are masked in shared/exported output.
-final inspector = FlutterInspector();
+final inspector = FlutterInspector(navigatorKey: navigatorKey);
 
 // Opt out (e.g. internal builds where you need the raw values).
-final inspector = FlutterInspector(redactSensitiveData: false);
+final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
+  redactSensitiveData: false,
+);
 ```
 
 The flag only affects shared/exported text — the headers shown live inside the dashboard are always the real values.
@@ -271,7 +275,10 @@ WebView network entries are ordinary `NetworkEntry` objects flowing through the 
 A continuously-updated system notification can summarise the latest call and the running total. It is **disabled by default** — enable it explicitly:
 
 ```dart
-final inspector = FlutterInspector(showNetworkNotification: true);
+final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
+  showNetworkNotification: true,
+);
 ```
 
 Once enabled, the inspector requests notification permission for you when it initialises — the host app does not need to add any permission-handling code.
@@ -406,7 +413,10 @@ By default you have to log errors yourself. Enable **uncaught error capture** to
 It is **disabled by default** so the package never touches your error handling unless you ask. Enable it on the constructor:
 
 ```dart
-final inspector = FlutterInspector(captureUncaughtErrors: true);
+final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
+  captureUncaughtErrors: true,
+);
 ```
 
 This wires three standard Flutter hooks — `FlutterError.onError` (build/layout/paint errors), `PlatformDispatcher.instance.onError` (uncaught async errors, including unawaited `Future` errors), and `ErrorWidget.builder` (which widget failed to build). Together they cover framework, asynchronous and build-time errors without wrapping `runApp` in a custom zone, so there is no `Zone mismatch` to manage.
@@ -420,7 +430,10 @@ Captured errors appear as red logs in the **Console** tab. Tap any log that carr
 Enable **lifecycle capture** to record every foreground/background transition as an `info`-level Console log, so a crash or a stalled request can be read against whether the app was in the foreground at that moment:
 
 ```dart
-final inspector = FlutterInspector(captureLifecycleEvents: true);
+final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
+  captureLifecycleEvents: true,
+);
 ```
 
 It is **disabled by default**, and `detach()` removes the observer again. Each transition (`resumed` / `inactive` / `paused` / `detached`, plus `hidden` on Flutter 3.13+) becomes one entry, which the merged Timeline interleaves with network, navigation and database events automatically.
@@ -620,6 +633,7 @@ You can register these sources when initializing `FlutterInspector` or dynamical
 ```dart
 // At initialization
 final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
   databaseSources: [SqfliteBrowserSource(db)],
 );
 
@@ -694,6 +708,7 @@ Then pass it in:
 
 ```dart
 final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
   diagnosticInfoSource: AppDiagnosticInfoSource(),
 );
 ```

--- a/README.md
+++ b/README.md
@@ -187,13 +187,17 @@ inspector.logNetwork(completedEntry, replaces: pending);
 
 Every share/export path in the Network detail view — copy as `cURL`, copy as text, and the system share sheet — **masks sensitive headers by default**, so secrets never leak to the clipboard, a share sheet, or a screenshot. The masked keys are `Authorization`, `Cookie`, `Set-Cookie`, and `X-Api-Key` (matched case-insensitively); their values are replaced with `••••`.
 
-This is controlled by the `redactSensitiveData` constructor flag, which defaults to `true`:
+This is controlled by the `redactSensitiveData` constructor flag, which defaults to `true`. Pick one of the two configurations below.
+
+Secure by default — sensitive headers are masked in shared/exported output:
 
 ```dart
-// Secure by default — sensitive headers are masked in shared/exported output.
 final inspector = FlutterInspector(navigatorKey: navigatorKey);
+```
 
-// Opt out (e.g. internal builds where you need the raw values).
+Or opt out (e.g. internal builds where you need the raw values):
+
+```dart
 final inspector = FlutterInspector(
   navigatorKey: navigatorKey,
   redactSensitiveData: false,

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^2.0.0
+  flutter_inspector_kit: ^2.1.0
 ```
 
 Then run `flutter pub get`.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -122,6 +122,7 @@ void initState() {
 
 ```dart
 final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
   customTab: const MyDebugPanel(),
   customTabTitle: 'Flags', // defaults to 'Custom'
 );
@@ -188,10 +189,13 @@ Network 詳情頁的每一條分享／匯出路徑——複製為 `cURL`、複�
 
 ```dart
 // Secure by default — sensitive headers are masked in shared/exported output.
-final inspector = FlutterInspector();
+final inspector = FlutterInspector(navigatorKey: navigatorKey);
 
 // Opt out (e.g. internal builds where you need the raw values).
-final inspector = FlutterInspector(redactSensitiveData: false);
+final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
+  redactSensitiveData: false,
+);
 ```
 
 這個 flag 只影響分享／匯出的文字——dashboard 內即時顯示的 headers 永遠是真實值。
@@ -269,7 +273,10 @@ WebView network 項目是流經與 Dio 擷取流量相同 buffer 的一般 `Netw
 一則持續更新的系統通知可摘要最新一筆呼叫與累計總數。它**預設停用**——請明確啟用：
 
 ```dart
-final inspector = FlutterInspector(showNetworkNotification: true);
+final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
+  showNetworkNotification: true,
+);
 ```
 
 一旦啟用，inspector 會在初始化時替你請求通知權限——host App 不需要加任何權限處理程式碼。
@@ -404,7 +411,10 @@ for (final entry in entries) {
 它**預設停用**，所以除非你主動要求，本套件絕不碰你的錯誤處理。在建構參數上啟用：
 
 ```dart
-final inspector = FlutterInspector(captureUncaughtErrors: true);
+final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
+  captureUncaughtErrors: true,
+);
 ```
 
 這會接上三個標準 Flutter hook——`FlutterError.onError`（build/layout/paint 錯誤）、`PlatformDispatcher.instance.onError`（未捕捉的 async 錯誤，包含未 await 的 `Future` 錯誤）與 `ErrorWidget.builder`（哪個 widget build 失敗）。三者合起來涵蓋 framework、非同步與 build-time 錯誤，且不需要把 `runApp` 包進自訂 zone，所以沒有 `Zone mismatch` 要處理。
@@ -418,7 +428,10 @@ final inspector = FlutterInspector(captureUncaughtErrors: true);
 啟用 **lifecycle capture**，把每一次前景／背景轉換記錄成 `info` 等級的 Console log，這樣崩潰或卡住的請求就能對照當下 App 是否在前景來判讀：
 
 ```dart
-final inspector = FlutterInspector(captureLifecycleEvents: true);
+final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
+  captureLifecycleEvents: true,
+);
 ```
 
 它**預設停用**，而 `detach()` 會把 observer 移除。每一次轉換（`resumed` / `inactive` / `paused` / `detached`，Flutter 3.13+ 另有 `hidden`）都會成為一筆項目，並自動被合併時間軸與 network、navigation、database 事件交錯排列。
@@ -618,6 +631,7 @@ class ObjectBoxBrowserSource implements DatabaseBrowserSource {
 ```dart
 // At initialization
 final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
   databaseSources: [SqfliteBrowserSource(db)],
 );
 
@@ -680,6 +694,7 @@ class AppDiagnosticInfoSource implements DiagnosticInfoSource {
 
 ```dart
 final inspector = FlutterInspector(
+  navigatorKey: navigatorKey,
   diagnosticInfoSource: AppDiagnosticInfoSource(),
 );
 ```

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -185,13 +185,17 @@ inspector.logNetwork(completedEntry, replaces: pending);
 
 Network 詳情頁的每一條分享／匯出路徑——複製為 `cURL`、複製為文字、以及系統分享面板——**預設都會遮罩敏感 headers**，讓 secret 絕不外洩到剪貼簿、分享面板或截圖。被遮罩的 key 是 `Authorization`、`Cookie`、`Set-Cookie` 與 `X-Api-Key`（不分大小寫比對）；其值會被替換成 `••••`。
 
-這由 `redactSensitiveData` 這個建構參數控制，預設為 `true`：
+這由 `redactSensitiveData` 這個建構參數控制，預設為 `true`。以下兩種配置擇一使用。
+
+預設即安全——敏感 headers 在分享／匯出的輸出中會被遮罩：
 
 ```dart
-// Secure by default — sensitive headers are masked in shared/exported output.
 final inspector = FlutterInspector(navigatorKey: navigatorKey);
+```
 
-// Opt out (e.g. internal builds where you need the raw values).
+或選擇退出（例如需要原始值的內部建置版）：
+
+```dart
 final inspector = FlutterInspector(
   navigatorKey: navigatorKey,
   redactSensitiveData: false,

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -48,7 +48,7 @@
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^1.8.0
+  flutter_inspector_kit: ^2.1.0
 ```
 
 接著執行 `flutter pub get`。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -55,13 +55,21 @@ dependencies:
 
 ### 初始化
 
-建立單一個共用的 `FlutterInspector` 實例並接進你的 App。註冊 navigator observer 以追蹤 route，並用 `FlutterInspectorMagicalTap` 包住你的 App，讓隱藏手勢能從任何地方打開 dashboard。
+建立單一個共用的 `FlutterInspector` 實例並接進你的 App。`navigatorKey` 是**必填**的——inspector 透過它路由到 dashboard——所以請建立一把 key，傳給 inspector，並把**同一把 key** 也傳給你的 `MaterialApp`。接著註冊 navigator observer 以追蹤 route，並用 `FlutterInspectorMagicalTap` 包住你的 App，讓隱藏手勢能從任何地方打開 dashboard。
 
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
 
-final inspector = FlutterInspector();
+// 1. 一把 key，inspector 與 MaterialApp 共用。
+final navigatorKey = GlobalKey<NavigatorState>();
+
+final inspector = FlutterInspector(
+  // 必填：dashboard 透過這把 key 開啟。
+  navigatorKey: navigatorKey,
+  // 選填：設定判定為「🐢 SLOW」的門檻（預設 2 秒）
+  slowRequestThreshold: const Duration(seconds: 3),
+);
 
 void main() => runApp(const MyApp());
 
@@ -71,12 +79,14 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      // 1. Track navigation events
+      // 2. 同一把 key——少了這行，dashboard 就沒有可開啟的 context。
+      navigatorKey: navigatorKey,
+      // 3. 追蹤導航事件
       navigatorObservers: [inspector.navigatorObserver],
-      // 2. A hidden gesture opens the dashboard from anywhere
+      // 4. 隱藏手勢可從任何地方打開 dashboard
       builder: (context, child) {
         return FlutterInspectorMagicalTap(
-          onTap: () => inspector.openDashboard(context),
+          onTap: () => inspector.openDashboard(),
           child: child ?? const SizedBox.shrink(),
         );
       },
@@ -87,6 +97,8 @@ class MyApp extends StatelessWidget {
 ```
 
 就這樣？對，就這樣。
+
+> **兩個步驟缺一不可。** `navigatorKey` 在建構子上是編譯期強制的，但「有沒有傳給 `MaterialApp`」編譯器檢查不到。漏了第二步，這把 key 永遠拿不到已掛載的 context，`openDashboard()` 就會靜默無反應——不論是 magical tap、浮動按鈕，還是點通知都一樣。
 
 ### Floating button
 
@@ -268,20 +280,16 @@ final inspector = FlutterInspector(showNetworkNotification: true);
 - **iOS / macOS**：新的 API 呼叫抵達時顯示前景橫幅，節流方式與 Android 相同。**這需要在你的 `AppDelegate` 加一行設定——見下方 [必要的 iOS / macOS 設定](#必要的-ios--macos-設定)。** 少了它，iOS 會靜默地抑制前景橫幅（該項目仍會送達 Notification Center）。
 - 通知使用專屬的高優先權 Android channel（`flutter_inspector_network_v2`）——若你從較早的版本升級，舊的通知 channel 會自動被刪除，不會出現在系統設定中。
 
-要讓**點通知就打開 dashboard 並停在 Network 分頁**，請傳入一個同時也接進你 `MaterialApp` 的 `navigatorKey`：
+**點通知就會打開 dashboard 並停在 Network 分頁**——這用的是你在[初始化](#初始化)時已經接好的那把必填 `navigatorKey`，不需要額外設定：
 
 ```dart
-final navigatorKey = GlobalKey<NavigatorState>();
-
 final inspector = FlutterInspector(
+  navigatorKey: navigatorKey, // 必填——初始化時已設定
   showNetworkNotification: true,
-  navigatorKey: navigatorKey,
 );
-
-MaterialApp(navigatorKey: navigatorKey, /* ... */);
 ```
 
-沒有 `navigatorKey` 時通知仍會顯示；只是點它會是 no-op，因為沒有可路由的 navigation context。
+與其他 dashboard 入口一樣，只有在同一把 key 也傳給了 `MaterialApp` 時，這個點擊才會真的路由過去。
 
 <details>
 <summary>Android 設定（必要）</summary>

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -42,11 +42,22 @@ class FlutterInspector {
   /// prompts they didn't ask for).
   final bool showNetworkNotification;
 
-  /// Optional navigator key used to open the dashboard from a notification tap
-  /// (US-3). When supplied alongside [showNetworkNotification], tapping the
-  /// network notification opens the dashboard on the Network tab. Without it,
-  /// the tap is a no-op since there is no [BuildContext] to route from.
-  final GlobalKey<NavigatorState>? navigatorKey;
+  /// Navigator key used to route to the dashboard.
+  ///
+  /// This is **required**: [openDashboard] resolves its [BuildContext] from
+  /// this key, so the dashboard cannot be opened without it — by a magical
+  /// tap, by the floating button, or by a notification tap.
+  ///
+  /// The same key must also be passed to your [MaterialApp] (or [WidgetsApp]),
+  /// otherwise it never gets a mounted context:
+  ///
+  /// ```dart
+  /// final navigatorKey = GlobalKey<NavigatorState>();
+  /// final inspector = FlutterInspector(navigatorKey: navigatorKey);
+  ///
+  /// MaterialApp(navigatorKey: navigatorKey, /* ... */);
+  /// ```
+  final GlobalKey<NavigatorState> navigatorKey;
 
   /// Whether to capture uncaught errors from the three standard Flutter hooks
   /// ([FlutterError.onError], [PlatformDispatcher.instance.onError],
@@ -129,10 +140,12 @@ class FlutterInspector {
   final Set<TimestampedEntry> _bookmarkedEntries = <TimestampedEntry>{};
 
   /// Unmodifiable view of currently bookmarked entries.
-  Set<TimestampedEntry> get bookmarkedEntries => Set.unmodifiable(_bookmarkedEntries);
+  Set<TimestampedEntry> get bookmarkedEntries =>
+      Set.unmodifiable(_bookmarkedEntries);
 
   /// Checks if an entry is bookmarked.
-  bool isBookmarked(TimestampedEntry entry) => _bookmarkedEntries.contains(entry);
+  bool isBookmarked(TimestampedEntry entry) =>
+      _bookmarkedEntries.contains(entry);
 
   /// Toggles bookmark state for an entry.
   void toggleBookmark(TimestampedEntry entry) {
@@ -190,7 +203,7 @@ class FlutterInspector {
     this.customTabTitle = 'Custom',
     this.magicalTapCount = 5,
     this.showNetworkNotification = false,
-    this.navigatorKey,
+    required this.navigatorKey,
     this.captureUncaughtErrors = false,
     this.captureLifecycleEvents = false,
     this.redactSensitiveData = true,
@@ -207,9 +220,7 @@ class FlutterInspector {
         'must not be negative',
       );
     }
-    _overlayManager = InspectorOverlayManager(
-      onFabTap: (_) => openDashboard(),
-    );
+    _overlayManager = InspectorOverlayManager(onFabTap: (_) => openDashboard());
     _registry = InspectorRegistry(bufferSize: bufferSize);
     _uncaughtErrorHandler = UncaughtErrorHandler(onLog: log);
     if (captureUncaughtErrors) setupErrorHandlers();
@@ -352,13 +363,14 @@ class FlutterInspector {
   /// [initialIndex] selects the starting tab: Console (0), Network (1),
   /// Navigator (2), Database (3).
   void openDashboard({int initialIndex = 0}) {
-    final context = navigatorKey?.currentContext;
+    // navigatorKey is required, but its context is only mounted once the app
+    // has built its Navigator — a call before first frame is still a no-op.
+    final context = navigatorKey.currentContext;
     if (context == null) return;
     DashboardModal.show(context, this, initialIndex: initialIndex);
   }
 
   /// Opens the dashboard on the Network tab in response to a notification tap.
-  /// Requires [navigatorKey] to have a mounted context; otherwise a no-op.
   void _openNetworkFromNotification() {
     openDashboard(initialIndex: 1);
   }

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -61,21 +61,20 @@ class _ConsoleTabState extends State<ConsoleTab> {
   bool get _isAll => _selected.length == _all.length;
 
   void _selectAll() => setState(() {
-        _selected = {..._all};
-        _showOnlyBookmarks = false;
-      });
+    _selected = {..._all};
+    _showOnlyBookmarks = false;
+  });
 
   void _selectOnly(TimelineSource source) => setState(() {
-        _selected = {source};
-        _showOnlyBookmarks = false;
-      });
+    _selected = {source};
+    _showOnlyBookmarks = false;
+  });
 
   @override
   Widget build(BuildContext context) {
     var entries = widget.inspector.mergedTimeline(sources: _selected);
     if (_showOnlyBookmarks) {
-      entries =
-          entries.where((e) => widget.inspector.isBookmarked(e)).toList();
+      entries = entries.where((e) => widget.inspector.isBookmarked(e)).toList();
     }
 
     return Column(
@@ -213,8 +212,11 @@ class _LogEntryRow extends StatelessWidget {
       title: Row(
         children: [
           if (isBookmarked) ...[
-            const Icon(Icons.push_pin,
-                size: ThemeSize.size18, color: ThemeColor.colorFF9800),
+            const Icon(
+              Icons.push_pin,
+              size: ThemeSize.size18,
+              color: ThemeColor.colorFF9800,
+            ),
             const SizedBox(width: ThemeSize.space4),
           ],
           Expanded(
@@ -231,10 +233,10 @@ class _LogEntryRow extends StatelessWidget {
           : null,
       onTap: canTap
           ? () => pushInspectorRoute(
-                context,
-                kInspectorLogDetailRoute,
-                (_) => LogDetailView(entry: entry),
-              )
+              context,
+              kInspectorLogDetailRoute,
+              (_) => LogDetailView(entry: entry),
+            )
           : null,
       onLongPress: onToggleBookmark,
     );
@@ -260,8 +262,11 @@ class _NetworkEntryRow extends StatelessWidget {
       title: Row(
         children: [
           if (isBookmarked) ...[
-            const Icon(Icons.push_pin,
-                size: ThemeSize.size18, color: ThemeColor.colorFF9800),
+            const Icon(
+              Icons.push_pin,
+              size: ThemeSize.size18,
+              color: ThemeColor.colorFF9800,
+            ),
             const SizedBox(width: ThemeSize.space4),
           ],
           Expanded(
@@ -332,13 +337,14 @@ class _NavigatorEntryRow extends StatelessWidget {
       title: Row(
         children: [
           if (isBookmarked) ...[
-            const Icon(Icons.push_pin,
-                size: ThemeSize.size18, color: ThemeColor.colorFF9800),
+            const Icon(
+              Icons.push_pin,
+              size: ThemeSize.size18,
+              color: ThemeColor.colorFF9800,
+            ),
             const SizedBox(width: ThemeSize.space4),
           ],
-          Expanded(
-            child: Text('${entry.action.name} ${entry.displayName}'),
-          ),
+          Expanded(child: Text('${entry.action.name} ${entry.displayName}')),
         ],
       ),
       subtitle: Text(entry.displayTime),
@@ -365,13 +371,14 @@ class _DatabaseEntryRow extends StatelessWidget {
       title: Row(
         children: [
           if (isBookmarked) ...[
-            const Icon(Icons.push_pin,
-                size: ThemeSize.size18, color: ThemeColor.colorFF9800),
+            const Icon(
+              Icons.push_pin,
+              size: ThemeSize.size18,
+              color: ThemeColor.colorFF9800,
+            ),
             const SizedBox(width: ThemeSize.space4),
           ],
-          Expanded(
-            child: Text('${entry.operation.name} ${entry.tableName}'),
-          ),
+          Expanded(child: Text('${entry.operation.name} ${entry.tableName}')),
         ],
       ),
       subtitle: Text(entry.displayTime),

--- a/lib/src/ui/dashboard/tabs/network_tab.dart
+++ b/lib/src/ui/dashboard/tabs/network_tab.dart
@@ -275,8 +275,7 @@ class _EntryTile extends StatelessWidget {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (entry.duration != null &&
-              entry.duration! >= slowRequestThreshold)
+          if (entry.duration != null && entry.duration! >= slowRequestThreshold)
             Container(
               margin: const EdgeInsets.only(right: ThemeSize.space8),
               padding: const EdgeInsets.symmetric(
@@ -364,15 +363,15 @@ class _ErrorSummaryBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final groups = aggregateNetworkErrors(entries);
     final slowCount = entries
-        .where(
-          (e) => e.duration != null && e.duration! >= slowRequestThreshold,
-        )
+        .where((e) => e.duration != null && e.duration! >= slowRequestThreshold)
         .length;
     final thresholdSec = (slowRequestThreshold.inMilliseconds / 1000)
         .toStringAsFixed(1)
         .replaceAll(RegExp(r'\.0$'), '');
-    final slowText =
-        slowCount > 0 ? ' | 🐢 $slowCount slow (>$thresholdSec' 's)' : '';
+    final slowText = slowCount > 0
+        ? ' | 🐢 $slowCount slow (>$thresholdSec'
+              's)'
+        : '';
 
     if (groups.isEmpty && slowCount == 0) return const SizedBox.shrink();
 
@@ -397,7 +396,8 @@ class _ErrorSummaryBanner extends StatelessWidget {
                 ),
               ] else if (slowCount > 0) ...[
                 Text(
-                  '🐢 $slowCount slow requests (>$thresholdSec' 's)',
+                  '🐢 $slowCount slow requests (>$thresholdSec'
+                  's)',
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
               ],
@@ -426,7 +426,8 @@ class _ErrorSummaryBanner extends StatelessWidget {
               Text(
                 groups.isNotEmpty
                     ? 'Error Summary$slowText'
-                    : '🐢 $slowCount slow requests (>$thresholdSec' 's)',
+                    : '🐢 $slowCount slow requests (>$thresholdSec'
+                          's)',
                 style: Theme.of(context).textTheme.labelSmall,
               ),
               InkWell(

--- a/lib/src/ui/widgets/key_value_table.dart
+++ b/lib/src/ui/widgets/key_value_table.dart
@@ -42,9 +42,7 @@ class KeyValueTable extends StatelessWidget {
       children: [
         for (final e in entries)
           Padding(
-            padding: const EdgeInsets.symmetric(
-              vertical: ThemeSize.space2,
-            ),
+            padding: const EdgeInsets.symmetric(vertical: ThemeSize.space2),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String packageVersion = '1.9.0';
+const String packageVersion = '2.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues

--- a/test/core/error_capture_test.dart
+++ b/test/core/error_capture_test.dart
@@ -43,7 +43,7 @@ void main() {
       final beforePlatform = PlatformDispatcher.instance.onError;
       final beforeWidget = ErrorWidget.builder;
 
-      FlutterInspector();
+      FlutterInspector(navigatorKey: GlobalKey<NavigatorState>());
 
       expect(FlutterError.onError, same(beforeFlutter));
       expect(PlatformDispatcher.instance.onError, same(beforePlatform));
@@ -55,7 +55,10 @@ void main() {
       final beforePlatform = PlatformDispatcher.instance.onError;
       final beforeWidget = ErrorWidget.builder;
 
-      FlutterInspector(captureUncaughtErrors: true);
+      FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
 
       expect(FlutterError.onError, isNot(same(beforeFlutter)));
       expect(PlatformDispatcher.instance.onError, isNot(same(beforePlatform)));
@@ -68,7 +71,10 @@ void main() {
       // Host handler set to a no-op so the default test binding does not
       // re-report the error as test noise.
       FlutterError.onError = (_) {};
-      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
 
       FlutterError.onError!(buildDetails(StateError('build boom')));
 
@@ -88,7 +94,10 @@ void main() {
       var hostCalled = false;
       FlutterError.onError = (_) => hostCalled = true;
 
-      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
       FlutterError.onError!(buildDetails(StateError('boom')));
 
       expect(hostCalled, isTrue);
@@ -108,7 +117,10 @@ void main() {
         hostCalled = true;
         return true;
       };
-      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
 
       final handled = PlatformDispatcher.instance.onError!(
         StateError('async boom'),
@@ -132,7 +144,10 @@ void main() {
         hostCalled = true;
         return false;
       };
-      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
 
       final handled = PlatformDispatcher.instance.onError!(
         StateError('async boom'),
@@ -149,7 +164,10 @@ void main() {
 
     test('returns false when host has no handler (never swallows)', () {
       PlatformDispatcher.instance.onError = null;
-      FlutterInspector(captureUncaughtErrors: true);
+      FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
 
       final handled = PlatformDispatcher.instance.onError!(
         StateError('async boom'),
@@ -163,7 +181,10 @@ void main() {
   group('ErrorWidget.builder wrap', () {
     test('logs then delegates to original builder', () {
       final originalBuilder = ErrorWidget.builder;
-      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
 
       final details = buildDetails(StateError('widget boom'));
       final widget = ErrorWidget.builder(details);
@@ -183,7 +204,10 @@ void main() {
   group('dedup flag', () {
     test('calling setupErrorHandlers twice attaches hooks only once', () {
       FlutterError.onError = (_) {};
-      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
       // Second explicit call must be a no-op.
       inspector.setupErrorHandlers();
 
@@ -200,7 +224,10 @@ void main() {
     test('captureUncaughtErrors:true then a manual setupErrorHandlers attaches '
         'hooks once', () {
       FlutterError.onError = (_) {};
-      final inspector = FlutterInspector(captureUncaughtErrors: true);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        captureUncaughtErrors: true,
+      );
 
       // A second setupErrorHandlers call must be a no-op; the flag must prevent
       // re-attaching the hooks.

--- a/test/core/flutter_inspector_bookmark_test.dart
+++ b/test/core/flutter_inspector_bookmark_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/log_entry.dart';
@@ -6,7 +7,9 @@ import 'package:flutter_inspector_kit/src/models/log_level.dart';
 void main() {
   group('FlutterInspector Bookmarks', () {
     test('should toggle bookmark state correctly', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final entry = LogEntry(message: 'Test log', level: LogLevel.info);
 
       expect(inspector.isBookmarked(entry), false);
@@ -22,7 +25,9 @@ void main() {
     });
 
     test('clearBookmarks and clearLogs should reset bookmarks', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final entry = LogEntry(message: 'Test log', level: LogLevel.info);
       inspector.toggleBookmark(entry);
       expect(inspector.isBookmarked(entry), true);

--- a/test/core/flutter_inspector_lifecycle_test.dart
+++ b/test/core/flutter_inspector_lifecycle_test.dart
@@ -16,7 +16,9 @@ void main() {
   });
 
   test('default off: no lifecycle log in logEntries', () {
-    final inspector = FlutterInspector();
+    final inspector = FlutterInspector(
+      navigatorKey: GlobalKey<NavigatorState>(),
+    );
     currentInspector = inspector;
 
     WidgetsBinding.instance.handleAppLifecycleStateChanged(
@@ -27,7 +29,10 @@ void main() {
   });
 
   test('opt-in: lifecycle transition appears in logEntries', () {
-    final inspector = FlutterInspector(captureLifecycleEvents: true);
+    final inspector = FlutterInspector(
+      navigatorKey: GlobalKey<NavigatorState>(),
+      captureLifecycleEvents: true,
+    );
     currentInspector = inspector;
 
     WidgetsBinding.instance.handleAppLifecycleStateChanged(
@@ -44,7 +49,10 @@ void main() {
   });
 
   test('detach stops lifecycle logging', () {
-    final inspector = FlutterInspector(captureLifecycleEvents: true);
+    final inspector = FlutterInspector(
+      navigatorKey: GlobalKey<NavigatorState>(),
+      captureLifecycleEvents: true,
+    );
     currentInspector = inspector;
 
     WidgetsBinding.instance.handleAppLifecycleStateChanged(
@@ -61,7 +69,10 @@ void main() {
   });
 
   test('lifecycle log names the current top page from the nav stack', () {
-    final inspector = FlutterInspector(captureLifecycleEvents: true);
+    final inspector = FlutterInspector(
+      navigatorKey: GlobalKey<NavigatorState>(),
+      captureLifecycleEvents: true,
+    );
     currentInspector = inspector;
 
     // 推一筆 push 進 navigator buffer，讓 resolver 有 top page 可推導。
@@ -80,7 +91,10 @@ void main() {
   });
 
   test('empty nav stack yields a bare lifecycle message', () {
-    final inspector = FlutterInspector(captureLifecycleEvents: true);
+    final inspector = FlutterInspector(
+      navigatorKey: GlobalKey<NavigatorState>(),
+      captureLifecycleEvents: true,
+    );
     currentInspector = inspector;
 
     // 未推任何 navigator 事件 → resolver 回空 → 不加尾巴。

--- a/test/core/flutter_inspector_test.dart
+++ b/test/core/flutter_inspector_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/database_browser_source.dart';
 import 'package:flutter_inspector_kit/src/models/database_operation.dart';
@@ -9,8 +10,14 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('FlutterInspector Core', () {
     test('instances hold isolated registries', () {
-      final inspector1 = FlutterInspector(bufferSize: 10);
-      final inspector2 = FlutterInspector(bufferSize: 10);
+      final inspector1 = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        bufferSize: 10,
+      );
+      final inspector2 = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        bufferSize: 10,
+      );
 
       inspector1.log('Message 1');
 
@@ -19,7 +26,9 @@ void main() {
     });
 
     test('log adds to LogInspector', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.log('Test message', level: LogLevel.warning);
 
       final entries = inspector.registry.log.entries;
@@ -29,7 +38,9 @@ void main() {
     });
 
     test('logNetwork adds to NetworkInspector', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(NetworkEntry(method: 'GET', url: '/api'));
 
       final entries = inspector.registry.network.entries;
@@ -38,7 +49,9 @@ void main() {
     });
 
     test('database adds to DatabaseInspector', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.database(DatabaseOperation.insert, 'users', affectedRows: 1);
 
       final entries = inspector.registry.database.entries;
@@ -48,24 +61,32 @@ void main() {
     });
 
     test('provides a NavigatorObserver linked to its NavigatorInspector', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final observer = inspector.navigatorObserver;
       expect(observer, isNotNull);
     });
 
     test('redactSensitiveData defaults to true (secure by default)', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       expect(inspector.redactSensitiveData, isTrue);
     });
 
     test('redactSensitiveData can be disabled explicitly', () {
-      final inspector = FlutterInspector(redactSensitiveData: false);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        redactSensitiveData: false,
+      );
       expect(inspector.redactSensitiveData, isFalse);
     });
 
     test('rejects negative slowRequestThreshold', () {
       expect(
         () => FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
           slowRequestThreshold: const Duration(seconds: -1),
         ),
         throwsArgumentError,
@@ -74,11 +95,13 @@ void main() {
 
     test('accepts zero and positive slowRequestThreshold', () {
       final inspectorZero = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
         slowRequestThreshold: Duration.zero,
       );
       expect(inspectorZero.slowRequestThreshold, Duration.zero);
 
       final inspectorPositive = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
         slowRequestThreshold: const Duration(seconds: 5),
       );
       expect(
@@ -90,21 +113,28 @@ void main() {
 
   group('Database Browser Sources API', () {
     test('default source is always first and named Operation log', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       expect(inspector.databaseSources.length, 1);
       expect(inspector.databaseSources.first.name, 'Operation log');
     });
 
     test('constructor injects custom database sources', () {
       final source = FakeDatabaseBrowserSource();
-      final inspector = FlutterInspector(databaseSources: [source]);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        databaseSources: [source],
+      );
       expect(inspector.databaseSources.length, 2);
       expect(inspector.databaseSources[0].name, 'Operation log');
       expect(inspector.databaseSources[1], source);
     });
 
     test('registerDatabaseSource registers custom source dynamically', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final source = FakeDatabaseBrowserSource();
       inspector.registerDatabaseSource(source);
       expect(inspector.databaseSources.length, 2);
@@ -112,7 +142,9 @@ void main() {
     });
 
     test('databaseSources returns an unmodifiable list', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final sources = inspector.databaseSources;
       expect(
         () => (sources as List).add(FakeDatabaseBrowserSource()),
@@ -123,7 +155,9 @@ void main() {
     test(
       'logs logged to database are visible via OperationLogSource',
       () async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         inspector.database(DatabaseOperation.insert, 'users');
 
         final opLogSource = inspector.databaseSources.first;
@@ -136,12 +170,19 @@ void main() {
 
   group('Diagnostic Info Source API', () {
     test('diagnosticInfoSource defaults to null', () {
-      expect(FlutterInspector(bufferSize: 10).diagnosticInfoSource, isNull);
+      expect(
+        FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+          bufferSize: 10,
+        ).diagnosticInfoSource,
+        isNull,
+      );
     });
 
     test('an injected source is retained and collectable', () async {
       final source = _FakeDiagnosticInfoSource();
       final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
         bufferSize: 10,
         diagnosticInfoSource: source,
       );

--- a/test/core/inspector_registry_merged_timeline_test.dart
+++ b/test/core/inspector_registry_merged_timeline_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/core/inspector_registry.dart';
 import 'package:flutter_inspector_kit/src/models/database_entry.dart';
@@ -40,7 +41,9 @@ void main() {
 
   group('InspectorRegistry.mergedTimeline', () {
     test('default returns all four entries sorted by timestamp descending', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       seedAll(inspector.registry);
 
       final result = inspector.registry.mergedTimeline();
@@ -53,7 +56,9 @@ void main() {
     });
 
     test('single source {network} returns only the network entry', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       seedAll(inspector.registry);
 
       final result = inspector.registry.mergedTimeline(
@@ -66,7 +71,9 @@ void main() {
     });
 
     test('sources {log, nav} returns two entries, still descending', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       seedAll(inspector.registry);
 
       final result = inspector.registry.mergedTimeline(
@@ -81,7 +88,9 @@ void main() {
     });
 
     test('empty buffers return an empty list', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
 
       expect(inspector.registry.mergedTimeline(), isEmpty);
     });
@@ -89,7 +98,9 @@ void main() {
 
   group('FlutterInspector.mergedTimeline thin forward', () {
     test('default returns all four entries sorted descending', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       seedAll(inspector.registry);
 
       final result = inspector.mergedTimeline();
@@ -100,7 +111,9 @@ void main() {
     });
 
     test('single source {network} returns only the network entry', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       seedAll(inspector.registry);
 
       final result = inspector.mergedTimeline(
@@ -112,13 +125,17 @@ void main() {
     });
 
     test('empty buffers return an empty list', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
 
       expect(inspector.mergedTimeline(), isEmpty);
     });
 
     test('forward is equivalent to registry.mergedTimeline (default)', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       seedAll(inspector.registry);
 
       final viaInspector = inspector.mergedTimeline();

--- a/test/flutter_inspector_test.dart
+++ b/test/flutter_inspector_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
 import 'package:flutter_inspector_kit/src/version.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -5,7 +6,9 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('FlutterInspector', () {
     test('can be instantiated', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       expect(inspector, isA<FlutterInspector>());
     });
 

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/interceptors/dio_interceptor.dart';
@@ -9,7 +10,7 @@ void main() {
     late FlutterInspectorDioInterceptor interceptor;
 
     setUp(() {
-      inspector = FlutterInspector();
+      inspector = FlutterInspector(navigatorKey: GlobalKey<NavigatorState>());
       interceptor = FlutterInspectorDioInterceptor(inspector);
     });
 

--- a/test/observers/inspector_route_filter_test.dart
+++ b/test/observers/inspector_route_filter_test.dart
@@ -40,7 +40,9 @@ void main() {
     testWidgets('ConsoleTab log row does not record navigation', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.log('boom', level: LogLevel.error, stackTrace: '#0 main');
       await pumpObserved(tester, inspector, ConsoleTab(inspector: inspector));
 
@@ -56,7 +58,9 @@ void main() {
     testWidgets('ConsoleTab network row does not record navigation', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: 'https://x.test/a', statusCode: 200),
       );
@@ -72,7 +76,9 @@ void main() {
     });
 
     testWidgets('NetworkTab row does not record navigation', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: 'https://x.test/b', statusCode: 200),
       );
@@ -90,7 +96,9 @@ void main() {
     testWidgets('DatabaseTab table row does not record navigation', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.database(DatabaseOperation.insert, 'users');
       await pumpObserved(tester, inspector, DatabaseTab(inspector: inspector));
       await tester.pumpAndSettle();
@@ -107,7 +115,9 @@ void main() {
     testWidgets('TableRowsView cell details sheet does not record navigation', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       await pumpObserved(
         tester,
         inspector,
@@ -121,7 +131,9 @@ void main() {
     });
 
     testWidgets('ExportReportSheet does not record navigation', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       await pumpObserved(
         tester,
         inspector,
@@ -139,7 +151,9 @@ void main() {
     });
 
     testWidgets('host app navigation is still recorded', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       await pumpObserved(tester, inspector, const SizedBox());
       final navigator = tester.state<NavigatorState>(find.byType(Navigator));
 

--- a/test/observers/navigator_observer_test.dart
+++ b/test/observers/navigator_observer_test.dart
@@ -11,7 +11,7 @@ void main() {
     late FlutterInspectorNavigatorObserver observer;
 
     setUp(() {
-      inspector = FlutterInspector();
+      inspector = FlutterInspector(navigatorKey: GlobalKey<NavigatorState>());
       observer = inspector.navigatorObserver;
     });
 

--- a/test/ui/dashboard/tabs/console_tab_bookmark_test.dart
+++ b/test/ui/dashboard/tabs/console_tab_bookmark_test.dart
@@ -4,66 +4,76 @@ import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/ui/dashboard/tabs/console_tab.dart';
 
 void main() {
-  testWidgets('Long press on timeline entry toggles bookmark icon and filters list', (tester) async {
-    final inspector = FlutterInspector();
-    inspector.log('Test message 1');
-    inspector.log('Test message 2');
+  testWidgets(
+    'Long press on timeline entry toggles bookmark icon and filters list',
+    (tester) async {
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
+      inspector.log('Test message 1');
+      inspector.log('Test message 2');
 
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: ConsoleTab(inspector: inspector),
-      ),
-    ));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
 
-    expect(find.byIcon(Icons.push_pin), findsNothing);
+      expect(find.byIcon(Icons.push_pin), findsNothing);
 
-    // Long press to toggle bookmark
-    await tester.longPress(find.text('Test message 1'));
-    await tester.pumpAndSettle();
+      // Long press to toggle bookmark
+      await tester.longPress(find.text('Test message 1'));
+      await tester.pumpAndSettle();
 
-    expect(find.byIcon(Icons.push_pin), findsOneWidget);
-    expect(inspector.bookmarkedEntries.length, 1);
+      expect(find.byIcon(Icons.push_pin), findsOneWidget);
+      expect(inspector.bookmarkedEntries.length, 1);
 
-    // Tap Bookmarks FilterChip
-    await tester.tap(find.text('📌 Bookmarks'));
-    await tester.pumpAndSettle();
+      // Tap Bookmarks FilterChip
+      await tester.tap(find.text('📌 Bookmarks'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Test message 1'), findsOneWidget);
-    expect(find.text('Test message 2'), findsNothing);
+      expect(find.text('Test message 1'), findsOneWidget);
+      expect(find.text('Test message 2'), findsNothing);
 
-    // Toggle bookmark off
-    await tester.longPress(find.text('Test message 1'));
-    await tester.pumpAndSettle();
+      // Toggle bookmark off
+      await tester.longPress(find.text('Test message 1'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('No bookmarked entries'), findsOneWidget);
-  });
+      expect(find.text('No bookmarked entries'), findsOneWidget);
+    },
+  );
 
-  testWidgets('Selecting a source chip restores visibility of non-bookmarked entries', (tester) async {
-    final inspector = FlutterInspector();
-    inspector.log('Test message 1');
-    inspector.log('Test message 2');
+  testWidgets(
+    'Selecting a source chip restores visibility of non-bookmarked entries',
+    (tester) async {
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
+      inspector.log('Test message 1');
+      inspector.log('Test message 2');
 
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: ConsoleTab(inspector: inspector),
-      ),
-    ));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
 
-    // Toggle bookmark on message 1
-    await tester.longPress(find.text('Test message 1'));
-    await tester.pumpAndSettle();
+      // Toggle bookmark on message 1
+      await tester.longPress(find.text('Test message 1'));
+      await tester.pumpAndSettle();
 
-    // Enable bookmarks filter
-    await tester.tap(find.text('📌 Bookmarks'));
-    await tester.pumpAndSettle();
+      // Enable bookmarks filter
+      await tester.tap(find.text('📌 Bookmarks'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Test message 2'), findsNothing);
+      expect(find.text('Test message 2'), findsNothing);
 
-    // Tap All chip
-    await tester.tap(find.text('All'));
-    await tester.pumpAndSettle();
+      // Tap All chip
+      await tester.tap(find.text('All'));
+      await tester.pumpAndSettle();
 
-    // Verify filter is reset and message 2 is visible again
-    expect(find.text('Test message 2'), findsOneWidget);
-  });
+      // Verify filter is reset and message 2 is visible again
+      expect(find.text('Test message 2'), findsOneWidget);
+    },
+  );
 }

--- a/test/ui/dashboard_error_badge_test.dart
+++ b/test/ui/dashboard_error_badge_test.dart
@@ -20,7 +20,9 @@ Finder _badgeCountUnderTab(String tabLabel, String countText) {
 void main() {
   group('DashboardModal error badges', () {
     testWidgets('Network tab shows 2 when two entries failed', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(NetworkEntry(method: 'GET', url: '/ok'));
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/fail1', statusCode: 500),
@@ -41,7 +43,9 @@ void main() {
     testWidgets('Network tab shows no badge when all requests succeeded', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/ok1', statusCode: 200),
       );
@@ -60,7 +64,9 @@ void main() {
     testWidgets('Console tab shows 2 for one error and one warning', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.log('error msg', level: LogLevel.error);
       inspector.log('warning msg', level: LogLevel.warning);
       inspector.log('info 1', level: LogLevel.info);
@@ -78,7 +84,9 @@ void main() {
     testWidgets('empty inspector renders no badges on either tab', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
 
       await tester.pumpWidget(
         MaterialApp(home: DashboardModal(inspector: inspector)),
@@ -93,7 +101,9 @@ void main() {
     testWidgets(
       'badge appears without any refresh when a failed request arrives',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
 
         await tester.pumpWidget(
           MaterialApp(home: DashboardModal(inspector: inspector)),
@@ -112,7 +122,9 @@ void main() {
     );
 
     testWidgets('badge disappears after the buffer is cleared', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/fail', statusCode: 500),
       );
@@ -132,7 +144,9 @@ void main() {
     testWidgets(
       'rebuilding with a new inspector re-subscribes to its revision',
       (tester) async {
-        final oldInspector = FlutterInspector();
+        final oldInspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         oldInspector.logNetwork(
           NetworkEntry(method: 'GET', url: '/old-fail', statusCode: 500),
         );
@@ -142,7 +156,9 @@ void main() {
         );
         expect(find.text('1'), findsOneWidget);
 
-        final newInspector = FlutterInspector();
+        final newInspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         // Same widget position/type with no key: State is preserved and
         // didUpdateWidget fires instead of a fresh initState.
         await tester.pumpWidget(

--- a/test/ui/dashboard_modal_test.dart
+++ b/test/ui/dashboard_modal_test.dart
@@ -6,7 +6,9 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('DashboardModal', () {
     testWidgets('renders 4 tabs by default', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
 
       await tester.pumpWidget(
         MaterialApp(home: DashboardModal(inspector: inspector)),
@@ -19,7 +21,9 @@ void main() {
     testWidgets('opens on the Network tab when initialIndex is 1', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
 
       await tester.pumpWidget(
         MaterialApp(
@@ -36,7 +40,9 @@ void main() {
     testWidgets('clamps an out-of-range initialIndex to the last tab', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
 
       await tester.pumpWidget(
         MaterialApp(
@@ -52,6 +58,7 @@ void main() {
 
     testWidgets('renders 5 tabs when customTab is provided', (tester) async {
       final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
         customTab: const Text('My Custom Tab Content'),
         customTabTitle: 'MyTab',
       );

--- a/test/ui/export_report_sheet_test.dart
+++ b/test/ui/export_report_sheet_test.dart
@@ -53,7 +53,10 @@ void main() {
 
   group('ExportReportSheet (AC-19, AC-20)', () {
     testWidgets('offers all three filter dimensions', (tester) async {
-      await pumpSheet(tester, FlutterInspector());
+      await pumpSheet(
+        tester,
+        FlutterInspector(navigatorKey: GlobalKey<NavigatorState>()),
+      );
 
       // Sources.
       expect(find.text('Logs'), findsOneWidget);
@@ -71,7 +74,10 @@ void main() {
     });
 
     testWidgets('errors-only is off by default', (tester) async {
-      await pumpSheet(tester, FlutterInspector());
+      await pumpSheet(
+        tester,
+        FlutterInspector(navigatorKey: GlobalKey<NavigatorState>()),
+      );
 
       final checkbox = tester.widget<CheckboxListTile>(
         find.ancestor(
@@ -86,7 +92,9 @@ void main() {
       tester,
     ) async {
       mockShareSheet(tester);
-      final inspector = FlutterInspector()..log('hello from the log');
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      )..log('hello from the log');
 
       await pumpSheet(tester, inspector);
       await tester.tap(find.text('Share report'));
@@ -103,7 +111,9 @@ void main() {
       tester,
     ) async {
       mockShareSheet(tester);
-      final inspector = FlutterInspector()..log('log line');
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      )..log('log line');
 
       await pumpSheet(tester, inspector);
       await tester.tap(find.text('Network'));
@@ -119,9 +129,10 @@ void main() {
       tester,
     ) async {
       mockShareSheet(tester);
-      final inspector = FlutterInspector()
-        ..log('just-fyi')
-        ..log('boom', level: LogLevel.error);
+      final inspector =
+          FlutterInspector(navigatorKey: GlobalKey<NavigatorState>())
+            ..log('just-fyi')
+            ..log('boom', level: LogLevel.error);
 
       await pumpSheet(tester, inspector);
       await tester.tap(find.text('Errors & warnings only'));
@@ -135,7 +146,10 @@ void main() {
 
     testWidgets('defaults to the last-5m window', (tester) async {
       mockShareSheet(tester);
-      await pumpSheet(tester, FlutterInspector());
+      await pumpSheet(
+        tester,
+        FlutterInspector(navigatorKey: GlobalKey<NavigatorState>()),
+      );
       await tester.tap(find.text('Share report'));
       await tester.pumpAndSettle();
 
@@ -147,7 +161,9 @@ void main() {
     ) async {
       mockShareSheet(tester);
       // An old log falls outside the default 5m window but inside "All".
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.registry.log.add(
         LogEntry(
           message: 'ancient-history',
@@ -169,7 +185,13 @@ void main() {
       tester,
     ) async {
       mockShareSheet(tester);
-      await pumpSheet(tester, FlutterInspector(redactSensitiveData: false));
+      await pumpSheet(
+        tester,
+        FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+          redactSensitiveData: false,
+        ),
+      );
       await tester.tap(find.text('Share report'));
       await tester.pumpAndSettle();
 
@@ -182,7 +204,10 @@ void main() {
       mockShareSheet(tester);
       await pumpSheet(
         tester,
-        FlutterInspector(diagnosticInfoSource: _FakeSource()),
+        FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+          diagnosticInfoSource: _FakeSource(),
+        ),
       );
       await tester.tap(find.text('Share report'));
       await tester.pumpAndSettle();
@@ -210,7 +235,11 @@ void main() {
           },
         );
 
-        await pumpSheet(tester, FlutterInspector()..log('needle'));
+        await pumpSheet(
+          tester,
+          FlutterInspector(navigatorKey: GlobalKey<NavigatorState>())
+            ..log('needle'),
+        );
         await tester.tap(find.text('Share report'));
         await tester.pumpAndSettle();
 
@@ -231,7 +260,10 @@ void main() {
 
         await pumpSheet(
           tester,
-          FlutterInspector(diagnosticInfoSource: _BrokenSource()),
+          FlutterInspector(
+            navigatorKey: GlobalKey<NavigatorState>(),
+            diagnosticInfoSource: _BrokenSource(),
+          ),
         );
         await tester.tap(find.text('Share report'));
         await tester.pumpAndSettle();
@@ -259,7 +291,10 @@ void main() {
         },
       );
 
-      await pumpSheet(tester, FlutterInspector());
+      await pumpSheet(
+        tester,
+        FlutterInspector(navigatorKey: GlobalKey<NavigatorState>()),
+      );
       await tester.tap(find.text('Share report'));
       await tester.pumpAndSettle();
 
@@ -273,7 +308,10 @@ void main() {
     testWidgets('sharing is disabled when no source is selected', (
       tester,
     ) async {
-      await pumpSheet(tester, FlutterInspector());
+      await pumpSheet(
+        tester,
+        FlutterInspector(navigatorKey: GlobalKey<NavigatorState>()),
+      );
 
       for (final source in ['Logs', 'Network', 'Navigation', 'Database']) {
         await tester.tap(find.text(source));
@@ -290,7 +328,13 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(home: DashboardModal(inspector: FlutterInspector())),
+        MaterialApp(
+          home: DashboardModal(
+            inspector: FlutterInspector(
+              navigatorKey: GlobalKey<NavigatorState>(),
+            ),
+          ),
+        ),
       );
 
       expect(find.byIcon(Icons.ios_share), findsOneWidget);

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -18,7 +18,9 @@ void main() {
     // ---- Preserved log-only tests (still valid under default All filter) ----
 
     testWidgets('displays logs and supports clearing', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.log('Test message 1', level: LogLevel.info);
       inspector.log('Test message 2', level: LogLevel.error);
 
@@ -41,7 +43,9 @@ void main() {
     testWidgets(
       'clearing wipes all four merged-timeline sources, not just logs',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         inspector.log('log msg', level: LogLevel.info);
         inspector.registry.navigator.add(
           NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
@@ -85,7 +89,9 @@ void main() {
     testWidgets('tapping error log with stackTrace opens LogDetailView', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.log(
         'Error occurred',
         level: LogLevel.error,
@@ -110,7 +116,9 @@ void main() {
     testWidgets('tapping error log with data opens LogDetailView', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.log(
         'Error with data',
         level: LogLevel.error,
@@ -133,7 +141,9 @@ void main() {
     });
 
     testWidgets('shows a chevron only on expandable rows', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       // Expandable: has a stackTrace.
       inspector.log('Expandable', level: LogLevel.error, stackTrace: 'x');
       // Non-expandable: plain info with neither stackTrace nor data.
@@ -163,7 +173,9 @@ void main() {
     testWidgets(
       'tapping pure info log without stackTrace or data does not navigate',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         inspector.log('Pure info', level: LogLevel.info);
 
         await tester.pumpWidget(
@@ -188,7 +200,9 @@ void main() {
     // ---- New merged-timeline tests ----
 
     testWidgets('filter chip Network shows only network rows', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.log('a log', level: LogLevel.info);
       inspector.logNetwork(
         NetworkEntry(
@@ -220,7 +234,9 @@ void main() {
     testWidgets('All filter shows mixed sources sorted newest-first', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final tLog = DateTime(2026, 6, 26, 10, 0, 0); // oldest
       final tNav = DateTime(2026, 6, 26, 10, 0, 1);
       final tNet = DateTime(2026, 6, 26, 10, 0, 2);
@@ -277,7 +293,9 @@ void main() {
     });
 
     testWidgets('network row taps into NetworkDetailView', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(
           method: 'GET',
@@ -302,7 +320,10 @@ void main() {
     });
 
     testWidgets('network row tap forwards redactSensitiveData', (tester) async {
-      final inspector = FlutterInspector(redactSensitiveData: false);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        redactSensitiveData: false,
+      );
       inspector.logNetwork(
         NetworkEntry(
           method: 'GET',
@@ -330,7 +351,9 @@ void main() {
     testWidgets('tints only error logs and failed network rows', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.log('boom', level: LogLevel.error);
       inspector.log('heads up', level: LogLevel.warning);
       inspector.log('all good', level: LogLevel.info);
@@ -383,7 +406,9 @@ void main() {
     testWidgets('nav and db rows are not tappable (no chevron)', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.registry.navigator.add(
         NavigatorEntry(action: NavigatorAction.push, routeName: '/home'),
       );
@@ -414,7 +439,9 @@ void main() {
     });
 
     testWidgets('each row shows displayTime (HH:mm:ss.mmm)', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.registry.log.add(
         LogEntry(
           message: 'tm',

--- a/test/ui/tabs/database_tab_test.dart
+++ b/test/ui/tabs/database_tab_test.dart
@@ -30,7 +30,9 @@ void main() {
     testWidgets('displays database tables grouped and supports clearing', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.database(
         DatabaseOperation.insert,
         'users',
@@ -76,7 +78,9 @@ void main() {
     });
 
     testWidgets('shows empty state for empty sources', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
 
       await tester.pumpWidget(
         MaterialApp(
@@ -92,7 +96,10 @@ void main() {
       tester,
     ) async {
       final customSource = FakeCustomSource();
-      final inspector = FlutterInspector(databaseSources: [customSource]);
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+        databaseSources: [customSource],
+      );
 
       await tester.pumpWidget(
         MaterialApp(
@@ -129,7 +136,9 @@ void main() {
     testWidgets('dropdown is not shown for single source, only text name', (
       tester,
     ) async {
-      final inspector = FlutterInspector(); // Only default Operation log
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      ); // Only default Operation log
 
       await tester.pumpWidget(
         MaterialApp(
@@ -144,7 +153,9 @@ void main() {
     });
 
     testWidgets('tapping table pushes TableRowsView', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.database(DatabaseOperation.insert, 'users');
 
       await tester.pumpWidget(

--- a/test/ui/tabs/navigator_active_stack_test.dart
+++ b/test/ui/tabs/navigator_active_stack_test.dart
@@ -10,7 +10,9 @@ void main() {
     testWidgets('displays active stack top-first with two cards', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       // Push A
       inspector.registry.navigator.add(
         NavigatorEntry(
@@ -59,7 +61,9 @@ void main() {
     testWidgets(
       'cards display displayName and routeName, but do not show arguments',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         inspector.registry.navigator.add(
           NavigatorEntry(
             action: NavigatorAction.push,
@@ -87,7 +91,9 @@ void main() {
     testWidgets(
       'empty navigatorEntries displays empty placeholder without crashing',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
 
         await tester.pumpWidget(
           MaterialApp(
@@ -106,7 +112,9 @@ void main() {
     testWidgets(
       'clearing navigator syncs the active stack view to empty placeholder',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         inspector.registry.navigator.add(
           NavigatorEntry(
             action: NavigatorAction.push,

--- a/test/ui/tabs/navigator_tab_test.dart
+++ b/test/ui/tabs/navigator_tab_test.dart
@@ -10,7 +10,9 @@ void main() {
     testWidgets('displays navigator entries and supports clearing', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.registry.navigator.add(
         NavigatorEntry(
           action: NavigatorAction.push,
@@ -35,7 +37,9 @@ void main() {
     });
 
     testWidgets('shows ChoiceChips with both mode labels', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.registry.navigator.add(
         NavigatorEntry(
           action: NavigatorAction.push,
@@ -58,7 +62,9 @@ void main() {
     testWidgets('defaults to eventHistory mode showing event list', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.registry.navigator.add(
         NavigatorEntry(
           action: NavigatorAction.push,
@@ -83,7 +89,9 @@ void main() {
     testWidgets(
       'switching to activeStack shows resolved stack and hides events',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         inspector.registry.navigator.add(
           NavigatorEntry(
             action: NavigatorAction.push,

--- a/test/ui/tabs/network_detail_view_test.dart
+++ b/test/ui/tabs/network_detail_view_test.dart
@@ -330,7 +330,9 @@ void main() {
     testWidgets('resend success records replay entry and shows snackbar', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final dio = Dio()
         ..httpClientAdapter = _StubAdapter(
           (_) async => ResponseBody.fromString(
@@ -377,7 +379,9 @@ void main() {
     testWidgets(
       'resend badResponse (500) records error entry and shows request resent',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         final dio = Dio()
           ..httpClientAdapter = _StubAdapter(
             (_) async => ResponseBody.fromString('err', 500),
@@ -416,7 +420,9 @@ void main() {
     testWidgets('resend connection failure shows resend failed', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final dio = Dio()
         ..httpClientAdapter = _StubAdapter(
           (_) async => throw DioException(
@@ -473,7 +479,9 @@ void main() {
     // Test 5: double-tap guard during in-flight request
     testWidgets('disabled while request is in-flight', (tester) async {
       final completer = Completer<ResponseBody>();
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final dio = Dio()
         ..httpClientAdapter = _StubAdapter((_) => completer.future);
       dio.interceptors.add(

--- a/test/ui/tabs/network_tab_test.dart
+++ b/test/ui/tabs/network_tab_test.dart
@@ -10,7 +10,9 @@ void main() {
     testWidgets('displays network entries and supports clearing', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/api/test', statusCode: 200),
       );
@@ -30,7 +32,9 @@ void main() {
     });
 
     testWidgets('keyword search filters the list', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/api/users', statusCode: 200),
       );
@@ -55,7 +59,9 @@ void main() {
     });
 
     testWidgets('method filter chip narrows results', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/api/users', statusCode: 200),
       );
@@ -77,7 +83,9 @@ void main() {
     });
 
     testWidgets('tapping an entry opens the detail view', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(
           method: 'GET',
@@ -103,7 +111,9 @@ void main() {
     testWidgets(
       'Error Summary banner is not rendered when there are no errors',
       (tester) async {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         inspector.logNetwork(
           NetworkEntry(method: 'GET', url: '/ok', statusCode: 200),
         );
@@ -122,7 +132,9 @@ void main() {
     testWidgets('Error Summary banner appears when there are errors', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/err', statusCode: 502),
       );
@@ -143,7 +155,9 @@ void main() {
     });
 
     testWidgets('Tapping error group card filters the list', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/ok', statusCode: 200),
       );
@@ -170,7 +184,9 @@ void main() {
     testWidgets('Tapping the same group card again clears the filter', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/ok', statusCode: 200),
       );
@@ -198,7 +214,9 @@ void main() {
     testWidgets('Clearing buffer hides the error summary banner', (
       tester,
     ) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/err', statusCode: 502),
       );
@@ -217,7 +235,9 @@ void main() {
     });
 
     testWidgets('Collapsing the banner shows summary text', (tester) async {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       inspector.logNetwork(
         NetworkEntry(method: 'GET', url: '/err1', statusCode: 502),
       );

--- a/test/utils/diagnostic_report_bookmark_test.dart
+++ b/test/utils/diagnostic_report_bookmark_test.dart
@@ -33,38 +33,41 @@ void main() {
       expect(report.contains('- ['), true);
     });
 
-    test('renders 📌 prefix for bookmarked network, navigator, and database entries', () {
-      final logInspector = LogInspector(bufferSize: 100);
-      final netEntry = NetworkEntry(
-        url: 'https://example.com/api',
-        method: 'GET',
-        statusCode: 200,
-        duration: const Duration(milliseconds: 150),
-      );
-      final navEntry = NavigatorEntry(
-        action: NavigatorAction.push,
-        routeName: '/details',
-      );
-      final dbEntry = DatabaseEntry(
-        operation: DatabaseOperation.query,
-        tableName: 'users',
-        affectedRows: 5,
-      );
+    test(
+      'renders 📌 prefix for bookmarked network, navigator, and database entries',
+      () {
+        final logInspector = LogInspector(bufferSize: 100);
+        final netEntry = NetworkEntry(
+          url: 'https://example.com/api',
+          method: 'GET',
+          statusCode: 200,
+          duration: const Duration(milliseconds: 150),
+        );
+        final navEntry = NavigatorEntry(
+          action: NavigatorAction.push,
+          routeName: '/details',
+        );
+        final dbEntry = DatabaseEntry(
+          operation: DatabaseOperation.query,
+          tableName: 'users',
+          affectedRows: 5,
+        );
 
-      final now = DateTime.now();
-      final report = buildDiagnosticReport(
-        logInspector: logInspector,
-        networkEntries: [netEntry],
-        navigatorEntries: [navEntry],
-        databaseEntries: [dbEntry],
-        now: now,
-        bookmarkedEntries: {netEntry, navEntry, dbEntry},
-      );
+        final now = DateTime.now();
+        final report = buildDiagnosticReport(
+          logInspector: logInspector,
+          networkEntries: [netEntry],
+          navigatorEntries: [navEntry],
+          databaseEntries: [dbEntry],
+          now: now,
+          bookmarkedEntries: {netEntry, navEntry, dbEntry},
+        );
 
-      expect(report.contains('- 📌 ['), true);
-      expect(report.contains('[NET] GET /api → 200 (150ms)'), true);
-      expect(report.contains('[NAV] push `/details`'), true);
-      expect(report.contains('[DB] query `users` (5 rows)'), true);
-    });
+        expect(report.contains('- 📌 ['), true);
+        expect(report.contains('[NET] GET /api → 200 (150ms)'), true);
+        expect(report.contains('[NAV] push `/details`'), true);
+        expect(report.contains('[DB] query `users` (5 rows)'), true);
+      },
+    );
   });
 }

--- a/test/webview/webview_bridge_adapter_test.dart
+++ b/test/webview/webview_bridge_adapter_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_inspector_kit/src/core/flutter_inspector.dart';
 import 'package:flutter_inspector_kit/src/models/log_level.dart';
 import 'package:flutter_inspector_kit/src/models/network_origin.dart';
@@ -9,7 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('WebViewBridgeAdapter · log 路徑', () {
     test('console.error 成為 error 級 LogEntry 並帶 webview provenance', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final adapter = WebViewBridgeAdapter(inspector);
       adapter.handleMessage(_Data.consoleError);
       final e = inspector.logEntries.single;
@@ -28,7 +31,9 @@ void main() {
         'weird': LogLevel.info,
       };
       for (final entry in cases.entries) {
-        final inspector = FlutterInspector();
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
         WebViewBridgeAdapter(
           inspector,
         ).handleMessage(_Data.consoleMethod(entry.key));
@@ -41,7 +46,9 @@ void main() {
     });
 
     test('window.onerror 成為 error 級 entry 且帶 JS stack', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       WebViewBridgeAdapter(inspector).handleMessage(_Data.windowOnError);
       final e = inspector.logEntries.single;
       expect(e.level, LogLevel.error);
@@ -49,13 +56,17 @@ void main() {
     });
 
     test('page 欄位缺省時 data 不塞 pageUrl', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       WebViewBridgeAdapter(inspector).handleMessage(_Data.consoleNoPage);
       expect(inspector.logEntries.single.data, {'origin': 'webview'});
     });
 
     test('malformed / unknown 訊息靜默丟棄不 throw', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final adapter = WebViewBridgeAdapter(inspector);
       for (final raw in ['not json{', '{"t":"log"', '{"t":"weird"}']) {
         expect(() => adapter.handleMessage(raw), returnsNormally);
@@ -66,7 +77,9 @@ void main() {
 
   group('WebViewBridgeAdapter · network 路徑', () {
     test('WebView fetch 成為非 Dio NetworkEntry：欄位正確對應', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       WebViewBridgeAdapter(inspector).handleMessage(_Data.fetch502);
       final e = inspector.networkEntries.single;
       expect(e.method, 'POST');
@@ -84,7 +97,9 @@ void main() {
     });
 
     test('傳輸失敗：statusCode null 且 error 保留', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       WebViewBridgeAdapter(inspector).handleMessage(_Data.fetchTransportError);
       final e = inspector.networkEntries.single;
       expect(e.statusCode, isNull);
@@ -94,7 +109,9 @@ void main() {
     });
 
     test('redaction parity：Authorization 遮罩與 native 同一 code path', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       WebViewBridgeAdapter(inspector).handleMessage(_Data.fetchWithAuth);
       final e = inspector.networkEntries.single;
       expect(buildPlainText(e, redact: true), contains('••••'));
@@ -102,28 +119,36 @@ void main() {
     });
 
     test('CRLF 訊息經既有 one-liner formatter 被壓平', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       WebViewBridgeAdapter(inspector).handleMessage(_Data.consoleWithCrlf);
       final oneLiner = buildLogOneLiner(inspector.logEntries.single);
       expect(oneLiner, isNot(contains('\n')));
     });
 
     test('malformed URL 的 net 事件經既有 formatter 不外洩 query', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       WebViewBridgeAdapter(inspector).handleMessage(_Data.fetchMalformedUrl);
       final oneLiner = buildNetworkOneLiner(inspector.networkEntries.single);
       expect(oneLiner, isNot(contains('secret=1')));
     });
 
     test('超出 DateTime 範圍的 ts 靜默丟棄不 throw（敵意輸入）', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final adapter = WebViewBridgeAdapter(inspector);
       expect(() => adapter.handleMessage(_Data.fetchHugeTs), returnsNormally);
       expect(inspector.networkEntries, isEmpty);
     });
 
     test('超過大小上限的 raw 訊息在 decode 前被丟棄（敵意輸入）', () {
-      final inspector = FlutterInspector();
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
       final adapter = WebViewBridgeAdapter(inspector);
       // 合法 JSON 但整體超過 256KB 上限——若無 guard 會成為一筆 entry。
       final oversized =


### PR DESCRIPTION
### Summary
[#124](https://github.com/Yomiamy/flutter_inspector_kit/issues/124) Release: Version 2.1.0

**[修正問題]**
發布新版 `2.1.0`，整合自 `v2.0.0` 以來合併入 `main` 的 Dashboard 錯誤數量徽章（PR #123）。發布前實查另外發現兩個既有缺陷，一併於本次修復：

1. **`main` 目前測試是紅的** —— v2.0.0 發布時漏改 `lib/src/version.dart`（仍為 `1.9.0`），導致 `test/version_test.dart` 持續失敗。該常數會印在 `FlutterInspector.version` 與**每一份使用者導出的診斷報告表頭**上，回報問題時會誤導排查方向。

2. **`navigatorKey` 的宣告與行為不一致** —— v1.9.0 時 `openDashboard(BuildContext context, ...)` 自帶 context，該參數確實是選填。但 v2.0.0 移除了該參數後，dashboard 改為完全透過 `navigatorKey` 取得 context，**自此它在行為上已是必要**，建構子卻仍允許不傳。後果是失敗完全靜默：沒傳 key 的 inspector 根本打不開 dashboard，magical tap、浮動按鈕、點通知全部無反應，且沒有任何錯誤訊息。兩份 README 的初始化範例也都沒有示範接線，照抄即得到一個打不開的 inspector。

**[修正方式]**
1. **`lib/src/core/flutter_inspector.dart`**：`navigatorKey` 宣告為 `required`，把靜默的執行期失敗提前到編譯期；移除已成死碼的 `?.`，並改寫欄位註解（原註解仍將它描述為通知專用）。
2. **`README.md` / `README.zh-TW.md`**：初始化範例補上 `navigatorKey` 接線，並註明「同一把 key 也要傳給 `MaterialApp`」這步編譯器檢查不到；修正 zh-TW 殘留的 `openDashboard(context)`（2.0.0 已移除的 API）與落後兩版的安裝版號。
3. **`pubspec.yaml` / `lib/src/version.dart` / 兩份 README**：四處版號同步為 `2.1.0`。
4. **`CHANGELOG.md`**：新增 `2.1.0` 區塊；並補正 2.0.0 條目為 `BREAKING CHANGES`——原文只寫「移除 `BuildContext` 參數」，未提及 context 需求是**轉移**到 `navigatorKey` 而非消失，讀起來像單純的 API 簡化。已附 migration 步驟與修訂註記。

**[為何維持 2.1.0 而非 3.0.0]**
真正的 breaking change 發生在 2.0.0（移除 `BuildContext` 參數那一刻），並已於當時公告。本次只是把型別宣告補到與既有行為一致，未引入任何新的行為約束——已經有傳 `navigatorKey` 的程式碼完全不受影響；沒傳的本來執行期就是壞的，現在改成編譯期報錯。故屬修正，維持 minor 版號。

**[驗證]**
- `flutter test test/version_test.dart`：由失敗轉為通過（`main` 由紅轉綠）。
- `flutter test`：462 項全數通過。
- `flutter analyze`：無 error/warning（6 項既有 `withOpacity` deprecation info，非本次範圍）。
- `example/`：`flutter analyze` 無問題——它原本就有傳 `navigatorKey`，可作為此 requirement 一直存在的旁證。

## Summary by Sourcery

发布 2.1.0，将构造函数、文档和测试统一到必需的 `navigatorKey` 上，同时为仪表盘错误徽章编写文档，并修正报告的包版本。

新功能：
- 通过测试和更新变更日志，在 Console 和 Network 标签页中记录并校验仪表盘错误徽章。

错误修复：
- 将 `FlutterInspector.navigatorKey` 设为必需参数，防止在省略该 key 时仪表盘路由静默失败。
- 将内部的 `packageVersion` 常量和 README 中的安装代码片段同步到 2.1.0，以确保导出的报告和版本 API 能正确报告当前发行版本。

改进：
- 在 2.0.0 和 2.1.0 的变更日志中，进一步澄清并扩展关于 `navigatorKey` 必填要求及迁移步骤的说明。
- 改进 README（英文和繁体中文）中的初始化指导，展示完整的 `navigatorKey` 接线流程，并解释在未正确配置 `MaterialApp` 时的失败模式。
- 在仪表盘的时间线和网络视图以及一些工具型组件中，进行小范围的 UI 和格式优化。

文档：
- 更新英文和繁体中文 README，展示必需的 `navigatorKey` 接线方式、当前安装版本，以及与该 key 绑定的通知行为。

测试：
- 更新所有与 inspector 相关的测试和观察者，在构造 `FlutterInspector` 时传入 `navigatorKey`，以在新的必需构造函数签名下保持测试覆盖率，并验证错误徽章的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Release 2.1.0, aligning the constructor, documentation, and tests around a required navigatorKey while documenting dashboard error badges and correcting the reported package version.

New Features:
- Document and validate dashboard error badges on Console and Network tabs via tests and changelog entry.

Bug Fixes:
- Make FlutterInspector.navigatorKey a required parameter so dashboard routing cannot silently fail when the key is omitted.
- Synchronize the internal packageVersion constant and README installation snippets to 2.1.0 so exported reports and version APIs report the correct release.

Enhancements:
- Clarify and expand CHANGELOG notes for 2.0.0 and 2.1.0 around the navigatorKey requirement and migration steps.
- Improve README (English and zh-TW) initialization guidance to show end-to-end navigatorKey wiring and explain failure modes if MaterialApp is not configured.
- Apply minor UI and formatting cleanups in dashboard timeline and network views and utility widgets.

Documentation:
- Update English and Traditional Chinese READMEs to show required navigatorKey wiring, current install version, and notification behavior tied to the same key.

Tests:
- Update all inspector-related tests and observers to construct FlutterInspector with a navigatorKey, keeping coverage green under the new required constructor signature and validating error badges behavior.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重大变更**
  * `navigatorKey` 现为必填配置，需同时传入检查工具和应用的 `MaterialApp`/`WidgetsApp`。
  * 仪表板入口改用导航键打开；未正确挂载时，相关入口和通知点击将无法访问。
  * `openDashboard()` 不再需要传入上下文。

* **改进**
  * 优化仪表板错误徽章及报告版本显示。

* **文档**
  * 更新初始化、网络通知及迁移示例，补充导航键配置说明。

* **版本**
  * 升级至 2.1.0。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->