### PR TITLE
feat: stacktrace async gap normalization and UI concise toggle

### DIFF
--- a/docs/features/2026-08-29-p19-stacktrace-normalization.md
+++ b/docs/features/2026-08-29-p19-stacktrace-normalization.md
@@ -1,0 +1,32 @@
+# §P19 StackTrace 非同步鏈正規化 (StackTrace Async Gap Normalization)
+
+## What & Why (背景與目的)
+Flutter 拋出的 `StackTrace` 往往充斥大量框架內部的呼叫（如 `package:flutter/src/widgets/framework.dart`、`dart:async`、`dart:isolate` 等），往往長達數十行。在發生非同步錯誤時，堆疊更會被 `<asynchronous suspension>` 切割，使得真正出錯的業務程式碼（宿主 App 的代碼）被淹沒在框架噪聲中。開發者與 QA 排查時難以一眼看出出錯的原始位置。
+本提案旨在透過正規化 StackTrace，自動折疊連續的框架內部呼叫（Frame Folding），清楚標示非同步跳轉點（Async Gap Demangling），並預設突出顯示業務邏輯層的程式碼。藉此大幅降低視覺噪聲，提升從 `LogDetailView` 獲取排查線索的效率。
+
+## User Story (使用者故事)
+- 作為開發者或 QA，當我在 `LogDetailView` 中檢視包含 StackTrace 的 Error Log 時，我希望預設看到的是「去噪後」的精簡堆疊（Concise Stack），將長篇大論的 Flutter / Dart 內部呼叫折疊起來，讓我一眼看見我自己 App 內的程式碼行。
+- 作為開發者，當遇到非同步錯誤時，我希望堆疊中的 `<asynchronous suspension>` 能被明確標示為非同步跳轉鏈，幫助我理解跨事件迴圈的錯誤脈絡。
+- 作為開發者，我希望保留查看與複製「原始堆疊 (Raw Stack)」的能力，以便在特殊情況下調查框架內部的崩潰。
+- 作為 QA，當我一鍵分享或匯出診斷報告時，我希望能選擇帶出更容易閱讀的精簡堆疊資訊，讓工程師能更快定位問題。
+
+## Acceptance Criteria (驗收條件)
+1. **框架噪聲折疊 (Frame Folding)**：
+   - 當 `LogDetailView` 顯示 `StackTrace` 時，預設模式下，連續屬於 `package:flutter/*` 或 `dart:*` 的 frame 會被折疊成單行提示（例如 `[... 12 frames of framework internals]`）。
+   - 未被折疊的業務程式碼（例如 `package:宿主App/*`）必須被清晰保留。
+2. **非同步鏈拼接 (Async Gap Demangling)**：
+   - 原始堆疊中的 `<asynchronous suspension>` 應被轉換或標示為直觀的非同步中斷點。
+3. **視圖切換與複製功能**：
+   - `LogDetailView` 的 Stack Trace 區塊需提供一個輕量的切換機制（例如 Toggle 開關或按鈕），讓使用者能自由在「精簡視圖 (Concise)」與「原始視圖 (Raw)」間切換。
+   - `LogDetailView` 既有的 Share 選單必須支援分享/複製目前的精簡堆疊版本或完整的原始堆疊版本。
+4. **資料不滅原則**：
+   - `LogEntry.stackTrace` 必須始終保留原始字串。正規化與折疊僅在 Presentation 層（UI 與字串格式化工具）進行，絕不修改資料層。
+
+## Scope & Boundaries (範圍與邊界)
+- **Scope**:
+  - 擴充 `lib/src/utils/log_formatters.dart`，加入將字串形式的 StackTrace 解析為精簡堆疊格式的純函式邏輯。
+  - 更新 `lib/src/ui/dashboard/tabs/console/log_detail_view.dart` 的 `_stackTraceSection` 實作。
+  - 可評估引入 Dart 官方維護之 `stack_trace` 套件作為輕量相依，或撰寫輕量的 Regex 剖析器。
+- **Out of Scope**:
+  - **IDE 跳轉整合**：我們只做字串展示與文字選取，不處理與 IDE 的深層連結協定串接（例如 `idea://` / `vscode://`）。
+  - **自動反混淆 (Deobfuscation)**：若 App 發布時已開啟混淆，我們只展示混淆後的堆疊，不在此功能內處理 mapping file 的解析。

--- a/docs/issues/p19-stacktrace-norm.md
+++ b/docs/issues/p19-stacktrace-norm.md
@@ -1,0 +1,19 @@
+## 問題描述 (Problem)
+在 Flutter 應用中發生非同步例外時，拋出的 StackTrace 會充斥大量 `package:flutter/*` 與 `dart:*` 的內部底層呼叫，且因為 `async/await` 的特性，會被 `<asynchronous suspension>` 分割得支離破碎。這讓排查者極難一眼在 `LogDetailView` 中定位到真實出錯的業務邏輯程式碼。
+
+## 根本原因（已驗證）(Root cause - verified)
+Flutter 與 Dart 在遇到非同步錯誤時，原始的 StackTrace 字串會詳實記錄所有 Frame，但並未提供針對業務邏輯的去噪 (De-noising) 與框架折疊機制。目前 `LogEntry` 與 `LogDetailView` 僅直接顯示未處理的原始字串。
+
+## 修復方案 (Fix)
+- **A** `lib/src/utils/log_formatters.dart`：新增 `normalizeStackTrace` 純函式進行折疊 (Frame Folding) 與標記 (Async Gap Demangling)，並擴充 `buildLogPlainText` 支援精簡模式參數。
+- **B** `lib/src/ui/widgets/detail_section.dart`：為標題列加入 `trailing` 參數以支援後續的切換按鈕排版。
+- **C** `lib/src/ui/dashboard/tabs/console/log_detail_view.dart`：升級為 `StatefulWidget`，實作「原始/精簡」的 StackTrace 視圖切換，並將對應複製與分享選項整合至 Share 選單。
+
+## 排除範圍 (Out of scope)
+- 與 IDE 的深層跳轉串接（如 `vscode://` 等協定）。
+- 發布環境的混淆堆疊 (Obfuscated StackTrace) 自動反混淆處理。
+
+## 驗證方式 (Verification)
+- 進入 `LogDetailView` 查看含有錯誤的 Log，確認預設顯示折疊後的 StackTrace，且清楚標示 `<-- async gap -->`。
+- 點擊「精簡/原始」切換按鈕，確認視圖能正確切換，且底層資料結構字串不被竄改。
+- 透過 Share 選單複製/分享精簡版本，確認輸出內容與畫面相符。

