### PR TITLE
fix(console): drop the Error level chip so Errors only is the sole failure filter

### DIFF
--- a/docs/brainstorm/2026-08-23-features-brainstorm.md
+++ b/docs/brainstorm/2026-08-23-features-brainstorm.md
@@ -314,6 +314,23 @@
 * **Review 補正**：`TextEditingController` 原由 `_SearchBar` 私有持有，導致跳轉清掉 `_filter` 後輸入框仍殘留舊關鍵字；已將所有權提升至 `_ConsoleTabState` 並於跳轉時同步清空（附回歸測試）。
 * **測試**：`test/utils/console_utils_test.dart`（過濾語意）＋ `test/ui/tabs/console_tab_test.dart`（跳轉、正交疊加、long-press 書籤不被跳轉接管）。
 
+> **⚠️ 後續修正（2026-08-23 · PR #140）：本項落地時留下 chip 語意重疊，已移除 `Error` level chip。**
+>
+> 上述「`errorsOnly` 與 LogLevel 為互斥語意」解決的是**狀態**衝突（兩者不會同時生效），但沒解決**命名**衝突——`⚡ Errors only` 與 `Error` 兩個 chip 並排，名字讀起來是同一個 filter，實際行為卻不同：
+>
+> | | `⚡ Errors only` | `Error` chip |
+> |:---|:---|:---|
+> | warning log | ✅ 留 | ❌ 濾掉 |
+> | error log | ✅ 留 | ✅ 留 |
+> | **成功**的網路請求 | ❌ 濾掉 | ✅ **留** |
+> | 導航 / DB 事件 | ❌ 濾掉 | ✅ **留** |
+>
+> 差異源自 `_matchesLevel` 的正確設計：level 約束**只作用於 `LogEntry`**，非 log 一律放行——否則選一個 level chip 就會把網路/導航/DB 全部濾掉，讓 level filter 悄悄變成 source filter。這個設計沒錯，錯在讓它與 `Errors only` 並排且名字幾乎一樣，使用者無從分辨。
+>
+> **修正**：移除 `Error` level chip，`⚡ Errors only` 成為看失敗的唯一入口。`Warning` chip 保留——`Errors only` 的 warning 覆蓋與 error、失敗請求綁在一起，跟「只看 warning」不是同一件事。實作上把 chip 列的迴圈由 `LogLevel.values` 改走 `logLevelLabels.entries`，讓 label map 成為「有哪些 chip」的唯一真相來源（刪 entry 即刪 chip，迴圈內不需 `if`）。`ConsoleFilter.levels` 刻意保留 `Set<LogLevel>` 不收窄——model 層仍接受 `LogLevel.error`，只拿掉 UI 入口，收窄會在 `_matchesLevel` 多一個特殊情況。
+>
+> **這是一種新的「文件與實況不符」，不計入既有的漂移計數**：累計 7 次那個計數追蹤的是「標為待辦、實際已完成」（狀態欄漂移），本項不屬於該型態——§D1 的狀態欄是對的，它確實已完成。這裡漏記的是**已完成項目留下的缺陷**：實作現況寫得詳盡，卻沒人注意到新增的 chip 列本身引入了語意重疊。**教訓：實作現況該記的不只「做了什麼」，還有「做完後這塊 UI 長什麼樣、有沒有新的並排衝突」。**
+
 ### §D2. 未捕捉例外去重修復（#1 殘留缺陷）— ✅ 已完成（PR #96 · 2026-07-24）
 
 > 同一個 widget build 崩潰，`FlutterError.onError` 和 `ErrorWidget.builder` 各觸發一次 `_logFlutterError`，Console 出現兩筆完全相同的 error log，干擾判斷「是一次還是兩次」。

--- a/lib/src/ui/dashboard/tabs/console_tab.dart
+++ b/lib/src/ui/dashboard/tabs/console_tab.dart
@@ -201,12 +201,12 @@ class _ConsoleTabState extends State<ConsoleTab> {
                       selected: _filter.errorsOnly,
                       onSelected: (_) => _toggleErrorsOnly(),
                     ),
