### PR TITLE
docs: add CLAUDE.md covering what the architecture docs leave out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ App 內除錯檢視工具（Flutter package）：把 log / network / navigator /
 | 每個檔案是什麼、放哪 | `docs/architecture/file-reference.md` |
 | 八條主要流程的時序圖（含 mergedTimeline 歸併） | `docs/architecture/data-flow.md` |
 
-⚠️ 這些文件會漂移（曾出現 `file-reference.md` 記版本 `1.6.0` 但實際已到 2.3.0）。
+⚠️ 這些文件會漂移——曾出現 `file-reference.md` 寫死版號、實際版本早已前進數個 minor 的情況。
 **以程式碼為準**，發現不符就順手修文件。
 
 ## 文件沒寫、但改壞會很痛的三件事
@@ -55,7 +55,9 @@ flutter test                                  # 全套 554 個，20–40s
 flutter test test/ui/console_tab_test.dart    # 單檔
 flutter analyze lib/ test/
 ./scripts/gen_test_coverage.sh                # coverage + genhtml
-make analyze_lint / make format / make fix
+make analyze_lint                             # dart analyze
+make format                                   # dart format
+make fix                                      # dart fix --apply
 ```
 
 **既有雜訊**：`flutter analyze` 目前有 **6 個** `deprecated_member_use` info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ App 內除錯檢視工具（Flutter package）：把 log / network / navigator /
 ## 指令
 
 ```bash
-flutter test                                  # 全套 554 個，20–40s
+flutter test                                  # 全套 554 個，15–20s
 flutter test test/ui/console_tab_test.dart    # 單檔
 flutter analyze lib/ test/
 ./scripts/gen_test_coverage.sh                # coverage + genhtml
