### PR TITLE
fix(workflow): prevent standalone entry points from bypassing state machine (Gap 2.6) (#129)

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -16,5 +16,23 @@
         ]
       }
     ]
+  },
+  "wf-guard-stage-check": {
+    "PreInvocation": null,
+    "PostInvocation": null,
+    "Stop": null,
+    "PreToolUse": [
+      {
+        "matcher": "invoke_subagent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.agents/hooks/wf-guard-stage-check.sh",
+            "timeout": 0
+          }
+        ]
+      }
+    ],
+    "PostToolUse": null
   }
 }

--- a/.claude/hooks/wf-guard-stage-check.sh
+++ b/.claude/hooks/wf-guard-stage-check.sh
@@ -55,7 +55,8 @@ if isinstance(tc_args, dict):
                 agent_types.append(sa["TypeName"].lower())
 
 # If responder is not being dispatched, allow immediately
-if not any("responder" in a for a in agent_types):
+RESPONDER_AGENT_TYPES = {"responder"}
+if not any(a in RESPONDER_AGENT_TYPES for a in agent_types):
     sys.exit(0)
 
 # Check if there is an active workflow state file in current directory or repo
@@ -102,22 +103,25 @@ if not matched_file:
 try:
     with open(matched_file, "r") as f:
         st_data = json.load(f)
-    stage = str(st_data.get("stage", ""))
-    
-    # In STAGE 5, stage should be "5" or "responder"
-    if stage in ("5", "responder"):
-        sys.exit(0)
-    
+except Exception as e:
     rel_path = os.path.relpath(matched_file)