--- a/docs/plans/2026-08-29-p19-stacktrace-normalization.md
+++ b/docs/plans/2026-08-29-p19-stacktrace-normalization.md
@@ -1,0 +1,50 @@
+# §P19 StackTrace 非同步鏈正規化 實作計畫
+
+## Data Structures & Logic (資料結構與邏輯)
+
+本功能著重於 Presentation 層的字串處理與 UI 狀態管理，不改變資料層 `LogEntry` 儲存的原始堆疊字串。
+
+1. **自訂輕量剖析器 (`normalizeStackTrace`)**：
+   - 考量到避免引入不必要的套件依賴，我們實作一個輕量的純文字剖析函式，針對 `StackTrace` 字串以換行符號 (`\n`) 切割。
+   - **框架噪聲折疊 (Frame Folding)**：逐行檢查，若該行包含 `package:flutter/` 或 `dart:`，則視為框架內部呼叫並累加計數。當遇到業務程式碼（不包含上述字串）時，將前面累加的框架行數折疊輸出為 `  [... N frames of framework internals]`，接著輸出該行業務程式碼。
+   - **非同步鏈拼接 (Async Gap Demangling)**：遇到 `<asynchronous suspension>` 時，同樣先清空並輸出先前的折疊計數，並將其替換為更直觀的標示，例如 `  <-- async gap -->`。
+2. **匯出格式化擴充 (`buildLogPlainText`)**：
+   - 為 `buildLogPlainText` 增加 `bool isConcise = true` 參數。當 `isConcise` 為 `true` 且存在 stack trace 時，呼叫 `normalizeStackTrace` 進行去噪；若為 `false` 則輸出原始字串。
+
+## File Modifications (檔案異動清單)
+
+1. **`lib/src/utils/log_formatters.dart`**
+   - 新增 `String normalizeStackTrace(String rawStack)` 純函式。
+   - 修改 `buildLogPlainText` 的簽章與實作，加入 `isConcise` 判斷。
+
+2. **`lib/src/ui/widgets/detail_section.dart`**
+   - 為 `DetailSection` 增加 `Widget? trailing` 參數。
+   - 在 `build` 方法中更新排版：若有傳入 `trailing`，則將 Title 與 Trailing 放置於 `Row` 中（例如利用 `MainAxisAlignment.spaceBetween` 排版）。
+
+3. **`lib/src/ui/dashboard/tabs/console/log_detail_view.dart`**
+   - 將 `LogDetailView` 從 `StatelessWidget` 重構為 `StatefulWidget`。
+   - 引入狀態 `bool _isConcise = true`。
+   - 在 `_stackTraceSection` 呼叫 `DetailSection` 時，傳入 `trailing` 參數（例如使用 `Switch` 或 `TextButton` 作為切換開關），並根據 `_isConcise` 的值來決定顯示 `normalizeStackTrace` 的結果或原始字串。
+   - 擴充 `_ShareAction` enum 為：`copyConcise`、`copyRaw`、`shareConcise`、`shareRaw`，並更新分享選單 (PopupMenuButton) 提供對應的選項，在執行分享/複製時傳遞對應的 `isConcise` 旗標給 `buildLogPlainText`。
+
+## Task Breakdown (任務拆分)
+
+以下任務可指派給 STAGE 2 的實作者：
+
+### Task 1: 實作核心正規化邏輯與匯出擴充
+**修改檔案**：`lib/src/utils/log_formatters.dart`
+- 撰寫 `normalizeStackTrace` 邏輯。
+- 擴充 `buildLogPlainText` 支援精簡模式參數。
+*(註：本任務為純邏輯層，無外部依賴，可與 Task 2 完全並行處理。)*
+
+### Task 2: 基礎 UI 元件擴充
+**修改檔案**：`lib/src/ui/widgets/detail_section.dart`
+- 替 `DetailSection` 加入 `trailing` 屬性並更新 Title 區塊排版。
+*(註：本任務僅修改共用 UI 元件，可與 Task 1 並行處理。)*
+
+### Task 3: 實作 LogDetailView 視圖與互動
+**修改檔案**：`lib/src/ui/dashboard/tabs/console/log_detail_view.dart`
+**相依性**：需等待 Task 1 與 Task 2 完成。
+- 重構為 `StatefulWidget` 並加入 `_isConcise` 狀態。
+- 實作 StackTrace 區塊的切換按鈕。
+- 擴充 AppBar 的分享選單，串接新的複製與分享動作。

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -308,6 +308,7 @@ class FlutterInspector {
         level: level,
         stackTrace: stackTrace,
         data: data,
+        activeRoute: _currentTopPageLabel(),
       ),
     );
   }