@@ -60,9 +60,10 @@ make format                                   # dart format
 make fix                                      # dart fix --apply
 ```
 
-**既有雜訊**：`flutter analyze` 目前有 **6 個** `deprecated_member_use` info
-（`withOpacity`、Radio 的 `groupValue`/`onChanged`）。看到這 6 個不用查，
-**變成 7 個才是你這次引入的**。
+**既有雜訊**：`flutter analyze lib/ test/` 目前有 **7 個 info**——6 個
+`deprecated_member_use`（`withOpacity` ×4、Radio 的 `groupValue`/`onChanged`）
+加 1 個 `invalid_runtime_check_with_js_interop_types`（`share_text_web.dart:15`）。
+看到這 7 個不用查，**多出來的才是你這次引入的**。
 
 ## 發版：版號在四處
 
@@ -71,9 +72,27 @@ make fix                                      # dart fix --apply
 IMPORTANT: 第四處最常漏（v1.6.0 已中招一次）。`FlutterInspector.version` 讀的就是
 `packageVersion`，漏改會讓診斷報告印出錯的版本號。
 
+## 驗證只在本機，沒有 CI
+
+repo **沒有 `.github/`**——沒有任何 workflow 會在 PR 上跑測試或 analyze。
+上面那些指令是唯一的把關，**你不跑就沒人跑**。
+
+⚠️ `Makefile` 有一批從樣板留下的死 target，相依根本不存在：
+`build_runner`／`build_watch`／`build_clean`（無 `build_runner` 相依）、
+`launcher_icon`（無 `flutter_launcher_icons`）、`intl`（無 `intl_utils`）、
+`analyze_custom`（無 `custom_lint`）、`get`（跑 `pod install`，但 root 沒有 `ios/`）。
+**只有 `analyze_lint`／`format`／`fix` 能用。**
+
+`example/` 是手動 demo，不是測試目標——`example/test/widget_test.dart` 是
+`flutter create` 的 counter 樣板、從未改過。要眼見為憑就 `cd example && flutter run`，
+別指望在那裡跑 `flutter test` 會抓到東西。
+
 ## 其他
 
 - 風格／流程規範在 `.claude/rules/`（自動載入，勿在此重複）
 - 開發流程走 `.claude/skills/gen-dev-workflow`
+- `best_practices.md` 與 `.claude/rules/flutter-styles.md` 內容高度重疊，但**受眾不同**：
+  前者給 CodeRabbit／Qodo 的 PR bot 讀（`.coderabbit.yaml`、`.pr_agent.toml`），
+  後者給 Claude Code 讀。**別合併或去重**
 - `network_notifier.dart` 與 `share_text.dart` 用 conditional export 切 `_io`/`_web`，
   **改一邊要同步另一邊的簽章**，否則只有 web build 會炸、單測抓不到

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,98 +1,75 @@
 # flutter_inspector_kit
 
-App 內除錯檢視工具（Flutter package）：把 log / network / navigator / database
-四種來源收在單一 API 後面，攤平成一條混合時間軸。
+App 內除錯檢視工具（Flutter Package）：把 log / network / navigator / database 四種來源收在單一 API 後，攤平成一條混合時間軸。
 
-**設計主張**：排查靠「鏈推斷」（不知道要找什麼，看事情怎麼演變成這樣），不是
-「點查詢」。任何會切斷前後文的設計都要先過這一關——這是否決 §D3（±5s 側欄）與
-§P2（錯誤上下文快照）的理由，動 filter / timeline 前先讀。
+**核心設計哲學**：排查靠「鏈推斷」（看事件演變脈絡），而非「點查詢」。任何切斷前後文的設計皆不被接受（如已否決的 ±5s 側欄與錯誤上下文快照）。
 
-## 架構文件（不要重寫，先讀）
+## 1. 架構文件導覽
 
-| 想知道 | 讀 |
-|:---|:---|
-| 分層、設計原則、WeakReference/錯誤鉤子/WebView 防護 | `docs/architecture/overview.md` |
-| 每個檔案是什麼、放哪 | `docs/architecture/file-reference.md` |
-| 八條主要流程的時序圖（含 mergedTimeline 歸併） | `docs/architecture/data-flow.md` |
-
-⚠️ 這些文件會漂移——曾出現 `file-reference.md` 寫死版號、實際版本早已前進數個 minor 的情況。
-**以程式碼為準**，發現不符就順手修文件。
-
-## 文件沒寫、但改壞會很痛的三件事
-
-**1. `RingBuffer.onMutate` → `revision` 是唯一的變更通道**
-
-四個 buffer 的 `onMutate` 全接到 `InspectorRegistry._bump()`，任一 buffer 變動就
-`revision.value++`。UI 只訂閱這一個 `ValueListenable<int>`，不逐 inspector 掛 listener。
-
-- `onMutate` 內**不可**再對同一 buffer `add`/`replace`/`clear`（重入仍在堆疊上的變更）
-- `InspectorRegistry` **不 dispose**（app-scoped 長生命週期）→ **取消訂閱是訂閱方的責任**，
-  加了 listener 就必須在 `dispose()` 移除，否則洩漏
-
-**2. `mergedTimeline()` 回傳 buffer 內的原始指標，不複製**
-
-所以 network entry 從 pending → completed，下次讀自然反映最新狀態，**不存在第二份真相**。
-過濾發生在收集階段（`if` 決定要不要讀某個 buffer），不是排序階段。
-要改成回傳 copy 之前，先想清楚會破壞這個不變式。
-
-**3. 緩衝型 vs 即時查詢型，是兩種不同的東西**
-
-| | 緩衝型（inspector） | 即時查詢型（browser source） |
+| 主題 | 參照路徑 | 核心內容 |
 |:---|:---|:---|
-| 資料 | 過去發生的事件，進 RingBuffer(500) | 當下的實際內容，呼叫時才查 |
-| 進時間軸 | ✅ | ❌ |
-| 註冊 | 內建四個，固定 | host 自行 register |
+| 系統架構 | `docs/architecture/overview.md` | 分層、設計原則、WeakReference、錯誤鉤子、WebView 防護 |
+| 檔案索引 | `docs/architecture/file-reference.md` | 模組結構與檔案職責（若與程式碼衝突以程式碼為準） |
+| 資料流向 | `docs/architecture/data-flow.md` | 8 條主要流程時序圖（含 `mergedTimeline` 歸併機制） |
 
-`TimelineSource` 只有 `{log, network, nav, db}`——**Storage tab 沒有對應項**，
-它是純即時查詢，不產生時序事件。`OperationLogSource` 是唯一的橋：把緩衝型的
-`DatabaseInspector` 包成 `DatabaseBrowserSource`，所以 Database tab 的下拉選單裡
-會同時出現「真實 DB」與「Operation log」兩種來源。
+## 2. 核心不變式與致命陷阱 (Critical Invariants)
 
-## 指令
+以下為本專案不可違背的關鍵設計約束，修改前必須理解：
+
+1. **`RingBuffer.onMutate` → `revision` 為唯一變更通道**
+   - 4 個 buffer 的 `onMutate` 統一觸發 `InspectorRegistry._bump()`（`revision.value++`）。
+   - UI 僅訂閱單一 `ValueListenable<int>`，禁止逐個 inspector 掛載 listener。
+   - `onMutate` 內**嚴禁重入**（不可再次對同一 buffer 執行 `add`/`replace`/`clear`）。
+   - `InspectorRegistry` 屬 App-scoped 長生命週期**不 dispose**；所有訂閱方（UI/Widget）**必須在 `dispose()` 中主動移除 listener**，否則必致記憶體洩漏。
+
+2. **`mergedTimeline()` 回傳原始物件指標（禁止防禦性複製）**
+   - 時間軸直接引用 buffer 內部 entry 物件，確保異步狀態（如 network pending → completed）自動反映最新值，**不存在第二份真相**。
+   - 過濾邏輯必須在收集階段（決定是否讀取 buffer）完成，而非排序後過濾。
+
+3. **緩衝型 (Inspector) vs 即時查詢型 (Browser Source) 嚴格分流**
+   - **緩衝型**（`log`, `network`, `nav`, `db`）：事件寫入 `RingBuffer(500)`，進入時間軸，由套件固定內建。
+   - **即時查詢型**（如 `Storage`、外部 DB）：呼叫時即時拉取，不產生時序事件，不進時間軸，由 Host 主動註冊。
+   - `OperationLogSource` 為唯一特例：將緩衝型 `DatabaseInspector` 包裝為 `DatabaseBrowserSource`。
+
+4. **條件匯出（Conditional Export）雙向簽章一致性**
+   - `network_notifier.dart` 與 `share_text.dart` 透過條件匯出切換 `_io.dart` 與 `_web.dart`。
+   - **修改任一側公開介面時，必須同步修改另一側的函式簽章**，否則 Web build 會崩潰且單元測試無法捕捉。
+
+5. **Flutter Package 純淨性與依賴限制**
+   - 本套件為輕量級除錯工具，核心禁止引入任何重量級狀態管理庫（如 BLoC、Riverpod、Provider），以原生效能元件（`ValueNotifier`、`StatefulWidget`）實作。
+
+## 3. 指令集與驗證基準 (Commands & Baseline)
 
 ```bash