-                    for (final level in LogLevel.values) ...[
+                    for (final entry in logLevelLabels.entries) ...[
                       const SizedBox(width: ThemeSize.space8),
                       FilterChip(
-                        label: Text(logLevelLabels[level] ?? ''),
-                        selected: _filter.levels.contains(level),
-                        onSelected: (_) => _toggleLevel(level),
+                        label: Text(entry.value),
+                        selected: _filter.levels.contains(entry.key),
+                        onSelected: (_) => _toggleLevel(entry.key),
                       ),
                     ],
                     const SizedBox(width: ThemeSize.space8),

--- a/lib/src/utils/console_utils.dart
+++ b/lib/src/utils/console_utils.dart
@@ -11,11 +11,12 @@ import '../models/timestamped_entry.dart';
 ///
 /// [LogLevel.error] is deliberately absent: the `Errors only` shortcut already
 /// covers it, and an `Error` chip beside it read as the same filter while
-/// behaving differently (the chip lets every non-log entry through, the
-/// shortcut keeps only failures). Two chips for one intent is the confusion,
-/// so the narrower one is gone. Warning keeps a chip because the shortcut's
-/// warning coverage comes bundled with errors and failed calls, which is not
-/// the same as looking at warnings alone.
+/// behaving differently (the chip keeps only error logs but lets every non-log
+/// entry through, the shortcut keeps warning/error logs plus failed network
+/// calls and drops everything else). Two chips for one intent is the
+/// confusion, so the narrower one is gone. Warning keeps a chip because the
+/// shortcut only ever surfaces warnings bundled with errors and failed calls,
+/// which is not the same as looking at warnings alone.
 ///
 /// The Console tab renders one chip per entry here, so this map — not
 /// [LogLevel.values] — decides which levels are selectable.

--- a/lib/src/utils/console_utils.dart
+++ b/lib/src/utils/console_utils.dart
@@ -7,13 +7,23 @@ import '../models/navigator_entry.dart';
 import '../models/network_entry.dart';
 import '../models/timestamped_entry.dart';
 
-/// Chip labels for each [LogLevel] shown in the Console tab.
+/// Chip labels for the [LogLevel]s that get their own Console tab chip.
+///
+/// [LogLevel.error] is deliberately absent: the `Errors only` shortcut already
+/// covers it, and an `Error` chip beside it read as the same filter while
+/// behaving differently (the chip lets every non-log entry through, the
+/// shortcut keeps only failures). Two chips for one intent is the confusion,
+/// so the narrower one is gone. Warning keeps a chip because the shortcut's
+/// warning coverage comes bundled with errors and failed calls, which is not
+/// the same as looking at warnings alone.
+///
+/// The Console tab renders one chip per entry here, so this map — not
+/// [LogLevel.values] — decides which levels are selectable.
 const Map<LogLevel, String> logLevelLabels = {
   LogLevel.verbose: 'Verbose',
   LogLevel.debug: 'Debug',
   LogLevel.info: 'Info',
   LogLevel.warning: 'Warning',
-  LogLevel.error: 'Error',
 };
 
 /// An immutable filter for the Console tab's merged timeline: a

--- a/test/ui/tabs/console_tab_test.dart
+++ b/test/ui/tabs/console_tab_test.dart
@@ -531,7 +531,7 @@ void main() {
         );
 
         await pumpTab(tester, inspector);
-        await tapChip(tester, 'Error');
+        await tapChip(tester, 'Warning');
 
         // The info log fails the level constraint...
         expect(find.text('an info log'), findsNothing);
@@ -573,6 +573,30 @@ void main() {
       expect(find.text('an info log'), findsNothing);
       expect(find.textContaining('https://api.test/ok'), findsNothing);
     });
