### PR TITLE
chore(release): bump version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.2.0
+
+### Added
+* **Console search and level filtering**: The Console tab now carries a search field above the timeline, matching a case-insensitive keyword against each entry's readable fields — log messages and stack traces, network URLs/methods/status codes, route names, and database tables and operations. A per-`LogLevel` chip row (`Verbose`, `Debug`, `Info`, `Warning`, `Error`) narrows logs further, and an `⚡ Errors only` chip isolates failures across types: `warning`/`error` logs together with failed network calls. Level chips only constrain log entries, so picking one does not silently hide network, navigation, or database events.
+* **Jump back to the full timeline**: While a filter is active, tapping any row clears every filter and scrolls the unfiltered timeline to that same entry — so a row found by searching can be read back in its surrounding context instead of in isolation.
+
+### Fixed
+* **Long-press bookmarking now survives filtering**: Bookmarking a row by long-press stopped working once a search or level filter was applied. Filtered rows accept long-press again, alongside the new tap-to-jump gesture.
+* **Search field text is cleared on jump-back**: Jumping from a filtered row back to the full timeline reset the filter but left the typed keyword visible in the search field, so the UI showed an active search over unfiltered results.
+
 ## 2.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^2.1.0
+  flutter_inspector_kit: ^2.2.0
 ```
 
 Then run `flutter pub get`.
@@ -391,7 +391,16 @@ Available levels: `verbose`, `debug`, `info`, `warning`, `error`.
 
 ### Read the merged timeline
 
-The **Console** tab already interleaves logs, network, navigation, and database events on a single timeline (newest first), with a filter chip per source. Error-level logs and failed network calls are given a faint red row background so they're spottable while scrolling a long timeline — warnings keep their orange text but stay un-tinted, so a warning-heavy app doesn't wash the whole list out. You can also read that same merged view programmatically:
+The **Console** tab already interleaves logs, network, navigation, and database events on a single timeline (newest first), with a filter chip per source. Error-level logs and failed network calls are given a faint red row background so they're spottable while scrolling a long timeline — warnings keep their orange text but stay un-tinted, so a warning-heavy app doesn't wash the whole list out.
+
+To narrow a long timeline, the tab also offers:
+
+- **Search** — a case-insensitive keyword matched against each entry's readable fields: log messages and stack traces, network URLs, methods and status codes, route names, and database tables and operations.
+- **Level chips** — `Verbose`, `Debug`, `Info`, `Warning`, `Error`. These constrain *log* entries only, so picking one narrows your logs without hiding network, navigation, or database events.
+- **`⚡ Errors only`** — isolates failures across types: `warning`/`error` logs together with failed network calls.
+- **Tap to jump back** — while a filter is active, tapping any row clears every filter and scrolls the full timeline to that same entry, so a row you found by searching can be read back in its surrounding context. Long-press still bookmarks the row, filtered or not.
+
+You can also read that same merged view programmatically:
 
 ```dart
 // All sources, newest first.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -48,7 +48,7 @@
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^2.1.0
+  flutter_inspector_kit: ^2.2.0
 ```
 
 接著執行 `flutter pub get`。
@@ -389,7 +389,16 @@ inspector.log(
 
 ### 讀取合併後的時間軸
 
-**Console** 分頁本身就已把 logs、network、navigation 與 database 事件交錯排在單一時間軸上（最新在前），並為每個來源提供一個 filter chip。error 等級的 log 與失敗的 network 呼叫會被加上淡紅色的列底色，捲動長時間軸時容易辨識——warning 維持原本的橘色文字但不上底色，避免 warning 一多就把整份列表洗成一片紅。你也可以用程式化方式讀取這份相同的合併檢視：
+**Console** 分頁本身就已把 logs、network、navigation 與 database 事件交錯排在單一時間軸上（最新在前），並為每個來源提供一個 filter chip。error 等級的 log 與失敗的 network 呼叫會被加上淡紅色的列底色，捲動長時間軸時容易辨識——warning 維持原本的橘色文字但不上底色，避免 warning 一多就把整份列表洗成一片紅。
+
+要在長時間軸中縮小範圍，此分頁另外提供：
+
+- **搜尋** — 不分大小寫的關鍵字，比對每筆項目可讀的欄位：log 訊息與 stack trace、network 的 URL／method／status code、route 名稱，以及 database 的資料表與操作。
+- **等級 chips** — `Verbose`、`Debug`、`Info`、`Warning`、`Error`。這些**只**約束 log 項目，所以選了某個等級不會連帶把 network、navigation、database 事件一起藏起來。
+- **`⚡ Errors only`** — 跨型別隔離失敗項目：`warning`／`error` 等級的 log，加上失敗的 network 呼叫。
+- **點擊跳回** — 篩選啟用時，點任一列會清掉所有篩選條件，並把完整時間軸捲動到該筆項目，讓你把搜尋找到的那一列放回前後脈絡中閱讀。長按仍然是加書籤，篩選中也一樣可用。
+
+你也可以用程式化方式讀取這份相同的合併檢視：
 
 ```dart
 // All sources, newest first.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String packageVersion = '2.1.0';