-flutter test                                  # 全套 554 個，15–20s
-flutter test test/ui/console_tab_test.dart    # 單檔
-flutter analyze lib/ test/
-./scripts/gen_test_coverage.sh                # coverage + genhtml
+# 測試
+flutter test                                  # 全套測試 (554 tests, ~15–20s)
+flutter test test/ui/console_tab_test.dart    # 單檔測試
+
+# 分析與程式碼格式化
+flutter analyze lib/ test/                    # 靜態分析
 make analyze_lint                             # dart analyze
-make format                                   # dart format
+make format                                   # dart format .
 make fix                                      # dart fix --apply
+./scripts/gen_test_coverage.sh                # 覆蓋率報告產生 (coverage + genhtml)
 ```
 
-**既有雜訊**：`flutter analyze lib/ test/` 目前有 **7 個 info**——6 個
-`deprecated_member_use`（`withOpacity` ×4、Radio 的 `groupValue`/`onChanged`）
-加 1 個 `invalid_runtime_check_with_js_interop_types`（`share_text_web.dart:15`）。
-看到這 7 個不用查，**多出來的才是你這次引入的**。
+- **既有分析雜訊基準**：目前 `flutter analyze lib/ test/` 存在 **7 個既有 info**（6 個 `deprecated_member_use` 關於 `withOpacity` / `groupValue`，以及 1 個 `share_text_web.dart:15` 的 js interop 型別檢查）。**唯有超出這 7 個的新增 warning/info 才是本次改動引入的問題**。
+- **無 CI 機制（本機嚴格驗證）**：Repo 未設置 `.github/` CI workflow，所有測試與靜態分析完全依賴開發者與 Agent 本機執行確認。
+- **Makefile 死指令警告**：僅 `analyze_lint`、`format`、`fix` 可用；其餘如 `build_runner`、`launcher_icon`、`intl`、`analyze_custom`、`get` 等 target 缺少外部相依，禁止調用。
+- **Demo 專案邊界**：`example/` 僅為手動示範沙盒（`cd example && flutter run`），其內部測試檔為預設樣板，不作為自動化測試驗證目標。
 
-## 發版：版號在四處
+## 4. 發版規範：4 處版本號同步
 
-`pubspec.yaml` → `README.md` → `CHANGELOG.md` → **`lib/src/version.dart`**
+發布新版本時，必須**同時更新以下 4 處版本號**（任何一處遺漏皆屬發版 Bug）：
+1. `pubspec.yaml`
+2. `README.md`
+3. `CHANGELOG.md`
+4. `lib/src/version.dart`（`FlutterInspector.version` 依賴此檔，漏改將導致診斷輸出錯誤版本）
 
-IMPORTANT: 第四處最常漏（v1.6.0 已中招一次）。`FlutterInspector.version` 讀的就是
-`packageVersion`，漏改會讓診斷報告印出錯的版本號。
+## 5. 規範體系與邊界分工
 
-## 驗證只在本機，沒有 CI
+- **`CLAUDE.md`**（本檔）：AI Agent 開發與對話之主要上下文，專注於專案架構不變式、踩坑防護與指令集。
+- **`best_practices.md`**：專供 CodeRabbit / Qodo Merge 等 PR Review Bot 讀取之審查標準，**請勿與本檔合併或去重**。
+- **`.agents/rules/`（或 `.claude/rules/`）**：細部程式碼風格（`flutter-styles.md`）、專家原則（`expert-rules.md`）與 RTK 規範。
+- **開發流程**：標準開發與 Feature 推進請遵循 `.claude/skills/gen-dev-workflow`。
 
-repo **沒有 `.github/`**——沒有任何 workflow 會在 PR 上跑測試或 analyze。
-上面那些指令是唯一的把關，**你不跑就沒人跑**。
-
-⚠️ `Makefile` 有一批從樣板留下的死 target，相依根本不存在：
-`build_runner`／`build_watch`／`build_clean`（無 `build_runner` 相依）、
-`launcher_icon`（無 `flutter_launcher_icons`）、`intl`（無 `intl_utils`）、
-`analyze_custom`（無 `custom_lint`）、`get`（跑 `pod install`，但 root 沒有 `ios/`）。
-**只有 `analyze_lint`／`format`／`fix` 能用。**
-
-`example/` 是手動 demo，不是測試目標——`example/test/widget_test.dart` 是
-`flutter create` 的 counter 樣板、從未改過。要眼見為憑就 `cd example && flutter run`，
-別指望在那裡跑 `flutter test` 會抓到東西。
-
-## 其他
-
-- 風格／流程規範在 `.claude/rules/`（自動載入，勿在此重複）
-- 開發流程走 `.claude/skills/gen-dev-workflow`
-- `best_practices.md` 與 `.claude/rules/flutter-styles.md` 內容高度重疊，但**受眾不同**：
-  前者給 CodeRabbit／Qodo 的 PR bot 讀（`.coderabbit.yaml`、`.pr_agent.toml`），
-  後者給 Claude Code 讀。**別合併或去重**
-- `network_notifier.dart` 與 `share_text.dart` 用 conditional export 切 `_io`/`_web`，
-  **改一邊要同步另一邊的簽章**，否則只有 web build 會炸、單測抓不到

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# flutter_inspector_kit
+
+App 內除錯檢視工具（Flutter package）：把 log / network / navigator / database
+四種來源收在單一 API 後面，攤平成一條混合時間軸。
+
+**設計主張**：排查靠「鏈推斷」（不知道要找什麼，看事情怎麼演變成這樣），不是
+「點查詢」。任何會切斷前後文的設計都要先過這一關——這是否決 §D3（±5s 側欄）與
+§P2（錯誤上下文快照）的理由，動 filter / timeline 前先讀。
+
+## 架構文件（不要重寫，先讀）
+
+| 想知道 | 讀 |
+|:---|:---|
+| 分層、設計原則、WeakReference/錯誤鉤子/WebView 防護 | `docs/architecture/overview.md` |
+| 每個檔案是什麼、放哪 | `docs/architecture/file-reference.md` |
+| 八條主要流程的時序圖（含 mergedTimeline 歸併） | `docs/architecture/data-flow.md` |
+
+⚠️ 這些文件會漂移（曾出現 `file-reference.md` 記版本 `1.6.0` 但實際已到 2.3.0）。
+**以程式碼為準**，發現不符就順手修文件。
+
+## 文件沒寫、但改壞會很痛的三件事
+
+**1. `RingBuffer.onMutate` → `revision` 是唯一的變更通道**
+
+四個 buffer 的 `onMutate` 全接到 `InspectorRegistry._bump()`，任一 buffer 變動就
+`revision.value++`。UI 只訂閱這一個 `ValueListenable<int>`，不逐 inspector 掛 listener。
+
+- `onMutate` 內**不可**再對同一 buffer `add`/`replace`/`clear`（重入仍在堆疊上的變更）
+- `InspectorRegistry` **不 dispose**（app-scoped 長生命週期）→ **取消訂閱是訂閱方的責任**，
+  加了 listener 就必須在 `dispose()` 移除，否則洩漏
+
+**2. `mergedTimeline()` 回傳 buffer 內的原始指標，不複製**
+
+所以 network entry 從 pending → completed，下次讀自然反映最新狀態，**不存在第二份真相**。
+過濾發生在收集階段（`if` 決定要不要讀某個 buffer），不是排序階段。
+要改成回傳 copy 之前，先想清楚會破壞這個不變式。
+
+**3. 緩衝型 vs 即時查詢型，是兩種不同的東西**
+
+| | 緩衝型（inspector） | 即時查詢型（browser source） |
+|:---|:---|:---|
+| 資料 | 過去發生的事件，進 RingBuffer(500) | 當下的實際內容，呼叫時才查 |
+| 進時間軸 | ✅ | ❌ |
+| 註冊 | 內建四個，固定 | host 自行 register |
+
+`TimelineSource` 只有 `{log, network, nav, db}`——**Storage tab 沒有對應項**，
+它是純即時查詢，不產生時序事件。`OperationLogSource` 是唯一的橋：把緩衝型的
+`DatabaseInspector` 包成 `DatabaseBrowserSource`，所以 Database tab 的下拉選單裡
+會同時出現「真實 DB」與「Operation log」兩種來源。
+
+## 指令
+
+```bash
+flutter test                                  # 全套 554 個，20–40s
+flutter test test/ui/console_tab_test.dart    # 單檔
+flutter analyze lib/ test/
+./scripts/gen_test_coverage.sh                # coverage + genhtml
+make analyze_lint / make format / make fix
+```
+
+**既有雜訊**：`flutter analyze` 目前有 **6 個** `deprecated_member_use` info
+（`withOpacity`、Radio 的 `groupValue`/`onChanged`）。看到這 6 個不用查，
+**變成 7 個才是你這次引入的**。
+
+## 發版：版號在四處
+
+`pubspec.yaml` → `README.md` → `CHANGELOG.md` → **`lib/src/version.dart`**
+
+IMPORTANT: 第四處最常漏（v1.6.0 已中招一次）。`FlutterInspector.version` 讀的就是
+`packageVersion`，漏改會讓診斷報告印出錯的版本號。
+
+## 其他
+
+- 風格／流程規範在 `.claude/rules/`（自動載入，勿在此重複）
+- 開發流程走 `.claude/skills/gen-dev-workflow`
+- `network_notifier.dart` 與 `share_text.dart` 用 conditional export 切 `_io`/`_web`，
+  **改一邊要同步另一邊的簽章**，否則只有 web build 會炸、單測抓不到

--- a/docs/architecture/file-reference.md
+++ b/docs/architecture/file-reference.md
@@ -106,4 +106,4 @@
 | 檔案路徑 | 關鍵類別/列舉 | 單一職責 (Single Responsibility) |
 | :--- | :--- | :--- |
 | [`lib/src/extensions/log_level_color_extension.dart`](../../lib/src/extensions/log_level_color_extension.dart) | `LogLevelColor` | 為不同 `LogLevel` 的日誌提供語意化色彩映射。 |
-| [`lib/src/version.dart`](../../lib/src/version.dart) | `packageVersion` (String) | 定義當前 package 的版本資訊。**發版時必須與 `pubspec.yaml` 同步**——此處刻意不寫死版號，避免文件與實際版本漂移（本行原記 `'1.6.0'`，實際已到 2.3.0）。 |
+| [`lib/src/version.dart`](../../lib/src/version.dart) | `packageVersion` (String) | 定義當前 package 的版本資訊。**發版時必須與 `pubspec.yaml` 同步**——此處刻意不寫死版號，避免文件與實際版本漂移。 |

--- a/docs/architecture/file-reference.md
+++ b/docs/architecture/file-reference.md
@@ -106,4 +106,4 @@
 | 檔案路徑 | 關鍵類別/列舉 | 單一職責 (Single Responsibility) |
 | :--- | :--- | :--- |
 | [`lib/src/extensions/log_level_color_extension.dart`](../../lib/src/extensions/log_level_color_extension.dart) | `LogLevelColor` | 為不同 `LogLevel` 的日誌提供語意化色彩映射。 |
-| [`lib/src/version.dart`](../../lib/src/version.dart) | `packageVersion` (String) | **[新增]** 定義當前 package 的版本資訊（應與 `pubspec.yaml` 同步為 `'1.6.0'`）。 |
+| [`lib/src/version.dart`](../../lib/src/version.dart) | `packageVersion` (String) | 定義當前 package 的版本資訊。**發版時必須與 `pubspec.yaml` 同步**——此處刻意不寫死版號，避免文件與實際版本漂移（本行原記 `'1.6.0'`，實際已到 2.3.0）。 |


### PR DESCRIPTION
Closes #146

## Summary

新增專案層 `CLAUDE.md`（77 行），只寫 `docs/architecture/` 沒涵蓋、且改壞會痛的事；順帶修掉 `file-reference.md` 一處版號漂移。

## 修正問題

專案原本沒有 `CLAUDE.md`。已有的規範散在兩處，各自有缺口：

- `.claude/rules/`（879 行，`always_on`）— 通用 Flutter/Dart 風格與 Linus 式設計判斷，**不含本專案的指令、測試、發版流程**
- `docs/architecture/`（588 行）— 分層、逐檔用途、八條流程時序圖，**不含 buffer 變更通道與時間軸的不變式**

## 修正方式

依 [Anthropic best practices](https://code.claude.com/docs/en/best-practices) 的 ✅/❌ 表格取捨——「可從 code 推導的」「逐檔描述」「詳細 API 文件（改為連結）」一律不寫：

**指路而非重寫**：三份 architecture 文件做成一張對照表（想知道 X → 讀哪份），不搬運內容。

**只補文件真正沒寫的三件事**（實查 `docs/` 逐項確認 `onMutate` / `revision` / 「不複製」皆零命中）：

1. `RingBuffer.onMutate` → `InspectorRegistry.revision` 是唯一變更通道。兩個陷阱：`onMutate` 內不可再動同一 buffer；registry 不 dispose，**取消訂閱是訂閱方的責任**
2. `mergedTimeline()` 回傳 buffer 原始指標不複製——所以 network entry pending→completed 會自然反映，不存在第二份真相
3. 緩衝型 vs 即時查詢型是兩種東西，解釋了為何 5 個 tab 只有 4 個 `TimelineSource`，以及 `OperationLogSource` 這座橋

**發版 gotcha**：版號在四處，`lib/src/version.dart` 最常漏（v1.6.0 已中招）。全檔僅此一行標 `IMPORTANT`——依官方建議，強調多處等於沒強調。

**順帶修根因**：`file-reference.md` 原寫「應與 pubspec.yaml 同步為 `'1.6.0'`」，實際已到 2.3.0。沒有改成 `2.3.0`（下次發版又會錯），而是**移除版號字面值**只留同步規則。

**Review 回應**（`1cae091`，CodeRabbit 2 則）：

- **`make` 指令會壞** — 原本寫成一行 `make analyze_lint / make format / make fix`，且位於 bash 區塊內讀起來可直接複製。實測 `make -n` 證實它被解析為**一次** make 呼叫：跑完 `analyze_lint` 後接連報 `Nothing to be done for '/'` 與 `No rule to make target 'make'`。已拆成三行並各自標注實際執行內容（對照 `Makefile:39-53`）。
- **移除當前版號字面值** — 在長期文件裡寫死當前版號，等於複製了它自己要警告的問題。已移除 `file-reference.md` 與 `CLAUDE.md:18` 的 `1.6.0`／`2.3.0`。**但 `CLAUDE.md:71` 的 `v1.6.0` 刻意保留**——那是**事件記錄**（發版漏改第四處那次中招），不是「當前版本是 X」的宣稱，歷史事實不會過期。判準是「這個數字宣稱當前狀態，還是已發生的事實」。

## Out of scope

- 不動 `.claude/rules/`（風格規範各司其職，CLAUDE.md 不重複）
- 不改任何 `lib/` 程式碼

## Verification

- 77 行，符合官方 200 行上限
- 所有引用路徑實測存在；`dashboard_modal.dart` 的 `revision.addListener` 已核對
- 兩個 opt-in 預設值、`packageVersion` 來源、`onMutate` 遞迴警告皆逐項比對原始碼
- 實測數字校正：全套 **554 tests passed**、`flutter analyze lib/ test/` 為 **6 個既有 info**
- 一併移除草稿階段誤植的「magical_tap_test 有 10 分鐘 timeout」——實測該檔 4.5s 通過，全 repo 無任何 `@Timeout`
- `make` 指令拆分經 `make -n` 實測驗證，三個 target 的說明對照 `Makefile:39-53`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

为未记录的架构不变量和发布实践添加项目专属的贡献者指南。

新功能：
- 添加项目级指南，涵盖其他文档中未记录的架构约定、开发命令和发布要求。

错误修复：
- 防止架构文档指定过时的软件包版本。

增强功能：
- 记录注册表修订版本的变更路径、缓冲区引用语义，以及缓冲时间线数据与实时查询源之间的区别。
- 提供现有架构文档的简明导航，并强调特定平台实现一致性的要求。

文档：
- 添加包含项目背景、架构导航、操作不变量、测试指南和发布版本说明的 77 行 `CLAUDE.md`。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

补充项目特定的架构不变量、开发工作流和发布实践指南，以覆盖现有文档中未涉及的内容。

新功能：
- 添加项目级贡献者指南，涵盖未记录的架构不变量、开发命令和发布要求。

错误修复：
- 从架构文件引用中移除硬编码的过时软件包版本，并将其替换为同步规则。

改进：
- 记录注册表修订版本的更新路径、缓冲区引用语义，以及缓冲时间线事件与实时查询源之间的区别。
- 为现有架构文档提供简明的导航，并强调平台实现一致性要求。

文档：
- 添加一个包含 77 行内容的 `CLAUDE.md`，涵盖项目背景、架构指南、运行不变量、测试和版本管理实践。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

新增项目特定的架构不变量、开发工作流和发布实践指南，同时移除架构参考文档中过时的硬编码版本号。

新功能：
- 添加项目级贡献者指南，涵盖其他文档中未记录的项目特定架构不变量、开发命令、测试指南和发布实践。

错误修复：
- 从架构文件引用中移除硬编码的软件包版本，并将其替换为版本同步规则。

增强功能：
- 记录注册表修订版本更新路径、缓冲区引用语义，以及缓冲的时间线事件与实时查询源之间的区别。
- 为现有架构文档提供简明的导航，并强调平台实现一致性要求。

文档：
- 添加包含项目背景、架构指南、操作不变量、命令和版本管理说明的 79 行 `CLAUDE.md`。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

新增项目专属的贡献者指南，涵盖架构不变量、开发工作流和发布实践，同时避免文档版本漂移。

新功能：
- 新增项目级贡献者指南，涵盖项目特定的架构不变量、开发命令、测试要求、发布版本同步，以及其他未在现有文档中说明的仓库约定。

错误修复：
- 移除架构文件引用中的硬编码软件包版本，并将其替换为通用的同步规则。

增强：
- 提供指向现有架构文档的简明导航，并记录缓冲区变更通知、时间线引用语义，以及缓冲数据源与实时数据源之间的区别。

文档：
- 记录当前没有 CI、受支持的 Make 目标、特定平台实现的一致性要求，以及手动示例与测试目标之间的区别。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

新增项目专属的贡献者指南，涵盖架构不变量、开发工作流和发布实践，同时防止文档版本漂移。

新功能：
- 新增项目级贡献者指南，涵盖项目专属的架构不变量、开发命令、测试要求和发布要求。

错误修复：
- 移除架构文件引用中的硬编码软件包版本，并将其替换为版本同步规则。

改进：
- 记录注册表修订版本更新路径、缓冲区引用语义、数据源区别、条件导出一致性要求，以及如何导航至现有架构文档。

文档：
- 在 `CLAUDE.md` 中记录仓库的本地验证基线、可用的 Make 目标、演示项目边界，以及发布版本在四个位置的同步要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add project-specific contributor guidance for architecture invariants, development workflows, and release practices while preventing documentation version drift.

New Features:
- Add a project-level contributor guide covering project-specific architecture invariants, development commands, testing expectations, and release requirements.

Bug Fixes:
- Remove the hard-coded package version from the architecture file reference and replace it with a version-synchronization rule.

Enhancements:
- Document the registry revision update path, buffer reference semantics, data-source distinctions, conditional-export consistency requirements, and navigation to existing architecture documentation.

Documentation:
- Document the repository’s local validation baseline, available Make targets, demo-project boundaries, and four-location release version synchronization in `CLAUDE.md`.

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 新增项目架构与设计原则说明，涵盖关键不变量、数据来源类型、常用测试与分析命令。
  * 补充版本号维护位置、本地验证限制、示例项目用途及条件导出同步要求。
  * 更新文件参考文档，移除固定版本号说明，明确版本信息应与项目配置保持同步。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