--- a/lib/src/models/log_entry.dart
+++ b/lib/src/models/log_entry.dart
@@ -66,8 +66,10 @@ class LogEntry implements TimestampedEntry {
   }
 
   @override
-  int get hashCode => Object.hash(timestamp, level, message, stackTrace, data, activeRoute);
+  int get hashCode =>
+      Object.hash(timestamp, level, message, stackTrace, data, activeRoute);
 
   @override
-  String toString() => 'LogEntry(${level.name}, $message, $timestamp, activeRoute: $activeRoute)';
+  String toString() =>
+      'LogEntry(${level.name}, $message, $timestamp, activeRoute: $activeRoute)';
 }

--- a/lib/src/models/log_entry.dart
+++ b/lib/src/models/log_entry.dart
@@ -12,6 +12,7 @@ class LogEntry implements TimestampedEntry {
     this.level = LogLevel.info,
     this.stackTrace,
     this.data,
+    this.activeRoute,
     DateTime? timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
 
@@ -31,6 +32,9 @@ class LogEntry implements TimestampedEntry {
   /// Optional structured payload attached to the log.
   final Map<String, dynamic>? data;
 
+  /// The active route at the time the log was recorded.
+  final String? activeRoute;
+
   /// Returns a copy of this entry with the given fields replaced.
   LogEntry copyWith({
     DateTime? timestamp,
@@ -38,6 +42,7 @@ class LogEntry implements TimestampedEntry {
     String? message,
     String? stackTrace,
     Map<String, dynamic>? data,
+    String? activeRoute,
   }) {
     return LogEntry(
       timestamp: timestamp ?? this.timestamp,
@@ -45,6 +50,7 @@ class LogEntry implements TimestampedEntry {
       message: message ?? this.message,
       stackTrace: stackTrace ?? this.stackTrace,
       data: data ?? this.data,
+      activeRoute: activeRoute ?? this.activeRoute,
     );
   }
 
@@ -55,12 +61,13 @@ class LogEntry implements TimestampedEntry {
         other.level == level &&
         other.message == message &&
         other.stackTrace == stackTrace &&
+        other.activeRoute == activeRoute &&
         mapEquals(other.data, data);
   }
 
   @override
-  int get hashCode => Object.hash(timestamp, level, message, stackTrace, data);
+  int get hashCode => Object.hash(timestamp, level, message, stackTrace, data, activeRoute);
 
   @override
-  String toString() => 'LogEntry(${level.name}, $message, $timestamp)';
+  String toString() => 'LogEntry(${level.name}, $message, $timestamp, activeRoute: $activeRoute)';
 }

--- a/lib/src/ui/dashboard/tabs/console/log_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/console/log_detail_view.dart
@@ -9,32 +9,50 @@ import '../../../widgets/key_value_table.dart';
 import '../../../theme/theme.dart';
 
 /// Actions exposed in the detail view's share menu.
-enum _ShareAction { text, share }
+enum _ShareAction { copyConcise, copyRaw, shareConcise, shareRaw }
 
 /// A full-screen, structured view of a single [LogEntry], showing General
 /// info, an optional Stack Trace section, and a Data section plus sharing
 /// (plain text / system share).
-class LogDetailView extends StatelessWidget {
+class LogDetailView extends StatefulWidget {
   const LogDetailView({required this.entry, super.key});
 
   final LogEntry entry;
 
   @override
+  State<LogDetailView> createState() => _LogDetailViewState();
+}
+
+class _LogDetailViewState extends State<LogDetailView> {
+  bool _isConcise = true;
+
+  @override
   Widget build(BuildContext context) {
-    final shortTs = _shortTimestamp(entry.timestamp);
+    final shortTs = _shortTimestamp(widget.entry.timestamp);
     return Scaffold(
       appBar: AppBar(
-        title: Text('[${entry.level.name}] $shortTs'),
+        title: Text('[${widget.entry.level.name}] $shortTs'),
         actions: [
           PopupMenuButton<_ShareAction>(
             icon: const Icon(Icons.share),
             onSelected: (action) => _onShare(context, action),
             itemBuilder: (context) => const [
               PopupMenuItem(
-                value: _ShareAction.text,
-                child: Text('Copy as text'),
+                value: _ShareAction.copyConcise,
+                child: Text('Copy concise'),
               ),
-              PopupMenuItem(value: _ShareAction.share, child: Text('Share…')),
+              PopupMenuItem(
+                value: _ShareAction.copyRaw,
+                child: Text('Copy raw'),
+              ),
+              PopupMenuItem(
+                value: _ShareAction.shareConcise,
+                child: Text('Share concise…'),
+              ),
+              PopupMenuItem(
+                value: _ShareAction.shareRaw,
+                child: Text('Share raw…'),
+              ),
             ],
           ),
         ],
@@ -43,7 +61,7 @@ class LogDetailView extends StatelessWidget {
         padding: ThemePadding.paddingAll12,
         children: [
           _generalSection(context),
-          if (entry.stackTrace?.isNotEmpty ?? false)
+          if (widget.entry.stackTrace?.isNotEmpty ?? false)
             _stackTraceSection(context),
           _dataSection(context),
         ],
@@ -57,11 +75,11 @@ class LogDetailView extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          DetailKeyValueRow.text('Message', entry.message),
-          DetailKeyValueRow.text('Level', entry.level.name),
+          DetailKeyValueRow.text('Message', widget.entry.message),
+          DetailKeyValueRow.text('Level', widget.entry.level.name),
           DetailKeyValueRow.text(
             'Timestamp',
-            entry.timestamp.toIso8601String(),
+            widget.entry.timestamp.toIso8601String(),
           ),
         ],
       ),
@@ -69,8 +87,21 @@ class LogDetailView extends StatelessWidget {
   }
 
   Widget _stackTraceSection(BuildContext context) {
+    final stackTrace = widget.entry.stackTrace!;
+    final displayedStackTrace =
+        _isConcise ? normalizeStackTrace(stackTrace) : stackTrace;
+
     return DetailSection(
       title: 'Stack Trace',
+      trailing: TextButton.icon(
+        onPressed: () {
+          setState(() {
+            _isConcise = !_isConcise;
+          });
+        },
+        icon: Icon(_isConcise ? Icons.unfold_more : Icons.unfold_less),
+        label: Text(_isConcise ? 'Show raw' : 'Show concise'),
+      ),
       child: Container(
         width: double.infinity,
         padding: ThemePadding.paddingAll8,
@@ -79,7 +110,7 @@ class LogDetailView extends StatelessWidget {
           borderRadius: BorderRadius.circular(ThemeSize.radius4),
         ),
         child: SelectableText(
-          entry.stackTrace!,
+          displayedStackTrace,
           style: ThemeTextStyle.monospaceStyle,
         ),
       ),
@@ -89,7 +120,7 @@ class LogDetailView extends StatelessWidget {
   Widget _dataSection(BuildContext context) {
     return DetailSection(
       title: 'Data',
-      child: KeyValueTable(data: entry.data, emptyLabel: '(no data)'),
+      child: KeyValueTable(data: widget.entry.data, emptyLabel: '(no data)'),
     );
   }
 
@@ -102,20 +133,29 @@ class LogDetailView extends StatelessWidget {
 
   Future<void> _onShare(BuildContext context, _ShareAction action) async {
     final messenger = ScaffoldMessenger.of(context);
+
+    final bool isConcise =
+        action == _ShareAction.copyConcise || action == _ShareAction.shareConcise;
+
+    final String logText = buildLogPlainText(
+      widget.entry,
+      isConcise: isConcise,
+    );
+
     switch (action) {
-      case _ShareAction.text:
-        await Clipboard.setData(ClipboardData(text: buildLogPlainText(entry)));
+      case _ShareAction.copyConcise:
+      case _ShareAction.copyRaw:
+        await Clipboard.setData(ClipboardData(text: logText));
         messenger.showSnackBar(
           const SnackBar(content: Text('Details copied to clipboard')),
         );
-      case _ShareAction.share:
+      case _ShareAction.shareConcise:
+      case _ShareAction.shareRaw:
         try {
-          await shareText(buildLogPlainText(entry));
+          await shareText(logText);
         } catch (_) {
           // Fallback to clipboard when the platform has no share sheet.
-          await Clipboard.setData(
-            ClipboardData(text: buildLogPlainText(entry)),
-          );
+          await Clipboard.setData(ClipboardData(text: logText));
           messenger.showSnackBar(
             const SnackBar(
               content: Text('Share unavailable — copied to clipboard'),

--- a/lib/src/ui/dashboard/tabs/console/log_detail_view.dart
+++ b/lib/src/ui/dashboard/tabs/console/log_detail_view.dart
@@ -81,6 +81,8 @@ class _LogDetailViewState extends State<LogDetailView> {
             'Timestamp',
             widget.entry.timestamp.toIso8601String(),
           ),
+          if (widget.entry.activeRoute != null)
+            DetailKeyValueRow.text('Active Route', widget.entry.activeRoute!),
         ],
       ),
     );

--- a/lib/src/ui/widgets/detail_section.dart
+++ b/lib/src/ui/widgets/detail_section.dart
@@ -4,10 +4,16 @@ import '../theme/theme.dart';
 
 /// A standard card container for sections in detail views.
 class DetailSection extends StatelessWidget {
-  const DetailSection({required this.title, required this.child, super.key});
+  const DetailSection({
+    required this.title,
+    required this.child,
+    this.trailing,
+    super.key,
+  });
 
   final String title;
   final Widget child;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +24,20 @@ class DetailSection extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(title, style: Theme.of(context).textTheme.titleSmall),
+            if (trailing != null)
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                  ),
+                  trailing!,
+                ],
+              )
+            else
+              Text(title, style: Theme.of(context).textTheme.titleSmall),
             const SizedBox(height: ThemeSize.space8),
             child,
           ],

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -39,7 +39,7 @@ String buildLogOneLiner(LogEntry entry) {
 
 /// Builds a full plain-text export of [entry] covering general info,
 /// stack trace, and data sections.
-String buildLogPlainText(LogEntry entry) {
+String buildLogPlainText(LogEntry entry, {bool isConcise = true}) {
   final b = StringBuffer()
     ..writeln('=== General ===')
     ..writeln('Message: ${entry.message}')
@@ -49,7 +49,7 @@ String buildLogPlainText(LogEntry entry) {
   b.writeln('\n=== Stack Trace ===');
   final stackTrace = entry.stackTrace;
   if (stackTrace != null && stackTrace.isNotEmpty) {
-    b.writeln(stackTrace);
+    b.writeln(isConcise ? normalizeStackTrace(stackTrace) : stackTrace);
   } else {
     b.writeln('(none)');
   }
@@ -63,4 +63,35 @@ String buildLogPlainText(LogEntry entry) {
   }
 
   return b.toString().trimRight();
+}
+
+/// Normalizes a stack trace string by collapsing consecutive framework-internal frames
+/// and converting asynchronous suspension gaps into a readable format.
+String normalizeStackTrace(String rawStack) {
+  final lines = rawStack.split('\n');
+  final result = <String>[];
+  int collapsedCount = 0;
+
+  void flushCollapsed() {
+    if (collapsedCount > 0) {
+      result.add('  [... $collapsedCount frames of framework internals]');
+      collapsedCount = 0;
+    }
+  }
+
+  for (final line in lines) {
+    if (line.trim().isEmpty) continue;
+
+    if (line.contains('<asynchronous suspension>')) {
+      flushCollapsed();
+      result.add('  <-- async gap -->');
+    } else if (line.contains('package:flutter/') || line.contains('dart:')) {
+      collapsedCount++;
+    } else {
+      flushCollapsed();
+      result.add(line);
+    }
+  }
+  flushCollapsed();
+  return result.join('\n');
 }

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -26,10 +26,18 @@ String buildLogOneLiner(LogEntry entry) {
 
   final stackTrace = entry.stackTrace;
   if (stackTrace != null) {
-    final frames = stackTrace
+    // 找出最相關的 App Callstack (過濾掉 framework 與 async gap)
+    final appFrames = stackTrace
         .split('\n')
         .where((l) => l.trim().isNotEmpty)
-        .take(3);
+        .where((l) =>
+            !l.contains('package:flutter/') &&
+            !l.contains('dart:') &&
+            !l.contains('<asynchronous suspension>'));
+            
+    // 若全都是 framework (雖然機率極低)，則 fallback 拿前 3 行；否則拿前 3 行 App Frames
+    final frames = (appFrames.isNotEmpty ? appFrames : stackTrace.split('\n').where((l) => l.trim().isNotEmpty)).take(3);
+
     for (final frame in frames) {
       b.write('\n  │ ${frame.trim()}');
     }

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -20,8 +20,10 @@ String buildLogOneLiner(LogEntry entry) {
   // carriage return as a line ending too, so leaving it behind would let an
   // embedded ``` fence back onto line-start.
   final message = entry.message.replaceAll(RegExp(r'\r\n?|\n'), ' ');
+  final activeRouteStr =
+      entry.activeRoute != null ? ' (Active Route: ${entry.activeRoute})' : '';
   final b = StringBuffer(
-    '[${entry.displayTime}] [LOG/${entry.level.name}] $message',
+    '[${entry.displayTime}] [LOG/${entry.level.name}] $message$activeRouteStr',
   );
 
   final stackTrace = entry.stackTrace;
@@ -53,6 +55,10 @@ String buildLogPlainText(LogEntry entry, {bool isConcise = true}) {
     ..writeln('Message: ${entry.message}')
     ..writeln('Level: ${entry.level.name}')
     ..writeln('Timestamp: ${entry.timestamp.toIso8601String()}');
+
+  if (entry.activeRoute != null) {
+    b.writeln('Active Route: ${entry.activeRoute}');
+  }
 
   b.writeln('\n=== Stack Trace ===');
   final stackTrace = entry.stackTrace;

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -84,13 +84,19 @@ String buildLogPlainText(LogEntry entry, {bool isConcise = true}) {
 String normalizeStackTrace(String rawStack) {
   final lines = rawStack.split('\n');
   final result = <String>[];
-  int collapsedCount = 0;
+  final collapsedLines = <String>[];
 
   void flushCollapsed() {
-    if (collapsedCount > 0) {
-      result.add('  [... $collapsedCount frames of framework internals]');
-      collapsedCount = 0;
+    if (collapsedLines.isEmpty) return;
+
+    if (collapsedLines.length <= 2) {
+      result.addAll(collapsedLines);
+    } else {
+      result.add(collapsedLines.first);
+      result.add('  [... ${collapsedLines.length - 2} frames of framework internals]');
+      result.add(collapsedLines.last);
     }
+    collapsedLines.clear();
   }
 
   for (final line in lines) {
@@ -100,7 +106,7 @@ String normalizeStackTrace(String rawStack) {
       flushCollapsed();
       result.add('  <-- async gap -->');
     } else if (line.contains(RegExp(r'[\s\(]package:flutter/')) || line.contains(RegExp(r'[\s\(]dart:'))) {
-      collapsedCount++;
+      collapsedLines.add(line);
     } else {
       flushCollapsed();
       result.add(line);

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -33,8 +33,8 @@ String buildLogOneLiner(LogEntry entry) {
         .split('\n')
         .where((l) => l.trim().isNotEmpty)
         .where((l) =>
-            !l.contains('package:flutter/') &&
-            !l.contains('dart:') &&
+            !l.contains(RegExp(r'[\s\(]package:flutter/')) &&
+            !l.contains(RegExp(r'[\s\(]dart:')) &&
             !l.contains('<asynchronous suspension>'));
             
     // 若全都是 framework (雖然機率極低)，則 fallback 拿前 3 行；否則拿前 3 行 App Frames
@@ -99,7 +99,7 @@ String normalizeStackTrace(String rawStack) {
     if (line.contains('<asynchronous suspension>')) {
       flushCollapsed();
       result.add('  <-- async gap -->');
-    } else if (line.contains('package:flutter/') || line.contains('dart:')) {
+    } else if (line.contains(RegExp(r'[\s\(]package:flutter/')) || line.contains(RegExp(r'[\s\(]dart:'))) {
       collapsedCount++;
     } else {
       flushCollapsed();

--- a/lib/src/utils/log_formatters.dart
+++ b/lib/src/utils/log_formatters.dart
@@ -20,8 +20,9 @@ String buildLogOneLiner(LogEntry entry) {
   // carriage return as a line ending too, so leaving it behind would let an
   // embedded ``` fence back onto line-start.
   final message = entry.message.replaceAll(RegExp(r'\r\n?|\n'), ' ');
-  final activeRouteStr =
-      entry.activeRoute != null ? ' (Active Route: ${entry.activeRoute})' : '';
+  final activeRouteStr = entry.activeRoute != null
+      ? ' (Active Route: ${entry.activeRoute})'
+      : '';
   final b = StringBuffer(
     '[${entry.displayTime}] [LOG/${entry.level.name}] $message$activeRouteStr',
   );
@@ -32,13 +33,19 @@ String buildLogOneLiner(LogEntry entry) {
     final appFrames = stackTrace
         .split('\n')
         .where((l) => l.trim().isNotEmpty)
-        .where((l) =>
-            !l.contains(RegExp(r'[\s\(]package:flutter/')) &&
-            !l.contains(RegExp(r'[\s\(]dart:')) &&
-            !l.contains('<asynchronous suspension>'));
-            
+        .where(
+          (l) =>
+              !l.contains(RegExp(r'[\s\(]package:flutter/')) &&
+              !l.contains(RegExp(r'[\s\(]dart:')) &&
+              !l.contains('<asynchronous suspension>'),
+        );
+
     // 若全都是 framework (雖然機率極低)，則 fallback 拿前 3 行；否則拿前 3 行 App Frames
-    final frames = (appFrames.isNotEmpty ? appFrames : stackTrace.split('\n').where((l) => l.trim().isNotEmpty)).take(3);
+    final frames =
+        (appFrames.isNotEmpty
+                ? appFrames
+                : stackTrace.split('\n').where((l) => l.trim().isNotEmpty))
+            .take(3);
 
     for (final frame in frames) {
       b.write('\n  │ ${frame.trim()}');
@@ -49,6 +56,10 @@ String buildLogOneLiner(LogEntry entry) {
 
 /// Builds a full plain-text export of [entry] covering general info,
 /// stack trace, and data sections.
+///
+/// When [isConcise] is `true` (default), the stack trace is passed through
+/// [normalizeStackTrace] to collapse framework internals while preserving
+/// boundary frames. When `false`, the raw stack trace is included as-is.
 String buildLogPlainText(LogEntry entry, {bool isConcise = true}) {
   final b = StringBuffer()
     ..writeln('=== General ===')
@@ -93,7 +104,9 @@ String normalizeStackTrace(String rawStack) {
       result.addAll(collapsedLines);
     } else {
       result.add(collapsedLines.first);
-      result.add('  [... ${collapsedLines.length - 2} frames of framework internals]');
+      result.add(
+        '  [... ${collapsedLines.length - 2} frames of framework internals]',
+      );
       result.add(collapsedLines.last);
     }
     collapsedLines.clear();
@@ -105,7 +118,8 @@ String normalizeStackTrace(String rawStack) {
     if (line.contains('<asynchronous suspension>')) {
       flushCollapsed();
       result.add('  <-- async gap -->');
-    } else if (line.contains(RegExp(r'[\s\(]package:flutter/')) || line.contains(RegExp(r'[\s\(]dart:'))) {
+    } else if (line.contains(RegExp(r'[\s\(]package:flutter/')) ||
+        line.contains(RegExp(r'[\s\(]dart:'))) {
       collapsedLines.add(line);
     } else {
       flushCollapsed();

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,20 @@
+Resolves #148
+
+## 目的 (Purpose)
+解決 Flutter 拋出非同步例外時，StackTrace 充斥內部框架呼叫且被 `<asynchronous suspension>` 分割，導致排查困難的問題。
+
+## 變更摘要 (Changes)
+1. **新增 `normalizeStackTrace` 函式** (`log_formatters.dart`)：
+   - 自動將連續的 `package:flutter/*` 或 `dart:*` 呼叫折疊。
+   - 將 `<asynchronous suspension>` 轉換為清晰的 `<-- async gap -->` 標示。
+2. **擴充 `DetailSection`** (`detail_section.dart`)：
+   - 支援傳入 `trailing` 參數，以便在標題列放入擴充操作按鈕。
+3. **升級 `LogDetailView`** (`log_detail_view.dart`)：
+   - 轉為 `StatefulWidget` 並加入「精簡 / 原始」視圖的切換按鈕。
+   - 擴充右上角的 Share 選單，提供複製與分享的獨立「精簡」與「原始」選項。
+4. **修正測試** (`log_detail_view_test.dart`)：
+   - 調整測試斷言以匹配新的按鈕文案 (Copy concise, Copy raw 等)。
+
+## 安全性與邊界 (Safety)
+- 底層 `LogEntry.stackTrace` 維持不變 (Immutable)。
+- 未引入額外的第三方套件，保持模組輕量化。

--- a/test/ui/tabs/log_detail_view_test.dart
+++ b/test/ui/tabs/log_detail_view_test.dart
@@ -65,7 +65,7 @@ void main() {
       expect(find.text('(no data)'), findsOneWidget);
     });
 
-    testWidgets('Copy as text writes buildLogPlainText to clipboard', (
+    testWidgets('Copy concise writes buildLogPlainText to clipboard', (
       tester,
     ) async {
       String? clipboardText;
@@ -85,7 +85,7 @@ void main() {
 
       await tester.tap(find.byIcon(Icons.share));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Copy as text'));
+      await tester.tap(find.text('Copy concise'));
       await tester.pumpAndSettle();
 
       expect(clipboardText, isNotNull);
@@ -95,7 +95,7 @@ void main() {
       expect(clipboardText, contains('=== Data ==='));
     });
 
-    testWidgets('share menu contains Copy as text and Share items', (
+    testWidgets('share menu contains Copy concise and Share items', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -105,8 +105,8 @@ void main() {
       await tester.tap(find.byIcon(Icons.share));
       await tester.pumpAndSettle();
 
-      expect(find.text('Copy as text'), findsOneWidget);
-      expect(find.text('Share…'), findsOneWidget);
+      expect(find.text('Copy concise'), findsOneWidget);
+      expect(find.text('Share concise…'), findsOneWidget);
       // No cURL option
       expect(find.text('Copy as cURL'), findsNothing);
     });

--- a/test/utils/normalize_stack_trace_test.dart
+++ b/test/utils/normalize_stack_trace_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_inspector_kit/src/utils/log_formatters.dart';
+
+void main() {
+  group('normalizeStackTrace', () {
+    test('collapses framework internals but keeps boundaries', () {
+      final stackTrace = '''
+#0      MyWidget.build (package:my_app/main.dart:10:12)
+#1      StatelessElement.build (package:flutter/src/widgets/framework.dart:4701:27)
+#2      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4630:15)
+#3      Element.rebuild (package:flutter/src/widgets/framework.dart:4343:5)
+#4      BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2536:19)
+#5      WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:883:20)
+#6      RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:363:5)
+#7      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1145:15)
+<asynchronous suspension>
+#8      App.main (package:my_app/main.dart:5:2)
+''';
+
+      final result = normalizeStackTrace(stackTrace);
+
+      expect(result, contains('MyWidget.build'));
+      expect(result, contains('StatelessElement.build'));
+      expect(result, contains('[... 5 frames of framework internals]'));
+      expect(result, contains('SchedulerBinding._invokeFrameCallback'));
+      expect(result, contains('<-- async gap -->'));
+      expect(result, contains('App.main'));
+    });
+    
+    test('does not collapse when there are 2 or less framework internals', () {
+      final stackTrace = '''
+#0      MyWidget.build (package:my_app/main.dart:10:12)
+#1      StatelessElement.build (package:flutter/src/widgets/framework.dart:4701:27)
+#2      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4630:15)
+#3      App.main (package:my_app/main.dart:5:2)
+''';
+
+      final result = normalizeStackTrace(stackTrace);
+
+      expect(result, contains('MyWidget.build'));
+      expect(result, contains('StatelessElement.build'));
+      expect(result, contains('ComponentElement.performRebuild'));
+      expect(result, isNot(contains('[...')));
+      expect(result, contains('App.main'));
+    });
+  });
+}


### PR DESCRIPTION
Resolves #148

## 目的 (Purpose)
解決 Flutter 拋出非同步例外時，StackTrace 充斥內部框架呼叫且被 `<asynchronous suspension>` 分割，導致排查困難的問題。

## 變更摘要 (Changes)
1. **新增 `normalizeStackTrace` 函式** (`log_formatters.dart`)：
   - 自動將連續的 `package:flutter/*` 或 `dart:*` 呼叫折疊。
   - 將 `<asynchronous suspension>` 轉換為清晰的 `<-- async gap -->` 標示。
2. **擴充 `DetailSection`** (`detail_section.dart`)：
   - 支援傳入 `trailing` 參數，以便在標題列放入擴充操作按鈕。
3. **升級 `LogDetailView`** (`log_detail_view.dart`)：
   - 轉為 `StatefulWidget` 並加入「精簡 / 原始」視圖的切換按鈕。
   - 擴充右上角的 Share 選單，提供複製與分享的獨立「精簡」與「原始」選項。
4. **修正測試** (`log_detail_view_test.dart`)：
   - 調整測試斷言以匹配新的按鈕文案 (Copy concise, Copy raw 等)。

## 安全性與邊界 (Safety)
- 底層 `LogEntry.stackTrace` 維持不變 (Immutable)。
- 未引入額外的第三方套件，保持模組輕量化。

## Sourcery 摘要

通过让异步堆栈跟踪更易于阅读，同时保留对其原始形式的访问，改进日志检查功能。

新功能：
- 添加简洁的堆栈跟踪规范化功能，折叠框架调用栈，并清晰标记异步间隔。
- 在日志详情视图中提供查看、复制和分享简洁版及原始堆栈跟踪的选项。

增强功能：
- 允许详情分区显示尾部标题控件。
- 保持原始日志条目的堆栈跟踪不变，并按需格式化导出和显示的内容。

测试：
- 更新日志详情视图测试，以覆盖简洁版和原始版分享菜单标签。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过让异步堆栈跟踪更易于阅读，同时保留对其原始形式的访问，改进日志检查功能。

新功能：
- 添加简洁的堆栈跟踪规范化功能，将连续的 Flutter/Dart 框架堆栈帧折叠，并标记异步间隔。
- 在日志详情视图中提供简洁/原始堆栈跟踪的查看、复制和分享选项。

增强功能：
- 为详情区段标题扩展可选的尾部控件。
- 保留原始堆栈跟踪，仅对显示和导出的简洁内容应用规范化。

文档：
- 记录堆栈跟踪规范化问题、需求、范围和实施计划。

测试：
- 更新日志详情视图测试，覆盖简洁堆栈跟踪的复制和分享操作。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过让异步堆栈跟踪更易于阅读，同时保留其原始形式，改进日志检查功能。

新功能：
- 添加简洁的堆栈跟踪规范化处理，折叠 Flutter/Dart 框架堆栈帧并标记异步间隙。
- 在日志详情视图中提供查看、复制和分享简洁版及原始堆栈跟踪的选项。

增强功能：
- 允许详情部分标题渲染可选的尾部控件，同时保留原始日志条目的堆栈跟踪。

文档：
- 记录堆栈跟踪规范化问题、需求、范围和实施计划。

测试：
- 更新日志详情视图测试，涵盖简洁堆栈跟踪的复制和分享操作。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过让异步堆栈跟踪更易于阅读，同时保留原始详细信息并添加活动路由上下文，改进日志诊断功能。

新功能：
- 添加简洁的堆栈跟踪规范化功能，折叠 Flutter/Dart 框架堆栈帧并标记异步间隙。
- 在日志详情视图中提供简洁/原始堆栈跟踪的查看、复制和分享选项。
- 记录并显示与每条日志条目关联的活动路由。

增强功能：
- 为详情部分扩展可选的尾部标题控件。
- 保留原始堆栈跟踪，仅在展示和导出时应用规范化。

文档：
- 记录堆栈跟踪规范化的要求、范围和实现计划。

测试：
- 更新日志详情视图测试，覆盖简洁堆栈跟踪的复制和分享操作。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过让异步堆栈跟踪更易于阅读，同时保留原始详细信息和路由上下文，改进日志诊断功能。

新功能：
- 添加简洁的堆栈跟踪规范化处理，折叠 Flutter/Dart 框架堆栈帧，并清晰标记异步间隙。
- 在日志详情视图中提供简洁和原始堆栈跟踪的查看、复制及分享选项。
- 捕获并显示与每条日志条目关联的当前路由。

增强功能：
- 允许详情部分的标题渲染可选的尾部控件，同时保留原始堆栈跟踪数据。

文档：
- 记录堆栈跟踪规范化问题、需求、范围和实现计划。

测试：
- 更新日志详情视图测试，覆盖简洁堆栈跟踪的复制和分享操作。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过让异步堆栈跟踪更易于阅读，同时保留原始详细信息和路由上下文，改进日志诊断功能。

新功能：
- 添加简洁的堆栈跟踪规范化功能，将连续的 Flutter 和 Dart 框架帧折叠，并清晰标记异步间隔。
- 在日志详情视图中提供简洁版和原始版堆栈跟踪的查看、复制和分享选项。
- 捕获并显示与每条日志条目关联的当前路由。

增强功能：
- 为详情分区扩展可选的尾部标题控件，同时保留原始堆栈跟踪数据。

构建：
- 使用 Flutter migrator 兼容性标志更新示例 Android Gradle 配置。

文档：
- 记录堆栈跟踪规范化问题、需求、范围和实施计划。

测试：
- 添加规范化相关测试覆盖，并更新日志详情视图测试，以覆盖简洁版和原始版分享操作。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过让异步堆栈跟踪更易于阅读，同时保留原始详细信息和路由上下文，改进日志诊断。

新功能：
- 添加简洁的堆栈跟踪规范化功能，将连续的 Flutter/Dart 框架堆栈帧折叠，并标记异步间隙。
- 在日志详情视图中提供简洁和原始堆栈跟踪的查看、复制与分享选项。
- 捕获并显示与每条日志条目关联的当前路由。

增强功能：
- 为详情部分标题扩展可选的尾部控件。
- 保留原始堆栈跟踪，仅在展示和导出时应用简洁格式。

构建：
- 更新示例 Android Gradle 属性，以兼容 Flutter migrator。

文档：
- 记录堆栈跟踪规范化问题、需求、范围和实现计划。

测试：
- 添加规范化覆盖测试，并更新日志详情视图测试，以验证简洁堆栈跟踪的复制和分享操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve log diagnostics by making asynchronous stack traces easier to read while preserving raw details and route context.

New Features:
- Add concise stack-trace normalization that folds consecutive Flutter/Dart framework frames and marks asynchronous gaps.
- Provide concise and raw stack-trace viewing, copying, and sharing options in the log detail view.
- Capture and display the active route associated with each log entry.

Enhancements:
- Extend detail section headers with optional trailing controls.
- Preserve raw stack traces while applying concise formatting only for presentation and exports.

Build:
- Update the example Android Gradle properties for Flutter migrator compatibility.

Documentation:
- Document the stack-trace normalization problem, requirements, scope, and implementation plan.

Tests:
- Add normalization coverage and update log detail view tests for concise stack-trace copy and share actions.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 日志详情页支持以简洁或原始格式复制、分享日志。
  - 堆栈跟踪默认折叠框架噪声，并支持切换查看原始内容。
  - 日志摘要优先展示应用相关堆栈信息，提升可读性。
  - 日志详情中新增活动路由信息。
  - 分享失败时自动回退为复制到剪贴板。
  - 详情区标题支持展示右侧操作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->