+const String packageVersion = '2.2.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 2.1.0
+version: 2.2.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary
[#131](https://github.com/Yomiamy/flutter_inspector_kit/issues/131) Release: Version 2.2.0

**[修正問題]**
發布新版 `2.2.0`，整合自 `v2.1.0` 起合併入 `main` 的 Console 搜尋／篩選功能，並同步更新版本號、說明文檔與變更日誌。自 `v2.1.0` 起的 39 個 commit 中，使用者可見的變更集中於 Console 分頁一組；其餘為 docs 與 workflow／agents 內部調整，不列入 CHANGELOG。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號為 `2.2.0`。
2. **`lib/src/version.dart`**：同步 `packageVersion` 為 `'2.2.0'`。此處未列於 release skill 的「三處版本資訊」表格，v1.6.0 曾因遺漏而回報錯誤版號，本次一併更新。
3. **`README.md` / `README.zh-TW.md`**：安裝版號更新為 `^2.2.0`；於「讀取合併後的時間軸」章節補上搜尋、等級 chips、`⚡ Errors only` 與點擊跳回完整時間軸的說明。`ConsoleFilter` 未經 barrel 匯出，屬內部實作，故僅描述 UI 行為而不示範該類別。
4. **`CHANGELOG.md`**：新增 `2.2.0` 區塊，記錄 Added（搜尋／等級篩選、跳回完整時間軸）與 Fixed（篩選中長按書籤失效、跳回後搜尋欄殘留文字）。

**[驗證]**
- `flutter analyze`：6 issues，全為 `info` 級 deprecation，無 warning／error。其中 `network_tab.dart` 兩筆於 `v2.1.0` 已存在（本次未動該檔），為既有問題。
- `flutter test`：487 passed。

## Summary by Sourcery

发布 2.2.0 版本，更新控制台时间线搜索和过滤的文档，并同步版本元数据。

新功能：
- 在英文和繁体中文 README 中记录控制台搜索、日志级别标签（chips）、仅错误过滤以及点击跳转行为。
- 在变更日志中记录控制台搜索、级别过滤和回跳行为作为新的功能能力。

缺陷修复：
- 在文档中说明在过滤条件下控制台书签行为的修复，以及在返回完整时间线时清除过期搜索文本的修复。

改进：
- 将 pubspec 和内部版本文件中的包版本元数据提升至 2.2.0，以与新版本发布保持一致。

文档：
- 更新安装说明以引用 flutter_inspector_kit ^2.2.0，并在英文和繁体中文 README 中描述新的控制台时间线搜索和过滤选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Release version 2.2.0 with updated console timeline search and filtering documentation and synchronized version metadata.

New Features:
- Document console search, log level chips, error-only filtering, and tap-to-jump behavior in both English and Traditional Chinese READMEs.
- Record console search, level filtering, and jump-back behavior as new capabilities in the changelog.

Bug Fixes:
- Document fixes for console bookmarking behavior under filters and clearing of stale search text when returning to the full timeline.

Enhancements:
- Bump package version metadata to 2.2.0 in pubspec and internal version file to align with the new release.

Documentation:
- Update installation instructions to reference flutter_inspector_kit ^2.2.0 and describe new console timeline search and filtering options in English and Traditional Chinese READMEs.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Console 支持按关键词、日志级别和错误状态筛选跨类型时间线。
  * 点击筛选结果可清除筛选，并返回完整时间线中的对应条目。

* **问题修复**
  * 修复筛选后长按收藏无法生效的问题。
  * 修复返回完整时间线后搜索文本未清除的问题。

* **文档**
  * 更新合并时间线的搜索与筛选功能说明。

* **版本**
  * 发布版本 2.2.0。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->