### PR TITLE
chore(release): bump version to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.3.0
+
+### Added
+* **Storage tab — browse and edit key-value stores**: A new dashboard tab lists the contents of `SharedPreferences`, `FlutterSecureStorage` and friends, with a search field over keys and values and a selector to switch between registered stores. Entries can be edited, deleted individually, or wiped in bulk, so a stale token or a stuck feature flag can be cleared on-device instead of through an `adb shell` or a reinstall. The tab only appears once at least one source is registered.
+* **`KeyValueBrowserSource` — pluggable storage adapters**: Register stores through `FlutterInspector(keyValueSources: [...])` or `registerKeyValueSource(...)`, mirroring how `DatabaseBrowserSource` already works. The package ships no implementation and takes no dependency on any storage plugin — the README carries copy-paste adapter examples for `SharedPreferences` and `FlutterSecureStorage`, and each adapter takes an optional `name` so two stores of the same kind stay distinguishable in the selector. When a source cannot enumerate its keys (`readAll()` is unsupported on some platforms for secure storage), the tab surfaces a retryable error rather than an empty list, so "cannot enumerate" is never mistaken for "nothing stored".
+* **Confirmation before every write**: Edits, deletes and clear-all each require an explicit confirmation. Editing runs a type-validation step first, so a mistyped value is rejected before the confirmation dialog appears rather than after it. Clear-all names the source and the entry count it is about to wipe, and is disabled while a store is still loading — so a destructive action can never be authorised against another source's data.
+* **Writes are logged to the Console timeline**: A successful write is recorded as an `info` log carrying the key, source and type, so a change made while debugging does not become a mystery later. Cancelled and failed writes leave no log — the audit trail only ever claims what actually landed. Old and new values are masked unless the host sets `redactSensitiveData: false`, since the log is shareable and a key-value source may hold secrets.
+
 ## 2.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In-app, multi-inspector debugging overlay for Flutter apps — logs, network, na
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^2.2.0
+  flutter_inspector_kit: ^2.3.0
 ```
 
 Then run `flutter pub get`.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -48,7 +48,7 @@
 
 ```yaml
 dependencies:
-  flutter_inspector_kit: ^2.2.0
+  flutter_inspector_kit: ^2.3.0
 ```
 
 接著執行 `flutter pub get`。

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String packageVersion = '2.2.0';
+const String packageVersion = '2.3.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inspector_kit
 description: "A multi-inspector tool integration for Flutter, bundling debugging and inspection utilities behind a single unified API."
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/Yomiamy/flutter_inspector_kit
 repository: https://github.com/Yomiamy/flutter_inspector_kit
 issue_tracker: https://github.com/Yomiamy/flutter_inspector_kit/issues


### PR DESCRIPTION
### Summary
[#138](https://github.com/Yomiamy/flutter_inspector_kit/issues/138) Release: Version 2.3.0

**[修正問題]**
發布新版 `2.3.0`，整合 `v2.2.0` 之後合併入 `main` 的核心變更 —— 全新的 **Storage tab（key-value browser）**，可瀏覽、搜尋、編輯、刪除與清空 `SharedPreferences` / `FlutterSecureStorage` 這類 key-value 儲存，並將成功的寫入記錄到 Console timeline。同時修正版本資訊四處未同步的問題：`pubspec.yaml`、`lib/src/version.dart`、`README.md` 與 `README.zh-TW.md` 皆仍停在 `2.2.0`。

**[修正方式]**
1. **`pubspec.yaml`**：更新版本號為 `2.3.0`。
2. **`lib/src/version.dart`**：`packageVersion` 更新為 `'2.3.0'`，確保 `FlutterInspector.version` 與匯出診斷報告的表頭回報正確版號。
3. **`README.md` / `README.zh-TW.md`**：安裝範例版號更新為 `^2.3.0`。功能說明章節（Features 表的 🔑 Storage 列與 `### 🔑 Browse key-value storage` 用法段落）已於功能 PR #137 合併時同步，本次不再重複調整。
4. **`CHANGELOG.md`**：新增 `## 2.3.0` 區塊，以 Added 記錄四項使用者可見異動 —— Storage tab、`KeyValueBrowserSource` 介面與 adapter 範例、寫入前的二次確認與過期破壞性操作阻擋、以及寫入稽核日誌與其值遮罩行為。純內部的 skill / hook / 規劃文件變更不列入。

**[驗證方式]**
- `flutter analyze`：0 warning / 0 error（僅 6 個既有 `deprecated_member_use` info）。
- `flutter test`：553 tests，全數通過。

## Sourcery 总结

发布 2.3.0 版本，并同步更新版本元数据和文档，以支持键值存储检查功能。

错误修复：
- 将所有软件包、运行时和文档中的版本引用统一为 2.3.0。

文档：
- 更新安装示例，并记录 Storage 选项卡、可插拔键值存储适配器、写入确认，以及带有敏感值掩码的审计写入日志。
- 添加变更日志条目，描述面向用户的 Storage 选项卡功能和安全行为。

维护：
- 发布 2.3.0 版本。]

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Release version 2.3.0 with synchronized version metadata and documentation for the key-value storage inspection features.

Bug Fixes:
- Align all package, runtime, and documentation version references with the 2.3.0 release.

Documentation:
- Update installation examples and document the Storage tab, pluggable key-value storage adapters, write confirmations, and audited write logging with sensitive-value masking.
- Add changelog entries describing the user-visible Storage tab capabilities and safety behaviors.

Chores:
- Release version 2.3.0.],

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增键值存储浏览与编辑功能，支持可插拔数据源。
  * 写入操作增加确认提示和编辑前类型校验。
  * 写入成功后记录 Console 时间线审计日志，默认遮盖敏感值。
* **体验改进**
  * 存储内容无法枚举时显示可重试错误。
  * 加载期间禁用清空操作。
* **版本更新**
  * 版本更新至 2.3.0。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->