### PR TITLE
feat(console): add search/level filter with jump-back to full timeline

### DIFF
--- a/.claude/skills/gen-dev-workflow/scripts/wf-state.sh
+++ b/.claude/skills/gen-dev-workflow/scripts/wf-state.sh
@@ -95,7 +95,7 @@ slugify() { echo "${1//\//-}"; }
 
 legal_transition() {
   case "$1->$2" in
-    "0a->0b"|"0b->1"|"1->2"|"2->3"|"3->4"|"3->2"|"4->done"|"reviewer->responder"|"responder->reviewer"|"reviewer->publisher") return 0 ;;
+    "0a->0b"|"0b->1"|"1->2"|"2->3"|"3->4"|"3->2"|"4->done"|"4->5"|"5->4"|"5->5"|"4->6"|"5->6"|"6->done"|"reviewer->responder"|"responder->reviewer"|"reviewer->publisher") return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/docs/features/2026-08-14-console-search-filter-jump.md
+++ b/docs/features/2026-08-14-console-search-filter-jump.md
@@ -1,0 +1,176 @@
+# 功能規格：Console 搜尋／過濾 + 點擊清過濾捲回主時間軸（§D1 + §P5）
+
+> 來源：`docs/brainstorm/2026-08-14-features-brainstorm.md` §D1（L268）+ §P5（L474）
+> Tier 3 · 檢索既有資訊 ｜ Effort: med ｜ 排查價值：⭐⭐⭐
+
+## What：這個功能是什麼
+
+在 ConsoleTab 的四源混合時間軸（log / network / nav / db）上，補上 NetworkTab 已有而
+Console 缺的檢索能力，**並且讓檢索完能回到完整脈絡**：
+
+1. **搜尋欄** — 關鍵字比對 entry 的文字內容
+2. **LogLevel 過濾** — verbose / debug / info / warning / error 多選 FilterChip
+3. **errors-only 快捷** — 一鍵等價於「warning + error level ＋ 失敗的網路請求」
+4. **點擊結果跳回主時間軸** — 點搜尋結果 → 清掉過濾 → 捲到該筆位置
+
+## Why：為什麼是這四項綁在一起
+
+### 為什麼不能只做過濾（§D1 單獨）
+
+文件 2026-07-24 的重新定性講得很清楚：
+
+> **過濾是點查詢（你已知道要找什麼），排查是鏈推斷（你不知道要找什麼）。**
+
+單獨的過濾**主動切斷因果鏈** —— 搜「timeout」剩 3 筆 error，前後的 API 呼叫與路由跳轉
+全被濾掉。但排查要問的不是「這筆 error 長什麼樣」，是「為什麼走到這裡」。
+
+### 為什麼不能只做跳轉（§P5 單獨）
+
+§P5 原案只能跳到「最新一筆 error」，跳不到「我搜到的那一筆」。
+
+### 合起來才閉環
+
+```
+搜到 → 點擊 → 清過濾 + 捲到該位置 → 站回完整四源時間軸看前後
+```
+
+這也正是 §D3（±5s 側欄）想解決卻解錯的同一個問題 —— 側欄用固定時間窗**猜**相關範圍，
+跳回主時間軸則讓使用者自己決定要往前看多遠。
+
+## 使用者故事
+
+**US-1**：QA 回報「結帳頁偶爾轉圈不會停」。開發者開 Console，搜 `checkout`，
+看到 3 筆相關請求，點最後一筆 → 過濾清空、時間軸捲到該筆 → 看見它前面
+一筆 `NavigatorEntry` push 了兩次，確認是重複導航造成重複請求。
+
+**US-2**：開發者只想快速掃有沒有錯誤，點 `⚡ errors-only`，
+四源裡的 error log 與失敗網路請求一次到齊，不必逐一切 source chip。
+
+**US-3**：開發者知道問題在 log 而非網路，點 `warning` + `error` 兩個 level chip，
+info/debug 的雜訊消失，但網路與導航事件仍在（level 過濾只作用於 log 類 entry）。
+
+## 驗收條件
+
+| # | 條件 |
+|---|------|
+| AC-1 | 搜尋欄輸入關鍵字後，只顯示文字內容命中的 entry；清空還原全部 |
+| AC-2 | 搜尋比對**四種 entry 各自的可讀欄位**（log: message/stackTrace；network: url/method/status；nav: routeName/displayName；db: tableName/operation） |
+| AC-3 | LogLevel chip 多選，**只作用於 LogEntry**；未選任何 level 等同全選 |
+| AC-4 | LogLevel 過濾啟用時，非 log 類 entry（network/nav/db）**不被濾掉** |
+| AC-5 | `⚡ errors-only` 是**單一條件內部的聯集**（唯一的 OR）：`LogEntry` 取 `level ∈ {warning, error}` **OR** `NetworkEntry` 取 `isFailed == true`。兩者型別互斥，寫成 AND 結果恆為空 —— 這是本規格唯一的聯集，不可與 AC-6 的條件間交集混淆 |
+| AC-5a | `⚡ errors-only` 啟用時，`NavigatorEntry` 與 `DatabaseEntry` **一律濾掉**（它們沒有「錯誤」語意，不適用 AC-4 的放行例外） |
+| AC-6 | 搜尋 × source 過濾 × level(或 errors-only) 三者**正交疊加**：**條件與條件之間一律取交集（AND）**，任一條件為空即該條件不設限。⚠️ 唯一的聯集發生在 AC-5 的 errors-only **內部**（跨型別 OR），不影響本條的條件間 AND |
+| AC-6a | **level + 搜尋**：選 `error` chip ＋ 搜 `cart` → `LogEntry` 需同時滿足 `level==error` 且文字含 `cart`；`NetworkEntry`/`NavigatorEntry`/`DatabaseEntry` **只需**文字含 `cart`（依 AC-4，level 不施加於非 log entry）。即：成功的 `GET /api/cart` **仍然顯示** |
+| AC-6b | **level + source**：選 `error` chip ＋ source 切到 `Network` → 結果為所有 network entry（level 對其不設限），不是空清單 |
+| AC-6c | **搜尋 + source**：搜 `cart` ＋ source 切到 `Log` → 只有 message/stackTrace 含 `cart` 的 log |
+| AC-6d | **三者同時**：`error` chip ＋ 搜 `cart` ＋ source 切到 `Log` → 只有 `level==error` 且文字含 `cart` 的 log（此時 AC-4 的例外不生效，因為 source 已排除非 log 型別） |
+| AC-6e | **errors-only + 搜尋**：`⚡ errors-only` ＋ 搜 `cart` → 先取 AC-5 的內層聯集（warning/error log ∪ isFailed 請求），**再與**搜尋條件取交集。即 `(errorsOnly(e)) && (keyword(e))`，關鍵字套在聯集之後、不是只套其中一支 |
+| AC-7 | 過濾有作用時點擊任一 entry → 清空所有過濾條件 + 時間軸捲動到該 entry 位置 |
+| AC-8 | 過濾無作用（未過濾）時點擊 entry → 維持既有行為（開 detail view），不觸發跳轉 |
+| AC-9 | 過濾後無命中時顯示 `No matches`（對齊 NetworkTab 既有文案） |
+| AC-10 | 既有功能零回歸：source chip、📌 Bookmarks、refresh、clear、error 底色高亮 |
+
+## 範圍邊界
+
+### 在範圍內
+
+- `ConsoleFilter` + `applyConsoleFilter()` 純函式（鏡射既有 `NetworkFilter` / `applyNetworkFilter`）
+- ConsoleTab 的搜尋欄、LogLevel chip、errors-only chip UI
+- 點擊跳轉：清過濾 + `ScrollController.animateTo`
+- 對應單元測試（過濾邏輯）與 widget 測試（跳轉行為）
+
+### 明確不在範圍內
+
+| 不做 | 理由 |
+|------|------|
+| 提取 `network_tab.dart` 的私有 `_SearchBar` 為共用元件 | 跨檔重構會擴大 diff 與回歸面；Console 先自建一份，日後兩邊都穩定再談收斂 |
+| 為 `TimestampedEntry` 增加 `searchableText` 等新介面成員 | 該介面刻意鎖為窄契約（`abstract interface class`，註解明寫「存在的唯一理由是提供排序鍵」），不為過濾污染它 |
+| §P5 原案的「⬆ Jump to Latest Error」浮動按鈕 | 合併後由「搜尋 → 點擊跳轉」覆蓋；獨立 FAB 會與點擊跳轉語意重疊 |
+| 捲動位置的持久化／錨定 entry identity | Console 是持續有新事件湧入的流，錨定機制成本高（見下方風險），本次跳轉為一次性 |
+| DatabaseTab 的搜尋過濾（§D4） | 獨立項目，寫入路徑不重疊，不併入 |
+
+## 已知風險與設計約束
+
+### R-1：搜尋語意必須是「過濾」，不是「捲動」
+
+既有 `NetworkTab` 把 `applyNetworkFilter()` 結果直接餵 `ListView.builder`，
+不匹配的 entry 根本不建立，全程無 `ScrollController`。Console 必須沿用**過濾語意**。
+
+捲動語意在此會壞掉：Console 是持續有新事件湧入的混合流，捲到第 300 筆後新事件進來
+會把目標推走，要修就得引入「錨定 entry identity + 重算 index」的狀態管理 ——
+為一個搜尋框長出一整套機制。
+
+**但 AC-7 的跳轉需要 `ScrollController`。** 兩者不衝突：`ScrollController` 只在
+「點擊結果」這個一次性動作使用（`animateTo` 後即結束），不用於維持捲動狀態。
+
+### R-2：`entriesAtLevel()` 接不上，不可重用
+
+`LogInspector.entriesAtLevel()` 回傳 `List<LogEntry>`，而 ConsoleTab 渲染的是
+`mergedTimeline` 的四源混合流 `List<TimestampedEntry>` —— 型別接不上。
+需另寫吃 `List<TimestampedEntry>` 的過濾函式。
+
+（`entriesAtLevel()` 現有 2 處呼叫都在 `dashboard_modal.dart` 算 badge，不受影響。）
+
+### R-3：`InspectorSearchBar` 不存在
+
+文件早期估計說「元件已存在只需接入」是錯的。`network_tab.dart` 內是**私有的
+`_SearchBar`**，跨檔不可見。本次在 console 側自建一份（見「不在範圍內」的理由）。
+
+### R-4：level 過濾對非 log entry 的語意（AC-4 的由來）
+
+`LogLevel` 只有 `LogEntry` 有。若把「未命中 level」直接判為過濾掉，
+network/nav/db 三種 entry 會在使用者點任一 level chip 時**全部消失** ——
+這會讓 level 過濾實質變成「只看 log」，與 source chip 功能重疊且違反正交性。
+
+**正確語意**：level 約束只施加於 `LogEntry`，其餘型別不受 level 條件影響。
+
+**與搜尋併用時最容易寫錯**（AC-6a 的由來）：選 `error` chip ＋ 搜 `cart` 時，
+直覺會想成「找 cart 的錯誤」而把成功的 `GET /api/cart` 濾掉 —— 但那是**把 level
+條件套到了 NetworkEntry 上**，違反本節語意，並讓 level chip 退化成 source chip。
+
+正確做法是各條件獨立求值後取交集，level 條件在遇到非 `LogEntry` 時直接回 `true`：
+
+```dart
+// ── 外層：條件與條件之間一律 AND（AC-6）──
+bool matches(TimestampedEntry entry) =>
+    _matchesLevel(entry) && _matchesKeyword(entry);
+
+// level 只約束 LogEntry，其餘型別一律放行
+bool _matchesLevel(TimestampedEntry entry) {
+  if (errorsOnly) return _matchesErrorsOnly(entry);  // errors-only 取代 level
+  if (levels.isEmpty) return true;
+  if (entry is! LogEntry) return true;   // ← AC-4 / AC-6a 的關鍵
+  return levels.contains(entry.level);
+}
+
+// ── 內層：唯一的 OR（AC-5）──
+// 型別互斥，寫成 AND 恆為空；nav/db 無「錯誤」語意故一律濾掉（AC-5a）
+bool _matchesErrorsOnly(TimestampedEntry entry) => switch (entry) {
+  final LogEntry e =>
+    e.level == LogLevel.warning || e.level == LogLevel.error,
+  final NetworkEntry e => e.isFailed,   // 重用 §P7 的收斂判定（R-5）
+  _ => false,
+};
+```
+
+**兩層結構一句話**：條件之間 AND，errors-only 內部 OR。搞混會得到兩種錯誤結果 ——
+把內層寫成 AND → errors-only 永遠空清單；把外層寫成 OR → 搜尋失效（任一條件命中就顯示）。
+
+### R-5：`errors-only` 必須重用 `NetworkEntry.isFailed`
+
+§P7 的教訓（同一份文件記載）：「網路請求是否失敗」的判定曾在三個檔案各手寫一份
+且已漂移、各漏一種失敗類型，最後收斂成 `NetworkEntry.isFailed`。
+
+本次 errors-only 的網路側判定**一律呼叫 `entry.isFailed`**，不得重寫等價邏輯。
+
+## 影響範圍
+
+| 檔案 | 動作 |
+|------|------|
+| `lib/src/utils/console_utils.dart` | **新增** — `ConsoleFilter` + `applyConsoleFilter()` |
+| `lib/src/ui/dashboard/tabs/console_tab.dart` | 修改 — 搜尋欄、level chips、errors-only chip、ScrollController、點擊跳轉 |
+| `test/console_utils_test.dart` | **新增** — 過濾邏輯單元測試 |
+| `test/console_tab_test.dart` | 新增或擴充 — 跳轉與正交疊加的 widget 測試 |
+
+**零改動**：`TimestampedEntry`（窄契約不動）、`LogInspector`、`network_tab.dart`、
+`NetworkFilter`、四個 model 檔。