-    sys.stderr.write(f"""[WF-GUARD BLOCK] 偵測到派發 responder agent，但當前 workflow 狀態為 stage: "{stage}"（非 stage: 5）。
+    sys.stderr.write(f"[WF-GUARD ERROR] 無法讀取或解析 workflow 狀態檔 {rel_path}：{e}\n請檢查修復該狀態檔或重新初始化。\n")
+    sys.exit(1)
+
+stage = str(st_data.get("stage", ""))
+
+# In STAGE 5, stage should be "5" or "responder"
+if stage in ("5", "responder"):
+    sys.exit(0)
+
+rel_path = os.path.relpath(matched_file)
+sys.stderr.write(f"""[WF-GUARD BLOCK] 偵測到派發 responder agent，但當前 workflow 狀態為 stage: "{stage}"（非 stage: 5）。
 依據獨立入口規範，進入 STAGE 5 回覆 PR Review 前必須先推進狀態機。
 請先執行：
   wf-state.sh advance {rel_path} 5 --confirmed
 （或若為新對話獨立入口：wf-state.sh init --mode jump --stage 5 --branch <branch>）
 推進狀態完成後，方可再次派發 responder。\n""")
-    sys.exit(1)
-except Exception:
-    sys.exit(0)
+sys.exit(1)
 ' <<< "$input"
 
 exit $?

--- a/.claude/hooks/wf-guard-stage-check.sh
+++ b/.claude/hooks/wf-guard-stage-check.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# PreToolUse(Agent / invoke_subagent) hook for Claude Code & Antigravity (agy).
+# Guardrail: prevents dispatching `responder` agent without advancing state to STAGE 5.
+#
+# False positive protection:
+#   - Only triggers if `responder` agent is being dispatched.
+#   - Only acts if an active workflow state file exists in the worktree/repo.
+#   - Bypasses immediately (exit 0) if no workflow state file is found.
+
+input=$(cat)
+
+# Run verification in python
+python3 -c '
+import json, sys, os, glob, subprocess
+
+try:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        sys.exit(0)
+    data = json.loads(raw)
+except Exception:
+    sys.exit(0)
+
+# Check tool name
+tool_name = data.get("tool_name") or data.get("toolCall", {}).get("name", "")
+
+# Extract invoked agent names/types across Claude Code & Antigravity schemas
+agent_types = []
+
+# Claude Code schema: .tool_input.name / .tool_input.subagent_type
+tool_input = data.get("tool_input", {})
+if isinstance(tool_input, dict):
+    if "name" in tool_input and isinstance(tool_input["name"], str):
+        agent_types.append(tool_input["name"].lower())
+    if "subagent_type" in tool_input and isinstance(tool_input["subagent_type"], str):
+        agent_types.append(tool_input["subagent_type"].lower())
+    if "agent" in tool_input and isinstance(tool_input["agent"], str):
+        agent_types.append(tool_input["agent"].lower())
+
+# Antigravity schema: .toolCall.args.Subagents / .toolCall.args.TypeName
+tc = data.get("toolCall", {})
+tc_args = tc.get("args", tc.get("Arguments", {}))
+if isinstance(tc_args, dict):
+    if "TypeName" in tc_args and isinstance(tc_args["TypeName"], str):
+        agent_types.append(tc_args["TypeName"].lower())
+    if "name" in tc_args and isinstance(tc_args["name"], str):
+        agent_types.append(tc_args["name"].lower())
+    if "subagents" in tc_args and isinstance(tc_args["subagents"], list):
+        for sa in tc_args["subagents"]:
+            if isinstance(sa, dict) and "TypeName" in sa and isinstance(sa["TypeName"], str):
+                agent_types.append(sa["TypeName"].lower())
+    if "Subagents" in tc_args and isinstance(tc_args["Subagents"], list):
+        for sa in tc_args["Subagents"]:
+            if isinstance(sa, dict) and "TypeName" in sa and isinstance(sa["TypeName"], str):
+                agent_types.append(sa["TypeName"].lower())
+
+# If responder is not being dispatched, allow immediately
+if not any("responder" in a for a in agent_types):
+    sys.exit(0)
+
+# Check if there is an active workflow state file in current directory or repo
+state_dir = os.environ.get("WF_STATE_DIR", "")
+state_files = []
+if state_dir and os.path.isdir(state_dir):
+    state_files = glob.glob(os.path.join(state_dir, "*.json"))
+else:
+    # Look in .claude/workflow-state in current dir or up to git root
+    cwd = os.getcwd()
+    check_dir = cwd
+    while check_dir and check_dir != "/":
+        wf_dir = os.path.join(check_dir, ".claude", "workflow-state")
+        if os.path.isdir(wf_dir):
+            files = [f for f in glob.glob(os.path.join(wf_dir, "*.json")) if not os.path.basename(f).startswith(".batch-")]
+            if files:
+                state_files = files
+                break
+        check_dir = os.path.dirname(check_dir)
+
+# If no state file found, bypass (allow out-of-workflow standalone calls)
+if not state_files:
+    sys.exit(0)
+
+# Match state file strictly with current branch
+matched_file = None
+try:
+    branch = subprocess.check_output(["git", "branch", "--show-current"], stderr=subprocess.DEVNULL).decode().strip()
+    if branch:
+        branch_slug = branch.replace("/", "-")
+        for sf in state_files:
+            if os.path.basename(sf) == f"{branch_slug}.json":
+                matched_file = sf
+                break
+except Exception:
+    pass
+
+# If the current branch has no matching workflow state, bypass immediately
+# (Prevents false positives when a workflow is active on another worktree/branch)
+if not matched_file:
+    sys.exit(0)
+
+# Inspect state
+try:
+    with open(matched_file, "r") as f:
+        st_data = json.load(f)
+    stage = str(st_data.get("stage", ""))
+    
+    # In STAGE 5, stage should be "5" or "responder"
+    if stage in ("5", "responder"):
+        sys.exit(0)
+    
+    rel_path = os.path.relpath(matched_file)
+    sys.stderr.write(f"""[WF-GUARD BLOCK] 偵測到派發 responder agent，但當前 workflow 狀態為 stage: "{stage}"（非 stage: 5）。
+依據獨立入口規範，進入 STAGE 5 回覆 PR Review 前必須先推進狀態機。
+請先執行：
+  wf-state.sh advance {rel_path} 5 --confirmed
+（或若為新對話獨立入口：wf-state.sh init --mode jump --stage 5 --branch <branch>）
+推進狀態完成後，方可再次派發 responder。\n""")
+    sys.exit(1)
+except Exception:
+    sys.exit(0)
+' <<< "$input"
+
+exit $?

--- a/.claude/hooks/wf-guard-stage-check.sh
+++ b/.claude/hooks/wf-guard-stage-check.sh
@@ -103,6 +103,8 @@ if not matched_file:
 try:
     with open(matched_file, "r") as f:
         st_data = json.load(f)
+    if not isinstance(st_data, dict):
+        raise ValueError("狀態檔根節點必須為 JSON 物件（dict）")
 except Exception as e:
     rel_path = os.path.relpath(matched_file)
     sys.stderr.write(f"[WF-GUARD ERROR] 無法讀取或解析 workflow 狀態檔 {rel_path}：{e}\n請檢查修復該狀態檔或重新初始化。\n")

--- a/.claude/skills/gen-dev-workflow/SKILL.md
+++ b/.claude/skills/gen-dev-workflow/SKILL.md
@@ -146,15 +146,23 @@ description: |
     STAGE 5：回覆 PR Review（獨立入口，由你手動觸發）
     ──────────────────────────────────────────────────
     觸發方式：你說「PR #42 有新的 review 意見」
+    🔴 第一步（不可跳過）：推進狀態至 STAGE 5
+       - 既有工作區已存在 state 檔：wf-state.sh advance <state_file> 5 --confirmed
+       - 新對話／獨立進入：wf-state.sh init --mode jump --stage 5 --branch <branch> --set pr=<PR>
+       ↑ 未執行此步就派發 responder = 流程違規（將遭 Hook 攔截）
     → 呼叫 responder agent 處理每條意見
     → 處理完畢 → 呼叫 reviewer agent 重新審查
-    → 審查通過 → 呼叫 publisher agent 更新 PR
+    → 審查通過 → 呼叫 publisher agent 更新 PR 描述與留言
+    → 呼叫 wf-state.sh stage-done 5 結束 STAGE 5
     → 完成後流程再次結束，Claude 停止等待。
 
     ──────────────────────────────────────────────────
     STAGE 6：清理 Worktree（獨立入口，由你手動觸發）
     ──────────────────────────────────────────────────
     觸發方式：PR **實際合併後**，你說「PR #42 合併了，清理 worktree」
+    🔴 第一步（不可跳過）：推進狀態至 STAGE 6
+       - 既有工作區已存在 state 檔：wf-state.sh advance <state_file> 6 --confirmed
+       - 新對話／獨立進入：wf-state.sh init --mode jump --stage 6 --branch <branch>
     → 【文件同步】先呼叫 gen-sync-docs-by-branchs skill，
       以當前處理的分支為目標，將該分支的實際變更回寫到
       docs 下的發想／結構說明文件（brainstorm、architecture 等）
@@ -163,6 +171,7 @@ description: |
     → 呼叫 worktree-close-cleanup skill 移除 STAGE 1 建立的 worktree
     → 只移除 worktree 本身，**對應 branch 一律保留、不刪除**
       （worktree-close-cleanup 的既有規則，不因併入此流程而改變）
+    → 呼叫 wf-state.sh stage-done 6（或標記 done）
     → 不自動觸發：workflow 不會偵測 PR 合併狀態並自動清理，
       需你明確告知已合併才執行，避免在 PR 還可能需要修改時
       誤刪工作區。
@@ -987,16 +996,22 @@ const findings = (await parallel([
 
 # 處理 PR review 意見（STAGE 5）
 /gen-dev-workflow review #<PR>
-→ 寫入狀態檔 { stage: 5, mode: "jump", pr: <PR> }
+→ 推進/寫入狀態檔：
+  - 既有工作區：wf-state.sh advance <state_file> 5 --confirmed
+  - 新對話 jump：wf-state.sh init --mode jump --stage 5 --branch <branch-name> --set pr=<PR>
 → 呼叫 responder agent 處理所有 review 意見（effort: high，輕量）
 → 處理完畢後呼叫 reviewer agent 重新審查（effort: xhigh，最強推論）
-→ 審查通過後呼叫 publisher agent 更新 PR（effort: high，輕量）
+→ 審查通過後呼叫 publisher agent 更新 PR 描述與留言（effort: high，輕量）
+→ 呼叫 wf-state.sh stage-done 5 結束 STAGE 5
 
 # PR 合併後清理 worktree（STAGE 6）
 /gen-dev-workflow cleanup <branch-name>
-→ 寫入狀態檔 { stage: 6, mode: "jump", branch: "<branch-name>" }
+→ 推進/寫入狀態檔：
+  - 既有工作區：wf-state.sh advance <state_file> 6 --confirmed
+  - 新對話 jump：wf-state.sh init --mode jump --stage 6 --branch <branch-name>
 → 呼叫 gen-sync-docs-by-branchs skill，以 <branch-name> 為目標同步文件
 → 同步完成後呼叫 gen-commit skill 將文件變更 commit（避免清理 worktree 時遺失）
 → 呼叫 worktree-close-cleanup skill 移除該 branch 對應的 worktree
 → 只移除 worktree，branch 本身保留不刪除（純 IO，無 model/effort 可調）
+→ 呼叫 wf-state.sh stage-done 6（或標記 done）
 ```

--- a/.claude/skills/gen-dev-workflow/SKILL.md
+++ b/.claude/skills/gen-dev-workflow/SKILL.md
@@ -429,7 +429,7 @@ batch-next 回傳 DONE → 輸出總結（各項 status / PR 連結），刪除�
 state 檔的**所有**建立、讀取、更新一律透過本 skill 的 `scripts/wf-state.sh`，**絕不手寫或手改 JSON**。guard 在腳本裡，不在本文件裡：
 
 - **schema 校驗 + 原子寫入**：先寫 tmp、`jq` 驗過才 `mv`——壞資料進不了磁碟，寫到一半中斷也不會留下半套 state。
-- **stage 轉移合法性**：sequence 模式只接受 `0a→0b→1→2→3→4`、`3→2`（審查退回）、`4→done`，非法跳段直接 exit 1。quick/jump 模式不套用轉移表（quick 的階段本來就非正式、jump 是使用者明示跳段），但校驗與棘輪照常生效。
+- **stage 轉移合法性**：sequence 模式接受 `0a→0b→1→2→3→4`、`3→2`（審查退回）、`4→done`，以及獨立入口銜接轉移 `4→5`、`5→4`、`5→5`、`4→6`、`5→6`、`6→done`，其餘非法跳段直接 exit 1。quick/jump 模式不套用轉移表（quick 的階段本來就非正式、jump 是使用者明示跳段），但校驗與棘輪照常生效。
 - **暫停點棘輪**：`stage-done` / `task-done` 之後 `awaiting_confirmation=true`，未帶 `--confirmed` 的 `advance` 一律拒絕。`--confirmed` 只能在**使用者真的在對話中確認後**帶上——跳過暫停點從「無聲遺忘」變成必須蓄意加旗標、在 Bash 歷史留下痕跡的動作。
 
 | 時機 | 指令 |

--- a/.claude/skills/gen-dev-workflow/scripts/wf-state.sh
+++ b/.claude/skills/gen-dev-workflow/scripts/wf-state.sh
@@ -95,7 +95,7 @@ slugify() { echo "${1//\//-}"; }
 
 legal_transition() {
   case "$1->$2" in
-    "0a->0b"|"0b->1"|"1->2"|"2->3"|"3->4"|"3->2"|"4->done"|"reviewer->responder"|"responder->reviewer"|"reviewer->publisher") return 0 ;;
+    "0a->0b"|"0b->1"|"1->2"|"2->3"|"3->4"|"3->2"|"4->done"|"4->5"|"5->4"|"5->5"|"4->6"|"5->6"|"6->done"|"reviewer->responder"|"responder->reviewer"|"reviewer->publisher") return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/docs/brainstorm/2026-08-07-workflow-brainstorm.md
+++ b/docs/brainstorm/2026-08-07-workflow-brainstorm.md
@@ -237,7 +237,7 @@
 * **解決方案**：
   在 `wf-state.sh` 中新增 `prune` 命令，允許使用者或系統定期清理建立時間大於 7 天的 `.pending-*.json` 檔案。
 
-### Gap 2.6: 獨立入口（STAGE 5/6）完全繞過狀態機 — ⬜ 待修（2026-08-07 實例）
+### Gap 2.6: 獨立入口（STAGE 5/6）完全繞過狀態機 — ✅ 已修（2026-08-14 方案 A + C 落地）
 
 * **漏洞描述**：既有守衛（棘輪、轉移表、任務數校驗）**只在 `wf-state.sh` 被呼叫時才生效**。STAGE 5/6 是不在 `0a→0b→1→2→3→4` 主鏈上的獨立入口，缺少前後階段的銜接慣性，LLM 容易在「處理 review 意見」的任務心智下直接派發 responder/reviewer，**全程不碰腳本**——此時沒有任何機制會察覺流程正在推進。
 
@@ -249,25 +249,13 @@
 
   **連帶損害**：STAGE 5 流程的第三步（publisher 更新 PR 描述）一併被遺漏，因為沒有 state 推進來提示還有後續步驟。若此時換 session 續接，新 session 會誤判 STAGE 5 尚未執行而重跑。
 
-* **解決方案**（建議 A + C 併行，跳過 B）：
-
-  **A. 文件層——獨立入口的首步硬性化**
-  在 SKILL.md 的 STAGE 5/6 區塊開頭，把 state 推進寫成不可跳過的第一步而非隱含前提：
-  ```
-  STAGE 5：回覆 PR Review（獨立入口）
-  🔴 第一步（不可跳過）：wf-state.sh advance <檔> 5 --confirmed
-     ↑ 未執行此步就派發 responder = 流程違規
-  → 呼叫 responder agent...
-  ```
-  成本最低，但**仍只是叮嚀**——本次違規時 SKILL.md 已寫明正確流程（含 `{ stage: 5, mode: "jump" }` 的寫入指示）卻仍被漏掉，證明純文件層不足以獨立成為對策。
-
-  **B. 腳本層——`assert-stage` 子命令**：❌ **不採用**。
-  新增 `wf-state.sh assert-stage <檔> 5`（stage 不符則 exit 1）雖比 A 強，但**與 A 共享同一個失效前提**（都要求 LLM 主動呼叫腳本）。多一個子命令卻換不到實質保障，不划算。
-
-  **C. Hook 層——唯一真正的強制**
-  以 `PreToolUse` hook 攔截 `Agent` 工具呼叫：偵測到派發 `responder`/`reviewer`/`publisher` 時，檢查當前 worktree 的 state 檔 stage 是否已推進至對應階段，未推進則**阻擋該次呼叫**並回傳提示。
-  * **為何有效**：執行者是 harness 而非 LLM，這是唯一「想繞也繞不過」的層級。
-  * **代價**：hook 邏輯需維護；且會誤擋「流程外單獨派發 reviewer 做零星審查」的正當用法——需評估是否加白名單，或退而採「警告但不阻擋」。此取捨需由使用者依實際使用習慣決定。
+* **落地解決方案（2026-08-14 · 方案 A + C 併行）**：
+  1. **方案 A（文件層硬性化）**：`SKILL.md` 的 STAGE 5/6 區塊開頭加粗標示 `🔴 第一步（不可跳過）：推進狀態至 STAGE 5/6`，並明確規範未推進即派發 responder 屬流程違規。
+  2. **方案 C（Hook 層強制攔截）**：新增 `.claude/hooks/wf-guard-stage-check.sh`，在 `PreToolUse` 攔截 `Agent`（Claude）與 `invoke_subagent`（Antigravity）呼叫：
+     - 若派發 `responder` 且當前 worktree 存在 active workflow state，檢查 `stage` 是否為 `5`；
+     - 若未推進（如停在 `4`），Hook 直接以 exit 1 阻擋派發，並在 stderr 輸出精確的修復指令（`wf-state.sh advance <state_file> 5 --confirmed`）；
+     - **防誤殺保護**：若目錄下無 workflow 狀態檔（流程外單獨調用），Hook 直接 exit 0 放行。
+  3. **轉移表補全**：`wf-state.sh:legal_transition()` 補上 `4->5`、`5->4`、`5->5`、`4->6`、`5->6`、`6->done` 等轉移路徑，確保 sequence 流程回覆 PR 時推進無阻。
 
 * **設計啟示**：本 Gap 揭露的是守衛架構的**結構性盲點**，而非單點疏失——「守衛需要被呼叫才生效」。任何未來新增的獨立入口（非主鏈階段）都會重現同一漏洞，因此對策應落在**入口攔截層**，而非繼續往 `wf-state.sh` 內部堆校驗。
 
@@ -1160,6 +1148,7 @@ Orchestrator 維護一份持續更新的 `progress.md`，記錄：已完成的 M
 | §5.5 Handoff | ✅ 需求已覆蓋 | SKILL.md:545-575 state 檔 + WIP commit 交接（不採 `HANDOFF.md`） |
 | §3 提案 1 `pause_level` | ✅ **已完成**（2026-08-06 · `9bce068`） | `wf-state.sh:141` `should_pause()` 單一判定來源；`:172` `apply_sets()` 白名單含 `pause_level` + enum 校驗；`:269`/`:286` 為 `stage-done`/`task-done` 兩個呼叫端；SKILL.md:179 暫停粒度章節、:872 選項語法 |
 | **批次佇列**（非原提案，2026-08-06 新增） | ✅ **已完成**（`9bce068`） | `wf-state.sh:349-430` `batch-init`/`batch-get`/`batch-next`/`batch-done`/`batch-fail`/`batch-abort`；獨立 schema + `batch_write` 原子寫入；SKILL.md:328 批次模式章節 |
+| **Gap 2.6 獨立入口狀態防護**（2026-08-14 補正） | ✅ **已完成**（2026-08-14 · 方案 A+C） | `SKILL.md:146` 首步硬性化；`.claude/hooks/wf-guard-stage-check.sh` PreToolUse 攔截 responder 派發；`.agents/hooks.json` 與 `.claude/settings.local.json` 掛載；`wf-state.sh:98` 補齊 `4->5` 轉移表 |
 | §3 提案 2 `cmd_rollback.sh` | ⬜ **未實作** | 全專案查無此檔；SKILL.md 內 `rollback` / `回滾` 零命中 |
 | §3 提案 3 `wf-truncate.sh` | ⬜ **未實作** | `scripts/` 下僅有 `wf-state.sh` |
 | §3 提案 4 `wf-exec.sh` | ❌ **不採用**（2026-08-10 定案） | 前提已變：委派改走 MCP 工具呼叫，不經 bash 子進程，沒有 `$?` 可保留，此形狀無對應物。其要解決的「回報不可信」問題改由**驗收紀律**覆蓋（`implementer.md`「回報不等於事實」+ SKILL.md 委派紀律第 3 條）。**前一版的判斷（「agy headless 不可用 ⇒ 委派已死 ⇒ 不必寫轉接層」）方向對、結論錯**——不可用的是傳輸層，不是委派本身；正解是換傳輸層，不是放棄委派 |

--- a/docs/features/2026-08-14-wf-standalone-entry-guard.md
+++ b/docs/features/2026-08-14-wf-standalone-entry-guard.md
@@ -1,0 +1,46 @@
+# 獨立入口狀態機防護與 PreToolUse Hook 守衛 (Gap 2.6)
+
+## 1. 背景與問題 (Background & Problem)
+
+在 `gen-dev-workflow` 的狀態機設計中，所有安全檢查（轉移表 `legal_transition`、暫停棘輪、任務完成度校驗）均位於 `wf-state.sh` 腳本內部。
+
+在主鏈流程（`0a → 0b → 1 → 2 → 3 → 4`）中，因為有連續推進的慣性，狀態機能如實記錄進度。然而在獨立入口（**STAGE 5：回覆 PR Review** 與 **STAGE 6：清理 Worktree**）中，由於是手動跳入，LLM 容易因任務心智直接派發 `responder` 處理 review 意見，**全程未呼叫 `wf-state.sh`**。
+
+這導致了以下嚴重問題：
+1. **狀態檔假死（State Blindness）**：遠端已推 commit，但本地狀態檔永久停在 `stage: "4"`，破壞單一真理來源。
+2. **步驟遺漏（Step Omission）**：因無狀態機推進引導，LLM 容易在 reviewer 複審通過後漏掉最後更新 PR 描述與留言的 `publisher` 步驟。
+3. **跨 Session 續接崩潰**：新對話讀取狀態檔時誤判 STAGE 5 未執行，引發重複派發或流程衝突。
+
+---
+
+## 2. 使用者故事 (User Stories)
+
+### US-1：獨立入口首步硬性化指引
+身為開發者／編排器，當進入 STAGE 5（回覆 PR）或 STAGE 6（清理 Worktree）時，流程規範應明確要求第一步必須先推進狀態機至對應階段，避免流程違規。
+
+### US-2：Hook 底層實體阻擋違規派發
+身為系統管理員，當 LLM 忘記執行狀態推進而直接試圖派發 `responder` 時，系統底層的 `PreToolUse` Hook 必須主動阻擋該次調用，並輸出可直接複製執行的修復指令。
+
+### US-3：防誤殺保護（嚴格分支綁定）
+身為開發者，當在主倉庫（`main`）或其他非 workflow 分支上進行日常開發或單點調用 `responder`/`reviewer` 時，Hook 必須自動判定當前分支未綁定 workflow 狀態，直接放行，絕不造成誤殺（Never break userspace）。
+
+### US-4：狀態機轉移表支援
+身為狀態機使用者，當從 STAGE 4（已建 PR）推進至 STAGE 5 或 STAGE 6 時，`wf-state.sh advance` 應能依轉移表順暢通過，不拋出非法轉移錯誤。
+
+---
+
+## 3. 驗收條件 (Acceptance Criteria)
+
+- [x] **AC-1**：`SKILL.md` 的 STAGE 5 與 STAGE 6 區塊明訂「🔴 第一步（不可跳過）：推進狀態至 STAGE 5/6」。
+- [x] **AC-2**：建立 `.claude/hooks/wf-guard-stage-check.sh`，在 `PreToolUse` 攔截 `Agent` / `invoke_subagent`。
+- [x] **AC-3**：當目錄存在 active workflow 且當前分支狀態非 STAGE 5 時，派發 `responder` 必被 Hook 阻擋（Exit code 1），並於 stderr 輸出修復命令。
+- [x] **AC-4**：當目錄無 active workflow 或當前分支無對應狀態檔時，派發 `responder` 必被 Hook 放行（Exit code 0）。
+- [x] **AC-5**：任何時候派發非 `responder` 之 Agent（如 `reviewer`, `verifier`），Hook 必直接放行（Exit code 0）。
+- [x] **AC-6**：`wf-state.sh` 的 `legal_transition()` 補齊 `4->5`、`5->4`、`5->5`、`4->6`、`5->6`、`6->done` 之轉移規則。
+
+---
+
+## 4. 邊界與排除 (Out of Scope)
+
+- 不針對 STAGE 6 設置專用 Agent Hook（STAGE 6 為 skill / bash 操作，由文件規範 A 與狀態機覆蓋）。
+- 不破壞或修改既有主鏈 `0a` 至 `4` 的狀態轉移規則與校驗。

--- a/docs/plans/2026-08-14-wf-standalone-entry-guard.md
+++ b/docs/plans/2026-08-14-wf-standalone-entry-guard.md
@@ -1,0 +1,59 @@
+# 獨立入口狀態機防護與 PreToolUse Hook 守衛實作計畫 (Gap 2.6)
+
+依據 [`docs/features/2026-08-14-wf-standalone-entry-guard.md`](../features/2026-08-14-wf-standalone-entry-guard.md) 之需求規格制定。
+
+---
+
+## 1. 架構設計與資料流 (Architecture & Data Flow)
+
+```text
+[Claude Code / Antigravity]
+           │
+           │ 觸發工具: Agent / invoke_subagent (派發 responder)
+           ▼
+┌────────────────────────────────────────────────────────┐
+│ PreToolUse Hook: wf-guard-stage-check.sh              │
+│ 1. 檢查派發目標是否為 responder                        │
+│    └─ 否 → exit 0 放行                                 │
+│ 2. 獲取當前分支 $(git branch --show-current)           │
+│ 3. 搜尋 .claude/workflow-state/<branch>.json 狀態檔     │
+│    └─ 無匹配檔（非 workflow 分支） → exit 0 放行         │
+│ 4. 檢查狀態檔 .stage                                   │
+│    ├─ stage == "5" 或 "responder" → exit 0 放行         │
+│    └─ stage != "5" → exit 1 阻擋並在 stderr 輸出修復命令 │
+└────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. 檔案異動清單 (File Changes)
+
+| 檔案路徑 | 類型 | 異動說明 |
+| :--- | :---: | :--- |
+| `.claude/skills/gen-dev-workflow/SKILL.md` | 修改 | STAGE 5/6 區塊明訂第一步推進狀態機之硬性規則 |
+| `.claude/skills/gen-dev-workflow/scripts/wf-state.sh` | 修改 | `legal_transition()` 新增 `4->5`, `5->4`, `5->5`, `4->6`, `5->6`, `6->done` |
+| `.claude/hooks/wf-guard-stage-check.sh` | 新增 | `PreToolUse` Hook 腳本，嚴格分支綁定與 responder 卡控 |
+| `.agents/hooks.json` | 修改 | 註冊 `wf-guard-stage-check` 於 Antigravity `PreToolUse` |
+| `.claude/settings.local.json` | 修改 | 註冊 `wf-guard-stage-check` 於 Claude `PreToolUse` |
+| `docs/brainstorm/2026-08-07-workflow-brainstorm.md` | 修改 | 更新 Gap 2.6 狀態為已修復與落地現況表格 |
+
+---
+
+## 3. 任務拆分與實作清單 (Task Breakdown)
+
+### Task 1: 文件層規範硬性化 (方案 A)
+- 修改 `SKILL.md`，在 STAGE 5 與 STAGE 6 標明不可跳過之第一步狀態推進指令。
+
+### Task 2: 狀態機轉移表擴充
+- 修改 `wf-state.sh` 之 `legal_transition()`，允許 `4->5`, `5->4`, `5->5`, `4->6`, `5->6`, `6->done`。
+
+### Task 3: 實作 PreToolUse Hook (方案 C)
+- 撰寫 `.claude/hooks/wf-guard-stage-check.sh`，實作雙 Schema 解析、嚴格分支比對、阻擋與精準 stderr 提示。
+- 賦予執行權限 `chmod +x`。
+
+### Task 4: Hook 配置與系統註冊
+- 於 `.claude/settings.local.json` 與 `.agents/hooks.json` 註冊該 Hook。
+
+### Task 5: 邊界測試與驗證
+- 驗證無狀態檔放行、非 responder 放行、Stage 4 阻擋、Stage 5 放行。
+- 更新 brainstorm 追蹤文件。


### PR DESCRIPTION
## Summary
- 修正 **Gap 2.6** 獨立入口（STAGE 5 回覆 PR Review / STAGE 6 清理 Worktree）完全繞過狀態機的結構性漏洞。
- 採用 **方案 A（文件層硬性化）+ 方案 C（Hook 層強制攔截）** 深度防禦策略。

## 修正問題與變更詳情
1. **方案 A：文件層硬性化**
   - 在 `SKILL.md` 的 STAGE 5 與 STAGE 6 區塊明訂「`🔴 第一步（不可跳過）：推進狀態至 STAGE 5/6`」。
2. **方案 C：Hook 層強制攔截**
   - 實作 `.claude/hooks/wf-guard-stage-check.sh`（掛載於 `PreToolUse`），在派發 `responder` 時檢查當前工作區狀態是否已推進至 STAGE 5，未推進則以 exit 1 阻擋並印出精確修復指令。
   - **防誤殺保護（Strict Branch Affinity）**：嚴格比對 Git 當前分支與狀態檔名稱，若處於 `main` 或非 workflow 分支則自動放行（exit 0），絕不影響非 workflow 的日常獨立調用。
3. **狀態機轉移表補全**
   - `wf-state.sh:legal_transition()` 補齊 `4->5`、`5->4`、`5->5`、`4->6`、`5->6`、`6->done` 之合法轉移路徑。
4. **規格與追蹤文件**
   - 新增功能規格 `docs/features/2026-08-14-wf-standalone-entry-guard.md` 與計畫 `docs/plans/2026-08-14-wf-standalone-entry-guard.md`。
   - 更新 `docs/brainstorm/2026-08-07-workflow-brainstorm.md` 之 Gap 2.6 落地狀態。

Closes #129

## Summary by Sourcery

加强围绕独立 STAGE 5/6 入口点的工作流，使 responder 的派发无法绕过状态机，并标记 Gap 2.6 为已解决。

New Features:
- 引入一个 PreToolUse 钩子脚本，在当前工作流状态不处于 STAGE 5 时阻止 responder agent 派发，并支持按分支感知的状态文件检测。
- 在 gen-dev-workflow 技能文档中，为 STAGE 5 和 STAGE 6 定义明确的首步状态推进要求。
- 添加功能说明文档和规划文档，描述针对 Gap 2.6 的独立入口保护机制和 PreToolUse 钩子设计。

Enhancements:
- 扩展工作流状态机的合法转换范围，以覆盖 STAGE 4、STAGE 5、STAGE 6 与 done 之间的迁移。
- 在 `SKILL.md` 中澄清 STAGE 5/6 的操作流程，包括 state-done 调用以及更精确的 PR 描述更新职责。
- 更新工作流头脑风暴文档，记录 Gap 2.6 已修复，并在跟踪表中补充已实施的 A+C 方案。

Documentation:
- 为针对 Gap 2.6 的独立入口状态保护和 PreToolUse 钩子添加功能规格说明和实现计划文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the workflow around standalone STAGE 5/6 entry points so responder dispatches cannot bypass the state machine, and mark Gap 2.6 as resolved.

New Features:
- Introduce a PreToolUse hook script to block responder agent dispatch when the active workflow state is not at STAGE 5, with branch-aware state file detection.
- Define explicit first-step state advancement requirements for STAGE 5 and STAGE 6 in the gen-dev-workflow skill documentation.
- Add feature and plan documents describing the standalone entry guard and PreToolUse hook design for Gap 2.6.

Enhancements:
- Extend the workflow state machine’s legal transitions to cover movements between STAGE 4, STAGE 5, STAGE 6 and done.
- Clarify STAGE 5/6 operational sequences in SKILL.md, including state-done calls and more precise PR description update responsibilities.
- Update the workflow brainstorm document to record Gap 2.6 as fixed and capture the implemented A+C solution in the tracking table.

Documentation:
- Add a feature spec and an implementation plan for the standalone entry state guard and PreToolUse hook for Gap 2.6.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加独立工作流入口的阶段校验，确保任务按正确顺序推进。
  - 未完成必要阶段时阻止不符合条件的任务派发，并提供修复指引；无工作流或不适用的任务可正常继续。
  - 补充阶段 4–6 及完成状态之间的合法流转支持。

- **文档**
  - 新增功能规格、实施计划和工作流状态防护说明。
  - 更新开发流程指南，明确审核、文档同步及收尾步骤。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->