+
+    testWidgets(
+      'there is no Error level chip, so Errors only is the single entry point '
+      'for looking at failures',
+      (tester) async {
+        final inspector = FlutterInspector(
+          navigatorKey: GlobalKey<NavigatorState>(),
+        );
+        inspector.log('a broken thing', level: LogLevel.error);
+
+        await pumpTab(tester, inspector);
+
+        // The neighbouring level chips are still there...
+        expect(find.widgetWithText(FilterChip, 'Warning'), findsOneWidget);
+        expect(find.widgetWithText(FilterChip, 'Info'), findsOneWidget);
+        // ...but the one that used to sit beside the shortcut and read as the
+        // same filter is gone.
+        expect(find.widgetWithText(FilterChip, 'Error'), findsNothing);
+        expect(
+          find.widgetWithText(FilterChip, '\u26a1 Errors only'),
+          findsOneWidget,
+        );
+      },
+    );
   });
 
   group('ConsoleTab jump back to the full timeline', () {


### PR DESCRIPTION
## Summary

Console tab 的 `⚡ Errors only` 與 `Error` 兩個 chip 並排，名字讀起來是同一個 filter，行為卻不同。移除 `Error` chip，讓 `Errors only` 成為看失敗的唯一入口。

## 修正問題

| | Errors only | Error chip（已移除） |
|:---|:---|:---|
| warning log | ✅ 留 | ❌ 濾掉 |
| error log | ✅ 留 | ✅ 留 |
| 成功的網路請求 | ❌ 濾掉 | ✅ **留** |
| 導航 / DB 事件 | ❌ 濾掉 | ✅ **留** |

`Error` chip 之所以放行所有非 log 項目，是因為按 level 濾掉其他型別，等於把 level filter 偷偷變成 source filter。這個設計本身沒錯，錯在它跟 `Errors only` 並排且名字幾乎一樣——使用者無從得知兩者的實際差異。

`Warning` chip 保留：`Errors only` 的 warning 覆蓋是與 error、失敗請求綁在一起的，跟「只看 warning」不是同一件事。

## 修正方式

- chip 迴圈由 `LogLevel.values` 改走 `logLevelLabels.entries`，讓 label map 成為「有哪些 chip」的唯一真相來源。刪一個 entry 就少一個 chip，迴圈裡不需要加 `if`。順帶退掉了永遠不會觸發的 `?? ''` fallback。
- `ConsoleFilter.levels` **刻意保留** `Set<LogLevel>`：model 層仍接受 `LogLevel.error`，只拿掉 UI 入口。收窄型別會在 `_matchesLevel` 多一個特殊情況，沒有好處。
- 原本點 `Error` 的 widget test 改點 `Warning`（守的是「level chip 不得退化成 source filter」這個不變式，仍需保留）；新增測試釘住「無 Error chip、Errors only 仍在」。

## Out of scope

- 不動 `ConsoleFilter` 的資料結構
- 不改其餘 chip 的命名或排列

## Verification

- `flutter test` → 554 passed
- `flutter analyze lib/ test/` → 6 issues，全為既有 `deprecated_member_use` info，與本 diff 無關
- Code review（correctness lens）→ Critical 0 / Important 0；確認 `logLevelLabels` 未 public export、全 repo 無 subscript 查詢、`_filter` 無序列化路徑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

通过移除重叠的 Error 级别筛选标签，使 Errors only 成为唯一的控制台失败筛选条件。

错误修复：
- 移除多余的 Error 控制台筛选标签，使 Errors only 成为查看失败的唯一 UI 入口。

改进：
- 使用已配置的日志级别标签条目作为可选控制台级别标签的唯一事实来源，同时保留 Warning 以及现有筛选模型的行为。

测试：
- 更新控制台筛选覆盖范围以包含 Warning 标签，并验证 Error 标签不存在，同时 Errors only 仍可用。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

移除冗余的 Error 控制台筛选标签，并使“仅错误”成为唯一的失败筛选入口。

错误修复：
- 移除重复的 Error 控制台筛选标签，使“仅错误”成为查看失败的唯一 UI 入口。

增强功能：
- 使用已配置的日志级别标签条目，作为可选控制台级别标签的唯一事实来源，同时保留现有的筛选模型和 Warning 行为。

文档：
- 记录移除重复 Error 标签的变更，并明确“仅错误”与级别筛选器之间的不同语义。

测试：
- 更新控制台筛选测试覆盖范围，使用 Warning 标签，并验证 Error 标签已移除，同时“仅错误”仍然可用。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

移除多余的 Error 控制台筛选标签，并使“仅错误”成为唯一的失败筛选入口。

错误修复：
- 移除重叠的 Error 级别标签，使“仅错误”成为查看失败内容的唯一控制台 UI 入口。

增强功能：
- 使用已配置的日志级别标签条目作为可选控制台级别标签的唯一事实来源，同时保留 Warning 以及现有筛选模型的行为。

文档：
- 记录移除重叠 Error 标签的变更，并明确“仅错误”与级别筛选器之间的区别。

测试：
- 更新控制台筛选覆盖范围，使用 Warning 标签，并验证 Error 标签不存在，同时“仅错误”仍可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the redundant Error console filter chip and make Errors only the single failure-filter entry point.

Bug Fixes:
- Remove the overlapping Error level chip so Errors only is the sole console UI entry point for viewing failures.

Enhancements:
- Use the configured log-level label entries as the single source of truth for selectable console level chips while preserving Warning and the existing filter model behavior.

Documentation:
- Document the removal of the overlapping Error chip and clarify the distinction between Errors only and level filters.

Tests:
- Update console filter coverage to use the Warning chip and verify that the Error chip is absent while Errors only remains available.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能优化**
  - 优化控制台日志级别筛选，保留“详细”“调试”“信息”和“警告”选项。
  - 移除独立的“错误”筛选芯片，错误日志和失败请求统一通过“仅显示错误”入口查看。
- **测试**
  - 更新并补充控制台筛选测试，覆盖现有级别选项及错误日志入口。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->