--- a/docs/features/2026-08-14-console-search-filter-jump.md
+++ b/docs/features/2026-08-14-console-search-filter-jump.md
@@ -30,7 +30,7 @@ Console 缺的檢索能力，**並且讓檢索完能回到完整脈絡**：
 
 ### 合起來才閉環
 
-```
+```text
 搜到 → 點擊 → 清過濾 + 捲到該位置 → 站回完整四源時間軸看前後
 ```
 
@@ -169,8 +169,8 @@ bool _matchesErrorsOnly(TimestampedEntry entry) => switch (entry) {
 |------|------|
 | `lib/src/utils/console_utils.dart` | **新增** — `ConsoleFilter` + `applyConsoleFilter()` |
 | `lib/src/ui/dashboard/tabs/console_tab.dart` | 修改 — 搜尋欄、level chips、errors-only chip、ScrollController、點擊跳轉 |
-| `test/console_utils_test.dart` | **新增** — 過濾邏輯單元測試 |
-| `test/console_tab_test.dart` | 新增或擴充 — 跳轉與正交疊加的 widget 測試 |
+| `test/utils/console_utils_test.dart` | **新增** — 過濾邏輯單元測試 |
+| `test/ui/tabs/console_tab_test.dart` | 新增或擴充 — 跳轉與正交疊加的 widget 測試 |
 
 **零改動**：`TimestampedEntry`（窄契約不動）、`LogInspector`、`network_tab.dart`、
 `NetworkFilter`、四個 model 檔。

--- a/docs/plans/2026-08-14-console-search-filter-jump.md
+++ b/docs/plans/2026-08-14-console-search-filter-jump.md
@@ -1,0 +1,226 @@
+# 實作計畫：Console 搜尋／過濾 + 點擊清過濾捲回主時間軸（§D1 + §P5）
+
+> 規格：`docs/features/2026-08-14-console-search-filter-jump.md`
+> Effort: med ｜ 4 個任務 ｜ 預估 diff：新增 2 檔、修改 1 檔、新增/擴充 2 測試檔
+
+## 資料結構（先定這個，其餘都是它的後果）
+
+### `ConsoleFilter` — 鏡射 `NetworkFilter`，但多一層型別分派
+
+既有 `NetworkFilter`（`lib/src/utils/network_utils.dart:65`）是單一型別（`NetworkEntry`）的過濾器。
+`ConsoleFilter` 面對的是四源混合流 `List<TimestampedEntry>`，差異全在此。
+
+```dart
+@immutable
+class ConsoleFilter {
+  const ConsoleFilter({
+    this.keyword = '',
+    this.levels = const <LogLevel>{},
+    this.errorsOnly = false,
+  });
+
+  final String keyword;
+  final Set<LogLevel> levels;
+  final bool errorsOnly;
+
+  bool get isEmpty => keyword.trim().isEmpty && levels.isEmpty && !errorsOnly;
+
+  // 外層：條件之間一律 AND（AC-6）
+  bool matches(TimestampedEntry entry) =>
+      _matchesLevel(entry) && _matchesKeyword(entry);
+}
+
+/// 沿用 applyNetworkFilter 的簽章形狀與 isEmpty 短路
+List<TimestampedEntry> applyConsoleFilter(
+  List<TimestampedEntry> entries,
+  ConsoleFilter filter,
+) {
+  if (filter.isEmpty) return entries;
+  return entries.where(filter.matches).toList(growable: false);
+}
+```
+
+**source 過濾不進 `ConsoleFilter`**：它已由 `inspector.mergedTimeline(sources:)` 在
+資料源頭處理（`console_tab.dart:75`），重複實作會產生兩份判定 —— 正是 §P7 的教訓。
+AC-6b/6c/6d 的 source 維度靠既有機制，`ConsoleFilter` 只管 keyword + level/errorsOnly。
+
+### 為什麼不動 `TimestampedEntry`
+
+該介面是 `abstract interface class`，註解明寫「存在的唯一理由是讓 mergedTimeline
+能用單一型別索取排序鍵」。加 `searchableText` 會讓四個 model 都被迫實作一個
+只為 UI 過濾存在的成員 —— 窄契約污染。
+
+改用 `switch (entry)` 型別分派，與 `console_tab.dart:162` 的 `_EntryRowDispatcher`
+完全同構（既有程式碼已用這個 idiom 處理四型別差異，照抄即可）。
+
+---
+
+## 任務拆分
+
+四個任務，**T1 → T2 → T3 → T4 嚴格序列**（後三者都依賴 T1 的 `ConsoleFilter`，
+且 T2/T3 寫入同一檔 `console_tab.dart`，路徑重疊不可並行）。
+
+### T1：`ConsoleFilter` + `applyConsoleFilter()` 純函式
+
+**複雜度**：標準（設計判斷已在規格定完，此處是照著寫）
+**寫入**：`lib/src/utils/console_utils.dart`（新增）
+
+實作要點：
+
+1. `_matchesKeyword` 依型別取可讀欄位（AC-2）：
+
+```dart
+bool _matchesKeyword(TimestampedEntry entry) {
+  final kw = keyword.trim().toLowerCase();
+  if (kw.isEmpty) return true;
+  return switch (entry) {
+    final LogEntry e =>
+      e.message.toLowerCase().contains(kw) ||
+      (e.stackTrace?.toLowerCase().contains(kw) ?? false),
+    final NetworkEntry e =>
+      e.url.toLowerCase().contains(kw) ||
+      e.method.toLowerCase().contains(kw) ||
+      (e.statusCode?.toString().contains(kw) ?? false),
+    final NavigatorEntry e =>
+      (e.routeName?.toLowerCase().contains(kw) ?? false) ||
+      e.displayName.toLowerCase().contains(kw),
+    final DatabaseEntry e =>
+      e.tableName.toLowerCase().contains(kw) ||
+      e.operation.name.toLowerCase().contains(kw),
+    _ => false,
+  };
+}
+```
+
+2. `_matchesLevel` 的兩層結構（AC-4 / AC-5 / AC-6a，**最容易寫錯的一段**）：
+
+```dart
+bool _matchesLevel(TimestampedEntry entry) {
+  if (errorsOnly) return _matchesErrorsOnly(entry);  // errors-only 取代 level
+  if (levels.isEmpty) return true;
+  if (entry is! LogEntry) return true;   // ← AC-4/AC-6a：level 不施加於非 log
+  return levels.contains(entry.level);
+}
+
+// 內層：唯一的 OR（AC-5）。型別互斥，寫成 AND 恆為空
+bool _matchesErrorsOnly(TimestampedEntry entry) => switch (entry) {
+  final LogEntry e =>
+    e.level == LogLevel.warning || e.level == LogLevel.error,
+  final NetworkEntry e => e.isFailed,   // 重用 §P7 收斂判定，不重寫（R-5）
+  _ => false,                            // nav/db 一律濾掉（AC-5a）
+};
+```
+
+**驗收**：`test/utils/console_utils_test.dart`（新增，模板為既有
+`test/utils/network_utils_test.dart`）。必測 AC-6a/6b/6e 三個組合，
+以及 AC-5a 的 nav/db 濾除。
+
+---
+
+### T2：ConsoleTab 接入搜尋欄 + level chips + errors-only chip
+
+**複雜度**：標準
+**寫入**：`lib/src/ui/dashboard/tabs/console_tab.dart`
+
+1. `_ConsoleTabState` 新增 `ConsoleFilter _filter = const ConsoleFilter()`
+2. `build()` 第 75 行後套用：`entries = applyConsoleFilter(entries, _filter)`
+   —— **順序**：`mergedTimeline(sources:)` → `applyConsoleFilter` → bookmark 過濾
+3. 搜尋欄：自建私有 `_SearchBar`（**不**跨檔提取 `network_tab.dart` 的同名私有元件，
+   見規格「不在範圍內」）。用 `TextField` + `onChanged`，對齊 NetworkTab 的模式
+4. level chips：`for (final level in LogLevel.values)` 產生 5 個 `FilterChip`，多選
+5. errors-only chip：`⚡ errors-only`，選中時 `levels` 的 UI 呈現為 disabled
+   （語意上 errorsOnly 已取代 level，見 T1 的 `_matchesLevel` 短路）
+6. 空狀態：過濾後無命中顯示 `No matches`（AC-9），與既有
+   `No bookmarked entries` 分支並存
+
+**⚠️ 既有 chip 列已橫向捲動**（`SingleChildScrollView(scrollDirection: Axis.horizontal)`，
+L85-86）。新增 5 個 level chip + 1 個 errors-only 會讓該列更長 —— 沿用既有捲動容器即可，
+不要改成換行佈局（那會動到既有 source chip 的排版，擴大回歸面）。
+
+**驗收**：AC-1/3/5/9 + AC-10 零回歸（既有 `console_tab_test.dart` 全綠）
+
+---
+
+### T3：點擊清過濾 + 捲回主時間軸
+
+**複雜度**：需設計判斷（狀態與捲動的交互）
+**寫入**：`lib/src/ui/dashboard/tabs/console_tab.dart`
+
+1. `_ConsoleTabState` 新增 `final ScrollController _scrollController = ScrollController()`
+   —— **必須在 `dispose()` 中 `_scrollController.dispose()`**（style guide §7.4 資源管理）
+2. `ListView.builder` 掛上 `controller: _scrollController`
+3. `_EntryRowDispatcher` 增加 `onJumpToEntry` 回呼；各 `_*EntryRow` 的 `onTap`：
+   - 過濾**有作用**時（`!_filter.isEmpty`）→ 觸發跳轉（AC-7）
+   - 過濾**無作用**時 → 維持既有行為開 detail view（AC-8）
+4. 跳轉實作：
+
+```dart
+Future<void> _jumpToEntry(TimestampedEntry entry) async {
+  // 1. 先在「清過濾後的完整清單」中定位目標 index
+  final full = widget.inspector.mergedTimeline(sources: _all);
+  final index = full.indexOf(entry);
+  if (index < 0) return;            // 已被 RingBuffer 淘汰，靜默放棄
+
+  // 2. 清空所有過濾條件並還原 source 為 All
+  setState(() {
+    _filter = const ConsoleFilter();
+    _selected = {..._all};
+    _showOnlyBookmarks = false;
+  });
+
+  // 3. 等重建完成才捲動 —— 清過濾後清單長度改變，
+  //    在同一幀捲動會用到舊的 extent
+  await WidgetsBinding.instance.endOfFrame;
+  if (!mounted) return;             // style guide §7.5：await 後檢查 mounted
+  if (!_scrollController.hasClients) return;
+  ...animateTo(...)
+}
+```
+
+**⚠️ 兩個非顯而易見的坑**（動工前先讀）：
+
+- **`indexOf` 依賴 `==`**。四個 model 是 immutable 且已有 `==`/`hashCode`
+  （`NetworkEntry` 刻意把 `WeakReference<Dio>` 排除在外）。若 `indexOf` 回 -1，
+  多半是 entry 已被 RingBuffer 淘汰 —— 靜默放棄，不拋錯。
+- **捲動位置需估算**：`ListView.builder` 的 item 高度不定（各型別 row 不同），
+  無法精確算 offset。用 `index * 估算行高` 近似即可 ——
+  **不要**為此引入 `scrollable_positioned_list` 新相依（規格「不在範圍內」的精神）。
+  近似落在目標附近即滿足「站回完整時間軸看前後」的目的。
+
+**驗收**：AC-7/AC-8
+
+---
+
+### T4：測試補齊 + 全套回歸
+
+**複雜度**：機械性
+**寫入**：`test/utils/console_utils_test.dart`（T1 已建，此處補齊）、
+`test/ui/tabs/console_tab_test.dart`（擴充）
+
+1. 補齊 AC-6a~6e 五個組合的單元測試（T1 只需涵蓋 6a/6b/6e，此處補 6c/6d）
+2. widget 測試：搜尋 → 點擊 → 驗證過濾已清空（AC-7）
+3. 跑全套 `flutter test` 確認零回歸
+
+**⚠️ 既有 timeout 注意**：`magical_tap_test` 有 10 分鐘既有 timeout，
+跑全套時預留時間，不要誤判為卡死。
+
+---
+
+## 風險與回滾
+
+| 風險 | 緩解 |
+|------|------|
+| chip 列過長影響既有 source chip 排版 | 沿用既有橫向捲動容器，不改佈局結構（T2） |
+| 捲動位置不精確 | 接受近似（估算行高）；不引入新相依 |
+| `indexOf` 回 -1（entry 已淘汰） | 靜默放棄跳轉，不拋錯不提示 |
+| 既有 console 測試回歸 | T2/T3 各自跑一次 `console_tab_test.dart`，不等到 T4 |
+
+**回滾點**：四個任務各自獨立 commit。T3 若出問題可單獨 revert，
+T1+T2 的過濾功能仍可用（只是少了跳轉）。
+
+## 不做的事（防止範圍蔓延）
+
+- 不提取 `network_tab.dart` 的 `_SearchBar` 為共用元件
+- 不動 `TimestampedEntry` / `LogInspector` / `NetworkFilter` / 四個 model
+- 不做 `entriesAtLevel()` 的重構（它在 dashboard badge 的 2 處呼叫不受影響）
+- 不順手修 `console_tab.dart:19` 的 `withOpacity` deprecation（無關變更，另案處理）

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 import '../../../core/flutter_inspector.dart';
 import '../../../models/database_entry.dart';
@@ -45,6 +46,8 @@ class _ConsoleTabState extends State<ConsoleTab> {
   /// Keyword and level constraints applied on top of the source selection.
   ConsoleFilter _filter = const ConsoleFilter();
 
+  final ScrollController _scrollController = ScrollController();
+
   static const Set<TimelineSource> _all = {
     TimelineSource.log,
     TimelineSource.network,
@@ -58,6 +61,12 @@ class _ConsoleTabState extends State<ConsoleTab> {
     TimelineSource.nav: 'Nav',
     TimelineSource.db: 'DB',
   };
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   void _refresh() => setState(() {});
 
@@ -92,6 +101,42 @@ class _ConsoleTabState extends State<ConsoleTab> {
       errorsOnly: false,
     );
   });
+
+  /// Row height used to approximate a scroll offset.
+  ///
+  /// Rows vary in height by type, so there is no exact offset to compute
+  /// without measuring every row above the target. Landing near the entry is
+  /// enough to read what came before and after it, which is the whole point of
+  /// going back to the full timeline.
+  static const double _kApproxRowHeight = 72;
+
+  /// Clears every filter and scrolls the full timeline to [entry].
+  Future<void> _jumpToEntry(TimestampedEntry entry) async {
+    final index = widget.inspector.mergedTimeline(sources: _all).indexOf(entry);
+    // Gone from the ring buffer between render and tap: nothing to scroll to.
+    if (index < 0) return;
+
+    setState(() {
+      _filter = const ConsoleFilter();
+      _selected = {..._all};
+      _showOnlyBookmarks = false;
+    });
+
+    // The list is longer now, so its scroll extent is too. Scrolling in the
+    // same frame would clamp against the filtered list's old extent.
+    await SchedulerBinding.instance.endOfFrame;
+    if (!mounted || !_scrollController.hasClients) return;
+
+    final offset = (index * _kApproxRowHeight).clamp(
+      0.0,
+      _scrollController.position.maxScrollExtent,
+    );
+    await _scrollController.animateTo(
+      offset,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+    );
+  }
 
   void _toggleErrorsOnly() => setState(() {
     _filter = ConsoleFilter(
@@ -181,6 +226,7 @@ class _ConsoleTabState extends State<ConsoleTab> {
               : !_filter.isEmpty && entries.isEmpty
               ? const Center(child: Text('No matches'))
               : ListView.builder(
+                  controller: _scrollController,
                   itemCount: entries.length,
                   itemBuilder: (context, index) => _EntryRowDispatcher(
                     entry: entries[index],
@@ -188,11 +234,31 @@ class _ConsoleTabState extends State<ConsoleTab> {
                     onToggleBookmark: () => setState(() {
                       widget.inspector.toggleBookmark(entries[index]);
                     }),
+                    onJump: _filter.isEmpty
+                        ? null
+                        : () => _jumpToEntry(entries[index]),
                   ),
                 ),
         ),
       ],
     );
+  }
+}
+
+/// Wraps a row so the whole thing jumps back to the unfiltered timeline.
+///
+/// The row keeps its own visuals; [IgnorePointer] on the child is what stops
+/// its normal tap (detail view, bookmark long-press) from competing with the
+/// jump while a filter is active.
+class _JumpRow extends StatelessWidget {
+  const _JumpRow({required this.onJump, required this.child});
+
+  final VoidCallback? onJump;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(onTap: onJump, child: child);
   }
 }
 
@@ -264,14 +330,36 @@ class _EntryRowDispatcher extends StatelessWidget {
     required this.entry,
     required this.inspector,
     required this.onToggleBookmark,
+    this.onJump,
   });
 
   final TimestampedEntry entry;
   final FlutterInspector inspector;
   final VoidCallback onToggleBookmark;
 
+  /// Set only while a filter is narrowing the list. Tapping a row then means
+  /// "take me back to this moment in the full timeline" rather than "show me
+  /// this entry's details" — the detail view is one tap away again afterwards.
+  final VoidCallback? onJump;
+
   @override
   Widget build(BuildContext context) {
+    // Intercepting here rather than in each row keeps the two tap meanings in
+    // one place, and gives navigation/database rows a jump target even though
+    // they have no detail view of their own to tap into.
+    if (onJump != null) {
+      return _JumpRow(
+        onJump: onJump,
+        child: IgnorePointer(
+          child: _EntryRowDispatcher(
+            entry: entry,
+            inspector: inspector,
+            onToggleBookmark: onToggleBookmark,
+          ),
+        ),
+      );
+    }
+
     switch (entry) {
       case final LogEntry e:
         return _LogEntryRow(

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -245,20 +245,32 @@ class _ConsoleTabState extends State<ConsoleTab> {
   }
 }
 
-/// Wraps a row so the whole thing jumps back to the unfiltered timeline.
+/// Wraps a row so tapping it jumps back to the unfiltered timeline.
 ///
-/// The row keeps its own visuals; [IgnorePointer] on the child is what stops
-/// its normal tap (detail view, bookmark long-press) from competing with the
-/// jump while a filter is active.
+/// Only the tap is taken over. Long-press still reaches the row underneath, so
+/// bookmarking keeps working while a filter is active — an entry you just
+/// searched for is precisely one you may want to pin.
 class _JumpRow extends StatelessWidget {
-  const _JumpRow({required this.onJump, required this.child});
+  const _JumpRow({
+    required this.onJump,
+    required this.onLongPress,
+    required this.child,
+  });
 
   final VoidCallback? onJump;
+  final VoidCallback onLongPress;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(onTap: onJump, child: child);
+    return GestureDetector(
+      // The child is wrapped in IgnorePointer, so without an opaque behavior
+      // there is nothing left to hit-test and neither gesture would fire.
+      behavior: HitTestBehavior.opaque,
+      onTap: onJump,
+      onLongPress: onLongPress,
+      child: child,
+    );
   }
 }
 
@@ -350,6 +362,9 @@ class _EntryRowDispatcher extends StatelessWidget {
     if (onJump != null) {
       return _JumpRow(
         onJump: onJump,
+        onLongPress: onToggleBookmark,
+        // Absorbs the row's own tap (detail view) so it cannot compete with
+        // the jump, while _JumpRow re-offers long-press above it.
         child: IgnorePointer(
           child: _EntryRowDispatcher(
             entry: entry,

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -48,6 +48,11 @@ class _ConsoleTabState extends State<ConsoleTab> {
 
   final ScrollController _scrollController = ScrollController();
 
+  /// Owned here (not by [_SearchBar]) so [_jumpToEntry] can clear the
+  /// visible text when it resets [_filter] — otherwise the field would keep
+  /// showing a keyword that no longer filters anything.
+  final TextEditingController _searchController = TextEditingController();
+
   static const Set<TimelineSource> _all = {
     TimelineSource.log,
     TimelineSource.network,
@@ -65,6 +70,7 @@ class _ConsoleTabState extends State<ConsoleTab> {
   @override
   void dispose() {
     _scrollController.dispose();
+    _searchController.dispose();
     super.dispose();
   }
 
@@ -116,6 +122,7 @@ class _ConsoleTabState extends State<ConsoleTab> {
     // Gone from the ring buffer between render and tap: nothing to scroll to.
     if (index < 0) return;
 
+    _searchController.clear();
     setState(() {
       _filter = const ConsoleFilter();
       _selected = {..._all};
@@ -158,7 +165,7 @@ class _ConsoleTabState extends State<ConsoleTab> {
 
     return Column(
       children: [
-        _SearchBar(onChanged: _setKeyword),
+        _SearchBar(controller: _searchController, onChanged: _setKeyword),
         Row(
           children: [
             Expanded(
@@ -280,8 +287,11 @@ class _JumpRow extends StatelessWidget {
 /// refresh/clear buttons and a match counter: the console keeps those in its
 /// own chip row, so bundling them here would duplicate existing controls.
 class _SearchBar extends StatefulWidget {
-  const _SearchBar({required this.onChanged});
+  const _SearchBar({required this.controller, required this.onChanged});
 
+  /// Owned by the parent [_ConsoleTabState] so a jump-to-entry can clear the
+  /// visible text alongside the filter it resets.
+  final TextEditingController controller;
   final ValueChanged<String> onChanged;
 
   @override
@@ -289,16 +299,8 @@ class _SearchBar extends StatefulWidget {
 }
 
 class _SearchBarState extends State<_SearchBar> {
-  final TextEditingController _controller = TextEditingController();
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
   void _clear() {
-    _controller.clear();
+    widget.controller.clear();
     widget.onChanged('');
     setState(() {});
   }
@@ -313,12 +315,12 @@ class _SearchBarState extends State<_SearchBar> {
         ThemeSize.space4,
       ),
       child: TextField(
-        controller: _controller,
+        controller: widget.controller,
         decoration: InputDecoration(
           isDense: true,
           hintText: 'Search message / url / route / table',
           prefixIcon: const Icon(Icons.search, size: ThemeSize.size20),
-          suffixIcon: _controller.text.isEmpty
+          suffixIcon: widget.controller.text.isEmpty
               ? null
               : IconButton(
                   icon: const Icon(Icons.clear, size: ThemeSize.size20),

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -9,6 +9,7 @@ import '../../../models/network_entry.dart';
 import '../../../models/timestamped_entry.dart';
 import '../../../extensions/log_level_color_extension.dart';
 import '../../../observers/inspector_route_names.dart';
+import '../../../utils/console_utils.dart';
 import '../../theme/theme.dart';
 import 'console/log_detail_view.dart';
 import 'network/network_detail_view.dart';
@@ -41,6 +42,9 @@ class _ConsoleTabState extends State<ConsoleTab> {
 
   bool _showOnlyBookmarks = false;
 
+  /// Keyword and level constraints applied on top of the source selection.
+  ConsoleFilter _filter = const ConsoleFilter();
+
   static const Set<TimelineSource> _all = {
     TimelineSource.log,
     TimelineSource.network,
@@ -70,15 +74,46 @@ class _ConsoleTabState extends State<ConsoleTab> {
     _showOnlyBookmarks = false;
   });
 
+  void _setKeyword(String keyword) => setState(() {
+    _filter = ConsoleFilter(
+      keyword: keyword,
+      levels: _filter.levels,
+      errorsOnly: _filter.errorsOnly,
+    );
+  });
+
+  void _toggleLevel(LogLevel level) => setState(() {
+    final levels = {..._filter.levels};
+    if (!levels.remove(level)) levels.add(level);
+    _filter = ConsoleFilter(
+      keyword: _filter.keyword,
+      levels: levels,
+      // Picking a level means the user wants that level, not "all failures".
+      errorsOnly: false,
+    );
+  });
+
+  void _toggleErrorsOnly() => setState(() {
+    _filter = ConsoleFilter(
+      keyword: _filter.keyword,
+      // The shortcut supersedes the level set, so drop it rather than leave a
+      // selection that has no effect while the chip is on.
+      levels: const {},
+      errorsOnly: !_filter.errorsOnly,
+    );
+  });
+
   @override
   Widget build(BuildContext context) {
     var entries = widget.inspector.mergedTimeline(sources: _selected);
+    entries = applyConsoleFilter(entries, _filter);
     if (_showOnlyBookmarks) {
       entries = entries.where((e) => widget.inspector.isBookmarked(e)).toList();
     }
 
     return Column(
       children: [
+        _SearchBar(onChanged: _setKeyword),
         Row(
           children: [
             Expanded(
@@ -109,6 +144,20 @@ class _ConsoleTabState extends State<ConsoleTab> {
                       }),
                     ),
                     const SizedBox(width: ThemeSize.space8),
+                    FilterChip(
+                      label: const Text('⚡ Errors only'),
+                      selected: _filter.errorsOnly,
+                      onSelected: (_) => _toggleErrorsOnly(),
+                    ),
+                    for (final level in LogLevel.values) ...[
+                      const SizedBox(width: ThemeSize.space8),
+                      FilterChip(
+                        label: Text(logLevelLabels[level] ?? ''),
+                        selected: _filter.levels.contains(level),
+                        onSelected: (_) => _toggleLevel(level),
+                      ),
+                    ],
+                    const SizedBox(width: ThemeSize.space8),
                   ],
                 ),
               ),
@@ -129,6 +178,8 @@ class _ConsoleTabState extends State<ConsoleTab> {
         Expanded(
           child: _showOnlyBookmarks && entries.isEmpty
               ? const Center(child: Text('No bookmarked entries'))
+              : !_filter.isEmpty && entries.isEmpty
+              ? const Center(child: Text('No matches'))
               : ListView.builder(
                   itemCount: entries.length,
                   itemBuilder: (context, index) => _EntryRowDispatcher(
@@ -141,6 +192,68 @@ class _ConsoleTabState extends State<ConsoleTab> {
                 ),
         ),
       ],
+    );
+  }
+}
+
+/// Keyword field for the console timeline.
+///
+/// Deliberately leaner than the network tab's namesake, which also carries the
+/// refresh/clear buttons and a match counter: the console keeps those in its
+/// own chip row, so bundling them here would duplicate existing controls.
+class _SearchBar extends StatefulWidget {
+  const _SearchBar({required this.onChanged});
+
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<_SearchBar> createState() => _SearchBarState();
+}
+
+class _SearchBarState extends State<_SearchBar> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _clear() {
+    _controller.clear();
+    widget.onChanged('');
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        ThemeSize.space8,
+        ThemeSize.space8,
+        ThemeSize.space8,
+        ThemeSize.space4,
+      ),
+      child: TextField(
+        controller: _controller,
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: 'Search message / url / route / table',
+          prefixIcon: const Icon(Icons.search, size: ThemeSize.size20),
+          suffixIcon: _controller.text.isEmpty
+              ? null
+              : IconButton(
+                  icon: const Icon(Icons.clear, size: ThemeSize.size20),
+                  onPressed: _clear,
+                ),
+          border: const OutlineInputBorder(),
+        ),
+        onChanged: (value) {
+          widget.onChanged(value);
+          // Rebuild so the clear affordance tracks emptiness.
+          setState(() {});
+        },
+      ),
     );
   }
 }

--- a/lib/src/utils/console_utils.dart
+++ b/lib/src/utils/console_utils.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/database_entry.dart';
+import '../models/log_entry.dart';
+import '../models/log_level.dart';
+import '../models/navigator_entry.dart';
+import '../models/network_entry.dart';
+import '../models/timestamped_entry.dart';
+
+/// Chip labels for each [LogLevel] shown in the Console tab.
+const Map<LogLevel, String> logLevelLabels = {
+  LogLevel.verbose: 'Verbose',
+  LogLevel.debug: 'Debug',
+  LogLevel.info: 'Info',
+  LogLevel.warning: 'Warning',
+  LogLevel.error: 'Error',
+};
+
+/// An immutable filter for the Console tab's merged timeline: a
+/// case-insensitive [keyword] plus either a [levels] constraint or the
+/// [errorsOnly] shortcut.
+///
+/// Mirrors `NetworkFilter`, with one structural difference: the console renders
+/// a four-source stream of [TimestampedEntry], so every predicate dispatches on
+/// the runtime type rather than reading fields off a single model.
+///
+/// **Source filtering is deliberately absent.** It is already applied upstream
+/// by `FlutterInspector.mergedTimeline(sources:)`; re-implementing it here
+/// would create a second copy of the same decision.
+@immutable
+class ConsoleFilter {
+  /// Creates a filter. A blank [keyword], empty [levels] and `errorsOnly:
+  /// false` match everything.
+  const ConsoleFilter({
+    this.keyword = '',
+    this.levels = const <LogLevel>{},
+    this.errorsOnly = false,
+  });
+
+  /// Substring matched against each entry's readable fields
+  /// (case-insensitive).
+  final String keyword;
+
+  /// Log levels to include. Empty means "all levels".
+  ///
+  /// Ignored while [errorsOnly] is set — the shortcut supersedes it.
+  final Set<LogLevel> levels;
+
+  /// Whether to keep only failures: `warning`/`error` logs and failed network
+  /// calls. Supersedes [levels] when set.
+  final bool errorsOnly;
+
+  /// Whether this filter would match every entry (no active constraints).
+  bool get isEmpty => keyword.trim().isEmpty && levels.isEmpty && !errorsOnly;
+
+  /// Returns whether [entry] satisfies all active constraints.
+  ///
+  /// Constraints combine with AND; the only OR lives inside [_matchesErrorsOnly].
+  bool matches(TimestampedEntry entry) =>
+      _matchesLevel(entry) && _matchesKeyword(entry);
+
+  /// Applies the level constraint.
+  ///
+  /// Non-[LogEntry] types are always let through: only logs carry a
+  /// [LogLevel], so constraining them by level would silently turn this into a
+  /// source filter and hide every network/navigation/database event the moment
+  /// a level chip is picked.
+  bool _matchesLevel(TimestampedEntry entry) {
+    if (errorsOnly) return _matchesErrorsOnly(entry);
+    if (levels.isEmpty) return true;
+    if (entry is! LogEntry) return true;
+    return levels.contains(entry.level);
+  }
+
+  /// The errors-only shortcut: warning/error logs **or** failed network calls.
+  ///
+  /// This is a union across two mutually exclusive types — an entry is never
+  /// both a [LogEntry] and a [NetworkEntry], so combining them with AND would
+  /// match nothing. Navigation and database entries carry no notion of
+  /// failure, so they are dropped rather than let through.
+  bool _matchesErrorsOnly(TimestampedEntry entry) => switch (entry) {
+    final LogEntry e =>
+      e.level == LogLevel.warning || e.level == LogLevel.error,
+    // Reuses the single source of truth for "did this call fail" rather than
+    // restating it here.
+    final NetworkEntry e => e.isFailed,
+    _ => false,
+  };
+
+  /// Applies the keyword constraint against each type's readable fields.
+  bool _matchesKeyword(TimestampedEntry entry) {
+    final kw = keyword.trim().toLowerCase();
+    if (kw.isEmpty) return true;
+
+    return switch (entry) {
+      final LogEntry e =>
+        e.message.toLowerCase().contains(kw) ||
+            (e.stackTrace?.toLowerCase().contains(kw) ?? false),
+      final NetworkEntry e =>
+        e.url.toLowerCase().contains(kw) ||
+            e.method.toLowerCase().contains(kw) ||
+            (e.statusCode?.toString().contains(kw) ?? false),
+      final NavigatorEntry e =>
+        (e.routeName?.toLowerCase().contains(kw) ?? false) ||
+            e.displayName.toLowerCase().contains(kw),
+      final DatabaseEntry e =>
+        e.tableName.toLowerCase().contains(kw) ||
+            e.operation.name.toLowerCase().contains(kw),
+      _ => false,
+    };
+  }
+}
+
+/// Returns the subset of [entries] satisfying [filter], preserving order.
+List<TimestampedEntry> applyConsoleFilter(
+  List<TimestampedEntry> entries,
+  ConsoleFilter filter,
+) {
+  if (filter.isEmpty) return entries;
+  return entries.where(filter.matches).toList(growable: false);
+}

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -602,6 +602,33 @@ void main() {
     });
 
     testWidgets(
+      'tapping a filtered row also clears the search field text, not just '
+      'the filter state',
+      (tester) async {
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
+        inspector.log('cart opened', level: LogLevel.info);
+        inspector.log('unrelated noise', level: LogLevel.info);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: ConsoleTab(inspector: inspector)),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'cart');
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('cart opened'));
+        await tester.pumpAndSettle();
+
+        final field = tester.widget<TextField>(find.byType(TextField));
+        expect(field.controller?.text, isEmpty);
+      },
+    );
+
+    testWidgets(
       'long-press still bookmarks while a filter is active, since taking over '
       'the tap must not take over every gesture',
       (tester) async {

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -458,4 +458,176 @@ void main() {
       expect(find.text('14:30:01.123'), findsOneWidget);
     });
   });
+
+  group('ConsoleTab search and level filters', () {
+    Future<void> pumpTab(WidgetTester tester, FlutterInspector inspector) =>
+        tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: ConsoleTab(inspector: inspector)),
+          ),
+        );
+
+    /// The chip row scrolls horizontally and is wider than the 800px test
+    /// viewport, so the level chips sit off-screen until scrolled to — same as
+    /// a user dragging the row.
+    Future<void> tapChip(WidgetTester tester, String label) async {
+      await tester.scrollUntilVisible(
+        find.widgetWithText(FilterChip, label),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilterChip, label));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('the keyword narrows the timeline across sources', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
+      inspector.log('cart opened', level: LogLevel.info);
+      inspector.log('unrelated noise', level: LogLevel.info);
+
+      await pumpTab(tester, inspector);
+      expect(find.text('unrelated noise'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'cart');
+      await tester.pumpAndSettle();
+
+      expect(find.text('cart opened'), findsOneWidget);
+      expect(find.text('unrelated noise'), findsNothing);
+    });
+
+    testWidgets('a filter matching nothing shows No matches', (tester) async {
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
+      inspector.log('only entry', level: LogLevel.info);
+
+      await pumpTab(tester, inspector);
+      await tester.enterText(find.byType(TextField), 'zzz-no-such-entry');
+      await tester.pumpAndSettle();
+
+      expect(find.text('No matches'), findsOneWidget);
+    });
+
+    testWidgets(
+      'a level chip keeps network rows visible, so it never degrades into a '
+      'source filter',
+      (tester) async {
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
+        inspector.log('an info log', level: LogLevel.info);
+        inspector.logNetwork(
+          NetworkEntry(
+            method: 'GET',
+            url: 'https://api.test/cart',
+            statusCode: 200,
+            isComplete: true,
+          ),
+        );
+
+        await pumpTab(tester, inspector);
+        await tapChip(tester, 'Error');
+
+        // The info log fails the level constraint...
+        expect(find.text('an info log'), findsNothing);
+        // ...but the successful call is not a log, so level never applied.
+        expect(find.textContaining('https://api.test/cart'), findsOneWidget);
+      },
+    );
+
+    testWidgets('errors only drops successful calls and healthy logs', (
+      tester,
+    ) async {
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
+      inspector.log('an info log', level: LogLevel.info);
+      inspector.log('a broken thing', level: LogLevel.error);
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'GET',
+          url: 'https://api.test/ok',
+          statusCode: 200,
+          isComplete: true,
+        ),
+      );
+      inspector.logNetwork(
+        NetworkEntry(
+          method: 'POST',
+          url: 'https://api.test/broken',
+          statusCode: 500,
+          isComplete: true,
+        ),
+      );
+
+      await pumpTab(tester, inspector);
+      await tapChip(tester, '⚡ Errors only');
+
+      expect(find.text('a broken thing'), findsOneWidget);
+      expect(find.textContaining('https://api.test/broken'), findsOneWidget);
+      expect(find.text('an info log'), findsNothing);
+      expect(find.textContaining('https://api.test/ok'), findsNothing);
+    });
+  });
+
+  group('ConsoleTab jump back to the full timeline', () {
+    testWidgets('tapping a filtered row clears every filter', (tester) async {
+      final inspector = FlutterInspector(
+        navigatorKey: GlobalKey<NavigatorState>(),
+      );
+      inspector.log('cart opened', level: LogLevel.info);
+      inspector.log('unrelated noise', level: LogLevel.info);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ConsoleTab(inspector: inspector)),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'cart');
+      await tester.pumpAndSettle();
+      expect(find.text('unrelated noise'), findsNothing);
+
+      await tester.tap(find.text('cart opened'));
+      await tester.pumpAndSettle();
+
+      // Filters are gone, so the surrounding context is back on screen.
+      expect(find.text('unrelated noise'), findsOneWidget);
+      expect(find.text('cart opened'), findsOneWidget);
+    });
+
+    testWidgets(
+      'tapping an unfiltered row still opens the detail view rather than '
+      'jumping',
+      (tester) async {
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
+        inspector.logNetwork(
+          NetworkEntry(
+            method: 'GET',
+            url: 'https://api.test/x',
+            statusCode: 200,
+            isComplete: true,
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: ConsoleTab(inspector: inspector)),
+          ),
+        );
+
+        await tester.tap(find.textContaining('https://api.test/x'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(NetworkDetailView), findsOneWidget);
+      },
+    );
+  });
 }

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -602,6 +602,32 @@ void main() {
     });
 
     testWidgets(
+      'long-press still bookmarks while a filter is active, since taking over '
+      'the tap must not take over every gesture',
+      (tester) async {
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
+        inspector.log('cart opened', level: LogLevel.info);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: ConsoleTab(inspector: inspector)),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'cart');
+        await tester.pumpAndSettle();
+        expect(inspector.bookmarkedEntries, isEmpty);
+
+        await tester.longPress(find.text('cart opened'));
+        await tester.pumpAndSettle();
+
+        expect(inspector.bookmarkedEntries, hasLength(1));
+      },
+    );
+
+    testWidgets(
       'tapping an unfiltered row still opens the detail view rather than '
       'jumping',
       (tester) async {

--- a/test/utils/console_utils_test.dart
+++ b/test/utils/console_utils_test.dart
@@ -1,0 +1,264 @@
+import 'package:flutter_inspector_kit/src/models/database_entry.dart';
+import 'package:flutter_inspector_kit/src/models/database_operation.dart';
+import 'package:flutter_inspector_kit/src/models/log_entry.dart';
+import 'package:flutter_inspector_kit/src/models/log_level.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_action.dart';
+import 'package:flutter_inspector_kit/src/models/navigator_entry.dart';
+import 'package:flutter_inspector_kit/src/models/network_entry.dart';
+import 'package:flutter_inspector_kit/src/models/timestamped_entry.dart';
+import 'package:flutter_inspector_kit/src/utils/console_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Data {
+  static final errorLog = LogEntry(
+    message: 'cart checkout failed',
+    level: LogLevel.error,
+  );
+
+  static final infoLog = LogEntry(
+    message: 'cart opened',
+    level: LogLevel.info,
+  );
+
+  static final warningLog = LogEntry(
+    message: 'slow response',
+    level: LogLevel.warning,
+  );
+
+  static final stackTraceLog = LogEntry(
+    message: 'boom',
+    level: LogLevel.debug,
+    stackTrace: 'at CartPage.build',
+  );
+
+  /// A successful call whose url contains "cart" — the entry that must survive
+  /// an `error` level chip combined with a `cart` keyword (AC-6a).
+  static final successfulCartCall = NetworkEntry(
+    url: 'https://api.example.com/api/cart',
+    method: 'GET',
+    statusCode: 200,
+  );
+
+  static final failedCall = NetworkEntry(
+    url: 'https://api.example.com/orders',
+    method: 'POST',
+    statusCode: 500,
+  );
+
+  static final navEntry = NavigatorEntry(
+    action: NavigatorAction.push,
+    routeName: '/cart',
+  );
+
+  static final dbEntry = DatabaseEntry(
+    operation: DatabaseOperation.insert,
+    tableName: 'cart_items',
+  );
+
+  static List<TimestampedEntry> get all => [
+    errorLog,
+    infoLog,
+    warningLog,
+    stackTraceLog,
+    successfulCartCall,
+    failedCall,
+    navEntry,
+    dbEntry,
+  ];
+}
+
+void main() {
+  group('ConsoleFilter.isEmpty', () {
+    test('a default filter matches everything', () {
+      const filter = ConsoleFilter();
+      final entries = _Data.all;
+      expect(filter.isEmpty, isTrue);
+      // Returns the very same list, not a copy: an empty filter short-circuits.
+      expect(applyConsoleFilter(entries, filter), same(entries));
+    });
+
+    test('a blank keyword is treated as no constraint', () {
+      const filter = ConsoleFilter(keyword: '   ');
+      expect(filter.isEmpty, isTrue);
+    });
+  });
+
+  group('keyword matching (AC-1 / AC-2)', () {
+    test('matches log message and stackTrace', () {
+      final result = applyConsoleFilter(
+        _Data.all,
+        const ConsoleFilter(keyword: 'CartPage'),
+      );
+      expect(result, [_Data.stackTraceLog]);
+    });
+
+    test('matches network url, method and status code', () {
+      expect(
+        applyConsoleFilter(_Data.all, const ConsoleFilter(keyword: 'orders')),
+        [_Data.failedCall],
+      );
+      expect(
+        applyConsoleFilter(_Data.all, const ConsoleFilter(keyword: 'post')),
+        [_Data.failedCall],
+      );
+      expect(
+        applyConsoleFilter(_Data.all, const ConsoleFilter(keyword: '500')),
+        [_Data.failedCall],
+      );
+    });
+
+    test('matches navigator routeName and database tableName', () {
+      final result = applyConsoleFilter(
+        _Data.all,
+        const ConsoleFilter(keyword: 'cart'),
+      );
+      expect(result, contains(_Data.navEntry));
+      expect(result, contains(_Data.dbEntry));
+    });
+
+    test('is case-insensitive', () {
+      expect(
+        applyConsoleFilter(_Data.all, const ConsoleFilter(keyword: 'CHECKOUT')),
+        [_Data.errorLog],
+      );
+    });
+  });
+
+  group('level matching (AC-3 / AC-4)', () {
+    test('an empty level set imposes no constraint', () {
+      const filter = ConsoleFilter(keyword: 'cart');
+      final result = applyConsoleFilter(_Data.all, filter);
+      // Every "cart" match survives regardless of level: the error log, the
+      // info log, the debug log (via its `at CartPage.build` stackTrace), the
+      // successful call, the nav push and the db insert. Only `failedCall`
+      // and `warningLog` miss the keyword.
+      expect(result, hasLength(6));
+      expect(result, isNot(contains(_Data.failedCall)));
+      expect(result, isNot(contains(_Data.warningLog)));
+    });
+
+    test('level constrains logs only', () {
+      final result = applyConsoleFilter(
+        _Data.all,
+        const ConsoleFilter(levels: {LogLevel.error}),
+      );
+      expect(result, contains(_Data.errorLog));
+      expect(result, isNot(contains(_Data.infoLog)));
+    });
+
+    test(
+      'non-log entries survive a level filter — otherwise the level chips '
+      'would silently degrade into a source filter (AC-4)',
+      () {
+        final result = applyConsoleFilter(
+          _Data.all,
+          const ConsoleFilter(levels: {LogLevel.error}),
+        );
+        expect(result, contains(_Data.successfulCartCall));
+        expect(result, contains(_Data.failedCall));
+        expect(result, contains(_Data.navEntry));
+        expect(result, contains(_Data.dbEntry));
+      },
+    );
+
+    test('multiple levels are OR-ed within the log type', () {
+      final result = applyConsoleFilter(
+        _Data.all,
+        const ConsoleFilter(levels: {LogLevel.error, LogLevel.warning}),
+      );
+      expect(result, contains(_Data.errorLog));
+      expect(result, contains(_Data.warningLog));
+      expect(result, isNot(contains(_Data.infoLog)));
+    });
+  });
+
+  group('errorsOnly (AC-5 / AC-5a)', () {
+    test('keeps warning/error logs and failed network calls', () {
+      final result = applyConsoleFilter(
+        _Data.all,
+        const ConsoleFilter(errorsOnly: true),
+      );
+      expect(result, contains(_Data.errorLog));
+      expect(result, contains(_Data.warningLog));
+      expect(result, contains(_Data.failedCall));
+    });
+
+    test('drops successful calls and non-error logs', () {
+      final result = applyConsoleFilter(
+        _Data.all,
+        const ConsoleFilter(errorsOnly: true),
+      );
+      expect(result, isNot(contains(_Data.successfulCartCall)));
+      expect(result, isNot(contains(_Data.infoLog)));
+    });
+
+    test(
+      'drops navigator and database entries, which carry no failure notion '
+      '(AC-5a)',
+      () {
+        final result = applyConsoleFilter(
+          _Data.all,
+          const ConsoleFilter(errorsOnly: true),
+        );
+        expect(result, isNot(contains(_Data.navEntry)));
+        expect(result, isNot(contains(_Data.dbEntry)));
+      },
+    );
+
+    test('supersedes the level set rather than intersecting with it', () {
+      final result = applyConsoleFilter(
+        _Data.all,
+        const ConsoleFilter(errorsOnly: true, levels: {LogLevel.info}),
+      );
+      expect(result, contains(_Data.errorLog));
+      expect(result, isNot(contains(_Data.infoLog)));
+    });
+  });
+
+  group('orthogonal composition (AC-6a / AC-6e)', () {
+    test(
+      'level + keyword: a successful /api/cart call survives an error chip, '
+      'because level never applies to network entries (AC-6a)',
+      () {
+        final result = applyConsoleFilter(
+          _Data.all,
+          const ConsoleFilter(keyword: 'cart', levels: {LogLevel.error}),
+        );
+
+        expect(result, contains(_Data.successfulCartCall));
+        expect(result, contains(_Data.errorLog));
+        // The info log matches "cart" but fails the level constraint.
+        expect(result, isNot(contains(_Data.infoLog)));
+        // The failed call does not match the keyword at all.
+        expect(result, isNot(contains(_Data.failedCall)));
+      },
+    );
+
+    test(
+      'errorsOnly + keyword: the keyword applies after the union, not to one '
+      'branch of it (AC-6e)',
+      () {
+        final result = applyConsoleFilter(
+          _Data.all,
+          const ConsoleFilter(keyword: 'cart', errorsOnly: true),
+        );
+
+        // Matches the union (error log) and the keyword.
+        expect(result, contains(_Data.errorLog));
+        // In the union but fails the keyword.
+        expect(result, isNot(contains(_Data.failedCall)));
+        // Matches the keyword but is not in the union.
+        expect(result, isNot(contains(_Data.successfulCartCall)));
+        expect(result, isNot(contains(_Data.navEntry)));
+      },
+    );
+
+    test('a filter matching nothing yields an empty list', () {
+      final result = applyConsoleFilter(
+        _Data.all,
+        const ConsoleFilter(keyword: 'no-such-entry'),
+      );
+      expect(result, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

為 ConsoleTab 的四源混合時間軸補上檢索能力，並讓檢索完能站回完整脈絡。

Closes #127（§D1 + §P5 合併）

新增四項：**搜尋欄**、**LogLevel 過濾**（多選）、**`⚡ Errors only` 快捷**、
**點擊已過濾的列 → 清掉所有過濾 + 捲回該筆在完整時間軸的位置**。

之所以合併成一項而非分開做：單獨的過濾**會切斷因果鏈**——搜「timeout」剩 3 筆 error 後，
前後的 API 呼叫與路由跳轉全被濾掉，而排查要問的是「為什麼走到這裡」，不是「這筆長什麼樣」。
過濾是點查詢，排查是鏈推斷。加上跳轉才閉環：搜到 → 點擊 → 站回完整時間軸看前後。

## 修正問題

| 問題 | 修正方式 |
|------|---------|
| ConsoleTab 無搜尋欄（全檔 `TextField` 命中數 0） | 新增私有 `_SearchBar`，比對四種 entry 各自的可讀欄位 |
| 無 LogLevel 過濾（既有 FilterChip 是 source 過濾，非 level） | 新增 5 個 level chip，多選 |
| `errorsOnly` 邏輯僅存在於 `diagnostic_report.dart`，UI 未暴露 | 新增 `⚡ Errors only` chip |
| 過濾後看不到前後文 | 點擊列 → 清過濾 + `animateTo` 回該筆位置 |

### 兩層過濾語意（最容易寫錯的一段）

- **條件之間一律 AND**：搜尋 × source × level 三者正交疊加。
- **唯一的 OR 在 `errorsOnly` 內部**：`LogEntry` 取 warning/error **OR** `NetworkEntry.isFailed`。
  兩型別互斥，寫成 AND 會恆為空清單。

其中 `_matchesLevel` 遇到非 `LogEntry` 一律放行。若不放行，點任一 level chip 會讓
network/nav/db 全部消失——level chip 就實質退化成 source chip，與既有功能重疊。
測試明確覆蓋這點：**選 `error` + 搜 `cart` 時，成功的 `GET /api/cart` 仍須顯示**。

### Review 階段抓到的回歸（`173fe8a`）

`_JumpRow` 用 `IgnorePointer` 攔截 tap 時**連 long-press 一起吞掉**，導致只要開了任一過濾，
長按加書籤就靜默失效——而「剛搜到的那筆」恰恰是最想釘起來的。

**485 個測試當時全綠**，因為沒有任何一個測試會在過濾啟用時長按。修正後補上會失敗的測試，
並反向驗證過（拿掉 `HitTestBehavior.opaque` 該測試即失敗）。

`HitTestBehavior.opaque` 在此是必要而非裝飾：child 在 `IgnorePointer` 內，
沒有它就沒東西可 hit-test，兩個手勢都不會觸發。

## 設計取捨

- **source 過濾不進 `ConsoleFilter`**——已由 `mergedTimeline(sources:)` 在資料源頭處理，
  搬進來會產生第二份判定（§P7「同一判定寫三份且已漂移」的教訓）。
- **不動 `TimestampedEntry`**——該介面註解明寫「存在的唯一理由是提供排序鍵」，
  加 `searchableText` 會讓四個 model 為 UI 過濾被迫實作成員。改用 `switch (entry)` 型別分派，
  與既有 `_EntryRowDispatcher` 同構。
- **攔截點在 dispatcher 而非各 row**——原計畫要改四個 row 的 `onTap`，但 nav/db 兩種 row
  本來就不可點、得替它們新增。包在外層只有一個判斷點，且 nav/db 自動獲得跳轉能力。
- **捲動位置接受近似**（`index × 估算行高`）——各型別 row 高度不定，精確 offset 得測量目標
  以上每一列。落在附近就滿足「看前後」的目的，**不引入 `scrollable_positioned_list` 新相依**。

## 排除範圍

- 不提取 `network_tab.dart` 的私有 `_SearchBar` 為共用元件（跨檔重構擴大回歸面）
- 不做 §P5 原案的獨立「⬆ Jump to Latest Error」FAB（與點擊跳轉語意重疊）
- 不順手修 `console_tab.dart` 既有的 `withOpacity` deprecation（無關變更）
- 同時開啟 📌 Bookmarks + 關鍵字且無命中時，空狀態顯示「No bookmarked entries」而非
  「No matches」——既有分支 precedence，措辭略誤導但改動會擴大本次 diff 的回歸面，留待日後

## Review 回饋處理

PR 開出後收到 4 則 review 意見，處置如下：

| 來源 | 位置 | 意見 | 處置 |
|------|------|------|------|
| sourcery-ai | `console_tab.dart:146` | 主張 `const {}` 會被推斷為 `Map`，無法編譯 | **Pushback，未改碼**。`levels` 是具名參數且宣告型別為 `Set<LogLevel>`，具名參數提供的型別上下文使 Dart 正確推斷為 `Set`；`flutter analyze` 零 error 佐證意見有誤 |
| coderabbitai | `console_tab.dart:119-123` | 點擊已過濾的列跳轉回完整時間軸後，搜尋欄殘留舊關鍵字 | **真 bug，已修復**（`c1b0aed`）。根因是 `TextEditingController` 歸屬錯置：原本活在 `_SearchBarState`，導致外層 `_jumpToEntry` 無法觸及。將 controller 上移至 `_ConsoleTabState`，`dispose` 責任隨之搬移，`_jumpToEntry` 內呼叫 `.clear()`。修根因而非加 listener 補症狀，另補上 regression test |
| coderabbitai | 文件 code fence | 缺語言標識，違反 MD040 | 已修復，補上 `text` |
| coderabbitai | 文件 | 測試路徑描述有誤 | 已修復，更正為 `test/utils/console_utils_test.dart` 與 `test/ui/tabs/console_tab_test.dart` |

搜尋欄殘留這則額外帶出一個流程腳本修正（`c84c5a0`，`wf-state` 允許 standalone entry 的階段轉移），與 console 功能無關，經使用者確認保留在本 PR。

## Verification

```
flutter test      486/486 全綠（含新增的 long-press 回歸測試）
flutter analyze   6 issues — 與動工前基準逐字相同，零新增
```

那 6 個全是既有的 `deprecated_member_use`（`export_report_sheet` ×2、`console_tab` ×2、
`network_tab` ×2），皆在範圍外。

零回歸確認：既有 `console_tab_test.dart`、`console_tab_bookmark_test.dart` 全綠，
source chip／📌 Bookmarks／refresh／clear／error 底色高亮皆不受影響。

## Summary by Sourcery

为控制台时间线添加关键字与日志级别过滤功能，支持“仅错误”快捷方式和跳回行为，并编写该功能及其实现方案的文档。

New Features:
- 引入 `ConsoleFilter` 实用工具，为合并后的控制台时间线提供关键字、日志级别和“仅错误”约束。
- 在控制台标签页 UI 中添加搜索栏、日志级别筛选芯片以及“⚡ Errors only”芯片，并在无匹配时显示空状态消息“No matches”。
- 支持在过滤状态下点击某条控制台记录来清除过滤条件，并在完整时间线中滚动回该记录位置，同时保留长按书签行为。

Enhancements:
- 将控制台过滤逻辑重构为 `console_utils` 中可复用的纯函数，并实现针对日志、网络、导航和数据库等不同类型条目的匹配。

Documentation:
- 为控制台搜索/级别过滤与跳回功能编写专门的特性规格说明，以及对应的实现计划文档。

Tests:
- 为 `ConsoleFilter` 和 `applyConsoleFilter` 添加单元测试，覆盖关键字、级别、“仅错误”和组合约束等场景。
- 扩展控制台标签页组件测试，覆盖搜索行为、级别/“仅错误”过滤、跳回滚动，以及在过滤状态下的长按书签行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add keyword and log-level filtering to the console timeline with an errors-only shortcut and jump-back behavior, and document the feature and its implementation plan.

New Features:
- Introduce a ConsoleFilter utility with keyword, log level, and errors-only constraints for the merged console timeline.
- Add a search bar, log level chips, and an '⚡ Errors only' chip to the console tab UI, including an empty-state 'No matches' message.
- Enable tapping a filtered console entry to clear filters and scroll back to that entry in the full timeline while preserving long-press bookmarking behavior.

Enhancements:
- Refactor console filtering logic into a reusable pure function in console_utils with type-specific matching across log, network, navigation, and database entries.

Documentation:
- Document the console search/level filter and jump-back feature with a dedicated feature spec and an implementation plan.

Tests:
- Add unit tests for ConsoleFilter and applyConsoleFilter covering keyword, level, errors-only, and combined constraints.
- Extend console tab widget tests to cover search behavior, level/errors-only filters, jump-back scrolling, and long-press bookmarking while filtered.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 控制台新增关键词搜索、日志级别筛选和“仅错误”筛选。
  - 支持组合筛选、无结果提示，以及覆盖日志、网络、导航和数据库记录。
  - 点击筛选结果可清除筛选并跳转回完整时间线；长按仍可添加书签。

- **测试**
  - 新增搜索、筛选、跳转及原有交互行为的自动化测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
