### PR TITLE
feat(lifecycle): record memory pressure on the merged timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* **Memory pressure lands on the timeline**: When `captureLifecycleEvents` is enabled, an OS memory-pressure warning is now recorded as a `warning`-level Console entry (`Memory pressure · CheckoutPage`). It is the only OOM/LMK precursor Dart can observe — the real RSS figure needs a platform channel — and as a timestamped event it interleaves with the network, navigation and database entries that came before it, so "the app just disappeared" becomes "pressure began right after that 8 MB image decode". It reuses the existing lifecycle flag rather than adding its own, because both are callbacks on a single `WidgetsBindingObserver` sharing one attach/detach lifecycle. Android reports it via `onTrimMemory`, iOS via `didReceiveMemoryWarning`; Web effectively never fires it.
+
 ## 2.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -506,6 +506,18 @@ The page is a best-effort replay of the navigation history; when it cannot be re
 
 > The observer is registered with `WidgetsBinding.instance.addObserver`, which appends to a list — your app's own `WidgetsBindingObserver`s keep receiving their callbacks untouched.
 
+The same flag also records **memory pressure**, as a `warning`-level entry:
+
+```text
+Memory pressure · CheckoutPage
+```
+
+This is the only OOM/LMK precursor visible from Dart — the actual RSS figure needs a platform channel — and it lands on the merged Timeline like any other event, so the pressure can be read against the network responses, route pushes and database queries that preceded it. That is the question Play Console cannot answer: not *how bad* the memory usage is, but *what happened right before it*. It is a `warning` rather than an `info` precisely so it surfaces through the Console's error/warning filters instead of sinking into the info stream.
+
+It shares `captureLifecycleEvents` rather than having its own flag because both are callbacks on the same `WidgetsBindingObserver`, with one attach/detach lifecycle.
+
+> **Platform coverage**: Android delivers it via `onTrimMemory`, iOS via `didReceiveMemoryWarning`. On Web it effectively never fires — no entry appearing there is the platform's behavior, not a fault in the package.
+
 ### Track navigation
 
 Nothing to do here — routes are tracked automatically once you register `inspector.navigatorObserver` in `navigatorObservers` (see [Initialize](#initialize)). Pushes, pops, and replacements all show up in the Navigator tab.

--- a/docs/features/2026-09-03-memory-pressure-marker.md
+++ b/docs/features/2026-09-03-memory-pressure-marker.md
@@ -74,7 +74,7 @@ Google Play 2026 Q3「Elevating app quality」把 Memory usage（RSS+Swap / Bitm
 |:---:|:---|:---|
 | 1 | `captureLifecycleEvents: true` 時，記憶體壓力事件產生一筆 log | 單元測試：`WidgetsBinding.instance.handleMemoryPressure()` → 斷言 log 一筆 |
 | 2 | 該 log 的 level 為 `LogLevel.warning`（非 `info`） | 單元測試斷言 level |
-| 3 | 訊息含可辨識文字，並在有 top page 時附上 ` · <page>` 尾巴 | 單元測試斷言訊息內容 |
+| 3 | 訊息含可辨識文字，並在有 top page 時附上「· page」尾巴 | 單元測試斷言訊息內容 |
 | 4 | `topPageLabel` 回傳 null／空字串時，訊息不含尾巴、不編造 | 單元測試（對齊既有 `didChangeAppLifecycleState` 的同型 case） |
 | 5 | 未 attach 時不產生 log | 單元測試 |
 | 6 | `detach()` 後不再產生 log | 單元測試 |

--- a/docs/features/2026-09-03-memory-pressure-marker.md
+++ b/docs/features/2026-09-03-memory-pressure-marker.md
@@ -1,0 +1,143 @@
+# 功能規格：記憶體壓力事件（§P21）
+
+- **日期**：2026-09-03
+- **來源**：`docs/brainstorm/2026-09-01-features-brainstorm.md` §P21（第七部分 · Google Play 品質要求 × 執行時期排查）
+- **Tier**：Tier 4 打磨 · 第七部分優先序建議第 1 順位（暖身首選）
+- **Effort**：trivial ｜ **排查價值**：⭐⭐⭐⭐
+
+---
+
+## 1. 使用者故事
+
+> 作為一位排查「App 用著用著就被系統殺掉」的開發者／QA，
+> 我希望**記憶體壓力事件出現在混合時間軸上**，
+> 這樣我就能看出壓力是「在載入那張大圖之後」「在那支回傳巨大 JSON 的 API 之後」才密集出現，
+> 而不是只知道 App 消失了、卻無從得知前因。
+
+### 為什麼這件事現在做
+
+Google Play 2026 Q3「Elevating app quality」把 Memory usage（RSS+Swap / Bitmap）列為 **Feb 2027 強制**門檻。
+但真正的 RSS 數值需要 platform channel，粗糙且跨平台不一致——
+**`didHaveMemoryPressure()` 是 Dart 層唯一拿得到的 OOM/LMK 前導信號**，
+且它天然就是「帶時間戳的離散事件」，正好是本套件混合時間軸要的因果原料。
+
+### 為什麼它不會重蹈 §P20 的覆轍
+
+§P20（掉幀維度）目前卡在「待裁決」，死因是 debug build 效能失真導致誤報。
+**本項不受該問題影響**——記憶體壓力是 **OS 主動送來的事件**，
+不是套件自己拿 duration 跟門檻比對出來的判定。沒有門檻，就沒有誤判空間。
+
+---
+
+## 2. 範圍邊界
+
+### ✅ 做
+
+- `LifecycleHandler` 多覆寫一個 `didHaveMemoryPressure()` callback
+- 事件寫入既有 log 維度，`LogLevel.warning`
+- 沿用既有 `topPageLabel` 尾巴（記錄壓力發生在哪一頁）
+- README 補充平台覆蓋度說明
+- 對應單元測試
+
+### ❌ 不做（明確排除）
+
+| 排除項 | 理由 |
+|:---|:---|
+| 新增 `captureMemoryPressure` 旗標 | **已裁決併入既有 `captureLifecycleEvents`**（見 §3） |
+| 新增 `MemoryEntry` / `MemoryInspector` / `RingBuffer` | 事件只有一個時間點，無結構化欄位可存；新增第五個 `TimelineSource` 是 Anti-Feature #6 |
+| 讀取實際 RSS / 記憶體用量數值 | 需 platform channel，粗糙且跨平台不一致（文件已劃為 app 內不可觀測） |
+| 記憶體洩漏偵測 / profiling | Anti-Feature #1 明確否決，交由官方 DevTools |
+| 事前加節流（throttle） | 尚未實測觸發頻率，先加是解決想像中的問題。實測到洗版才接既有 `AlertThrottler` |
+
+---
+
+## 3. 已裁決的設計決策
+
+**公開 API：併入既有 `captureLifecycleEvents`，不新增旗標。**（2026-09-03 使用者拍板）
+
+理由是資料結構層面的——兩者是**同一個 `WidgetsBindingObserver` 的兩個 callback**，
+共用同一套 `attach()` / `detach()` / `_attached` 生命週期管理。
+
+獨立旗標會製造一個真正的特殊情況：**旗標與 observer 不再一對一**，
+`attach()` 得判斷「至少一個為真」、`detach()` 得判斷「兩個都關」、
+每個 callback 內再各自檢查一次自己的旗標——為了一個 bool 長出四處判斷。
+
+**已知代價（可接受）**：既有使用者開啟 `captureLifecycleEvents` 後會**多收到**記憶體壓力 log。
+這不是破壞 userspace——無 API 消失、無簽章變更、無行為反轉，
+只是同一維度多一種事件，性質等同 §P13 當初為生命週期訊息加上 top-page 尾巴。
+
+---
+
+## 4. 驗收條件
+
+| # | 條件 | 驗證方式 |
+|:---:|:---|:---|
+| 1 | `captureLifecycleEvents: true` 時，記憶體壓力事件產生一筆 log | 單元測試：`WidgetsBinding.instance.handleMemoryPressure()` → 斷言 log 一筆 |
+| 2 | 該 log 的 level 為 `LogLevel.warning`（非 `info`） | 單元測試斷言 level |
+| 3 | 訊息含可辨識文字，並在有 top page 時附上 ` · <page>` 尾巴 | 單元測試斷言訊息內容 |
+| 4 | `topPageLabel` 回傳 null／空字串時，訊息不含尾巴、不編造 | 單元測試（對齊既有 `didChangeAppLifecycleState` 的同型 case） |
+| 5 | 未 attach 時不產生 log | 單元測試 |
+| 6 | `detach()` 後不再產生 log | 單元測試 |
+| 7 | `topPageLabel` 拋錯時不向宿主傳播、不產生半套 log | 單元測試 |
+| 8 | 事件出現在 ConsoleTab，並被既有 warning/error 過濾與高亮機制正確處理 | 既有機制認 `LogLevel`，隨測試通過即成立 |
+| 9 | `flutter test` 全綠（既有 554 tests + 新增） | 指令執行 |
+| 10 | `flutter analyze lib/ test/` 不超出既有 7 個 info 基準 | 指令執行 |
+
+---
+
+## 5. 實查發現（影響實作，非臆測）
+
+以下皆為本次規格階段實地查證，非文件轉述：
+
+1. **重用前提成立**：`lifecycle_handler.dart:11` 確為 `class LifecycleHandler with WidgetsBindingObserver`，
+   `:49` 僅覆寫 `didChangeAppLifecycleState` 一個 callback。多覆寫一個即可。
+
+2. **接線零改動**：`flutter_inspector.dart:237` 建構 `LifecycleHandler(onLog: log, topPageLabel: _currentTopPageLabel)`、
+   `:241` 依旗標 `attach()`、`:295` `detach()` 皆已就位。**本項不需改動接線**，
+   僅需更新 `captureLifecycleEvents` 的 doc comment 說明它現在也涵蓋記憶體壓力。
+
+3. **`activeRoute` 已自動帶上**：`FlutterInspector.log` 於 `:311` 自行呼叫 `_currentTopPageLabel()` 填入 `activeRoute` 欄位。
+   `topPageLabel` 尾巴是**訊息文字**的一部分（給人讀），與 `activeRoute` 欄位（給機器用）兩者並存，對齊既有生命週期事件的作法。
+
+4. **🔴 錯誤傳播路徑與生命週期不同（本次新發現，修正先前假設）**：
+   `binding.dart:1372` 的 `handleMemoryPressure()` **每個 observer 各自包在 try-catch 內**
+   （`:1376-1387`，捕捉後走 `FlutterError.reportError`），
+   而 `didChangeAppLifecycleState` 的廣播迴圈**沒有** per-observer try-catch。
+
+   **影響**：既有測試 `guard: onLog throws does not propagate` 依賴「例外會中斷廣播迴圈」來證明 guard 存在
+   （測試檔 `:133-135` 有註解特別說明註冊順序的用意）。
+   **該手法在記憶體壓力路徑上無效**——即使不加 try-catch，binding 也會接住，後續 observer 照樣被呼叫。
+
+   **結論**：本項**仍要加自己的 try-catch**（理由是不讓 host 的 `topPageLabel` 拋錯汙染 `FlutterError`，
+   且與既有 callback 保持一致寫法），但**測試不可照抄 `_HostObserver` 那套驗法**，
+   應改為直接斷言「拋錯時不產生 log 且不拋出」。
+
+5. **測試觸發點**：`WidgetsBinding.instance.handleMemoryPressure()` 為公開方法，可直接於測試呼叫，
+   不需要 platform channel mock。
+
+6. **平台覆蓋度**（README 需說明，避免使用者誤判為套件故障）：
+   Android 經 `onTrimMemory` 轉發、iOS 經 `didReceiveMemoryWarning`、**Web 實質不會觸發**。
+
+---
+
+## 6. 影響範圍
+
+| 檔案 | 動作 |
+|:---|:---|
+| `lib/src/core/lifecycle_handler.dart` | 新增 `didHaveMemoryPressure()` 覆寫（約 12 行） |
+| `lib/src/core/flutter_inspector.dart` | **僅** doc comment 補述（`captureLifecycleEvents` 涵蓋範圍） |
+| `test/core/lifecycle_handler_test.dart` | 新增測試 case（對應驗收條件 1–7） |
+| `README.md` | 平台覆蓋度說明 |
+| `CHANGELOG.md` | 版本條目 |
+
+**不動**：`inspector_registry.dart`、`ring_buffer.dart`、任何 UI 檔、任何 model 檔。
+
+---
+
+## 7. 風險
+
+| 風險 | 等級 | 處置 |
+|:---|:---:|:---|
+| 觸發頻率過高洗版時間軸 | 低 | 不預先節流。實測到才接既有 `AlertThrottler`（已支援建構式注入） |
+| 既有使用者多收到 log | 極低 | 已於 §3 評估為非破壞性，同維度多一種事件 |
+| 誤報 | 無 | OS 主動送出的事件，無門檻判定，不存在 §P20 的 debug build 誤報問題 |

--- a/docs/features/2026-09-03-memory-pressure-marker.md
+++ b/docs/features/2026-09-03-memory-pressure-marker.md
@@ -99,18 +99,24 @@ Google Play 2026 Q3「Elevating app quality」把 Memory usage（RSS+Swap / Bitm
 3. **`activeRoute` 已自動帶上**：`FlutterInspector.log` 於 `:311` 自行呼叫 `_currentTopPageLabel()` 填入 `activeRoute` 欄位。
    `topPageLabel` 尾巴是**訊息文字**的一部分（給人讀），與 `activeRoute` 欄位（給機器用）兩者並存，對齊既有生命週期事件的作法。
 
-4. **🔴 錯誤傳播路徑與生命週期不同（本次新發現，修正先前假設）**：
-   `binding.dart:1372` 的 `handleMemoryPressure()` **每個 observer 各自包在 try-catch 內**
-   （`:1376-1387`，捕捉後走 `FlutterError.reportError`），
-   而 `didChangeAppLifecycleState` 的廣播迴圈**沒有** per-observer try-catch。
+4. **🔴 錯誤傳播行為隨 SDK 版本而異（2026-09-03 PR review 後修正，見下方勘誤）**：
+   `handleMemoryPressure()` 的 per-observer try-catch 是 **Flutter 3.44.0 才加入的**。
+   本套件 `pubspec.yaml` 宣告 `flutter: ">=3.10.0"`，
+   **在 3.10.0 ～ 3.41.x（即絕大多數支援版本）該迴圈沒有 per-observer try-catch**，
+   與 `didChangeAppLifecycleState` 完全同型——例外逃逸會中斷廣播，
+   排在本 handler 之後註冊的 observer 全部收不到。
 
-   **影響**：既有測試 `guard: onLog throws does not propagate` 依賴「例外會中斷廣播迴圈」來證明 guard 存在
-   （測試檔 `:133-135` 有註解特別說明註冊順序的用意）。
-   **該手法在記憶體壓力路徑上無效**——即使不加 try-catch，binding 也會接住，後續 observer 照樣被呼叫。
+   **結論**：本項的 try-catch **是真正的保護**（不只是避免汙染 `FlutterError`），
+   且測試**應該**沿用既有 `_HostObserver` 手法——那才是在 SDK 下限上唯一有鑑別力的斷言。
+   同時保留 `FlutterError` 斷言，因為在 3.44.0+ 上 `hostCalled` 會恆為 true、失去鑑別力。
+   兩個斷言並存，整個支援範圍內才都驗得到 guard。
 
-   **結論**：本項**仍要加自己的 try-catch**（理由是不讓 host 的 `topPageLabel` 拋錯汙染 `FlutterError`，
-   且與既有 callback 保持一致寫法），但**測試不可照抄 `_HostObserver` 那套驗法**，
-   應改為直接斷言「拋錯時不產生 log 且不拋出」。
+   > **勘誤**：本節原記載「`handleMemoryPressure()` 每個 observer 各自包 try-catch，
+   > 故 `_HostObserver` 手法無效」。該結論**只在 Flutter 3.44.0+ 成立**，
+   > 是我只查了本機 SDK（3.44.1）就下的定論，未對照 `pubspec.yaml` 宣告的版本下限。
+   > 由 PR #155 的 CodeRabbit review 指出，經逐版查證 upstream `binding.dart` 確認：
+   > 3.10.0 / 3.16 / 3.19 / 3.22 / 3.24 / 3.27 / 3.29 / 3.32 / 3.35 / 3.38 / 3.41 皆無，
+   > 3.44.0 起才有。**教訓：驗證 SDK 行為時，基準是 `pubspec.yaml` 的版本下限，不是本機裝的版本。**
 
 5. **測試觸發點**：`WidgetsBinding.instance.handleMemoryPressure()` 為公開方法，可直接於測試呼叫，
    不需要 platform channel mock。

--- a/docs/plans/2026-09-03-memory-pressure-marker.md
+++ b/docs/plans/2026-09-03-memory-pressure-marker.md
@@ -67,10 +67,10 @@ OS (onTrimMemory / didReceiveMemoryWarning)
 |:---|:---|
 | `LogLevel.warning`（非 `info`） | 這是 OOM/LMK 前導信號，不是狀態轉換。要能被既有 warning/error 過濾與高亮機制撈起來，否則插進時間軸卻沉在資訊流裡 |
 | 沿用 `topPageLabel` 尾巴 | 「壓力發生在哪一頁」與 §P13 的「切換發生在哪一頁」同型，零額外成本 |
-| 保留 try-catch | `topPageLabel` 是 host 注入的 callback，會拋。雖然 binding 這條路徑會接住（見下方 1b），但不該讓 host 的錯誤汙染 `FlutterError`，且與既有 callback 寫法一致 |
+| 保留 try-catch | `topPageLabel` 是 host 注入的 callback，會拋。在 Flutter 3.10.0 ～ 3.41.x（本套件 SDK 下限所涵蓋的絕大多數版本）binding **不會**逐一捕捉 observer 例外，逃逸會中斷廣播、害後續 observer 收不到——**這是真正的保護**，不只是避免汙染 `FlutterError`（3.44.0+ 才由 binding 代為捕捉）。詳見下方 1b |
 | 類別 doc comment 同步更新 | 現有註解寫「Records app lifecycle transitions」，需擴及記憶體壓力 |
 
-#### 1b. 測試（🔴 不可照抄既有 guard 測試）
+#### 1b. 測試（🔴 guard 斷言須對照 SDK 下限，非本機版本）
 
 **規格 §5.4（已於 2026-09-03 修正）**：`handleMemoryPressure()` 的
 per-observer try-catch 是 **Flutter 3.44.0 才加入**的。本套件宣告

--- a/docs/plans/2026-09-03-memory-pressure-marker.md
+++ b/docs/plans/2026-09-03-memory-pressure-marker.md
@@ -72,16 +72,18 @@ OS (onTrimMemory / didReceiveMemoryWarning)
 
 #### 1b. 測試（🔴 不可照抄既有 guard 測試）
 
-**規格 §5.4 的發現**：`binding.dart:1372` 的 `handleMemoryPressure()`
-**每個 observer 各自包 try-catch**（`:1376-1387`），
-而 `didChangeAppLifecycleState` 的廣播迴圈**沒有**。
+**規格 §5.4（已於 2026-09-03 修正）**：`handleMemoryPressure()` 的
+per-observer try-catch 是 **Flutter 3.44.0 才加入**的。本套件宣告
+`flutter: ">=3.10.0"`，在 3.10.0 ～ 3.41.x 該迴圈**沒有** per-observer
+try-catch，與 `didChangeAppLifecycleState` 完全同型。
 
-既有測試 `guard: onLog throws does not propagate` 靠「例外中斷廣播迴圈、
-後續 `_HostObserver` 收不到」來證明 guard 存在。
-**該手法在本路徑上驗不到東西**——即使拿掉 try-catch，binding 也會接住，
-`_HostObserver` 照樣被呼叫，測試恆綠但零驗證力。
+**正確寫法**：沿用既有 `_HostObserver` 手法（在 SDK 下限上唯一有鑑別力的斷言），
+並**同時**保留 `FlutterError` 斷言（在 3.44.0+ 上 `hostCalled` 恆為 true、
+失去鑑別力時由它接手）。兩者並存，整個支援範圍才都驗得到 guard。
 
-**正確寫法**：直接斷言「拋錯時不產生 log、且不向外拋出」。
+> 原記載為「binding 每個 observer 各自包 try-catch，故 `_HostObserver` 無效」，
+> 那只在 3.44.0+ 成立——是只查本機 SDK（3.44.1）未對照版本下限所致，
+> 由 PR #155 review 指出後逐版查證修正。
 
 新增的 case（對應驗收條件 1–7）：
 
@@ -92,7 +94,7 @@ OS (onTrimMemory / didReceiveMemoryWarning)
 | 3 | `memory pressure: null and empty label omit the suffix` | 訊息 == `Memory pressure`（兩種輸入） |
 | 4 | `memory pressure: not attached produces no log` | callCount==0 |
 | 5 | `memory pressure: no log after detach` | detach 後再觸發，callCount 不變 |
-| 6 | `memory pressure: throwing topPageLabel is caught` | `returnsNormally` 且 logged==false（**不使用 `_HostObserver`**） |
+| 6 | `memory pressure: throwing topPageLabel is caught` | `returnsNormally`、hostCalled==true（`_HostObserver`，驗 3.10–3.41）、captured 為空（`FlutterError`，驗 3.44+）、logged==false |
 
 觸發方式：`WidgetsBinding.instance.handleMemoryPressure()`（公開方法，無需 mock）。
 

--- a/docs/plans/2026-09-03-memory-pressure-marker.md
+++ b/docs/plans/2026-09-03-memory-pressure-marker.md
@@ -1,0 +1,139 @@
+# 實作計畫：記憶體壓力事件（§P21）
+
+- **日期**：2026-09-03
+- **規格**：`docs/features/2026-09-03-memory-pressure-marker.md`
+- **Effort**：trivial
+
+---
+
+## 1. 資料結構
+
+**不新增任何資料結構。** 這是本項最重要的設計判斷。
+
+事件的完整資訊量是「一個時間點 + 發生在哪一頁」，沒有結構化欄位可存。
+既有 `LogEntry` 已能承載（`message` + `level` + `activeRoute`），
+新增 `MemoryEntry` / `MemoryInspector` / 第五個 `TimelineSource` 會讓
+過濾、報告、UI 全鏈路長出特殊情況，卻換不到任何新資訊——正是 Anti-Feature #6 的形狀。
+
+資料流沿用既有路徑，一條線到底：
+
+```
+OS (onTrimMemory / didReceiveMemoryWarning)
+  → WidgetsBinding.handleMemoryPressure()
+  → LifecycleHandler.didHaveMemoryPressure()      ← 本次唯一新增的節點
+  → onLog（建構時注入的 FlutterInspector.log）
+  → LogEntry（activeRoute 由 log() 自行填入）
+  → RingBuffer.add → onMutate → revision.value++  ← 既有唯一變更通道
+  → ConsoleTab 重繪
+```
+
+---
+
+## 2. 任務拆分
+
+**單一任務，序列執行。** 改動集中在一個檔案，無並行空間。
+
+### Task 1 · `didHaveMemoryPressure()` + 測試 + 文件
+
+**寫入路徑**：
+- `lib/src/core/lifecycle_handler.dart`（實作）
+- `test/core/lifecycle_handler_test.dart`（測試）
+- `lib/src/core/flutter_inspector.dart`（**僅** doc comment）
+- `README.md`、`CHANGELOG.md`（文件）
+
+#### 1a. 實作
+
+於 `lifecycle_handler.dart` 的 `didChangeAppLifecycleState` 之後新增：
+
+```dart
+  @override
+  void didHaveMemoryPressure() {
+    try {
+      final page = topPageLabel?.call();
+      final suffix = (page == null || page.isEmpty) ? '' : ' · $page';
+      onLog('Memory pressure$suffix', level: LogLevel.warning);
+    } catch (e, s) {
+      debugPrintStack(
+        stackTrace: s,
+        label: 'inspector memory pressure log failed: $e',
+      );
+    }
+  }
+```
+
+四個決定，全部對齊既有那支：
+
+| 決定 | 理由 |
+|:---|:---|
+| `LogLevel.warning`（非 `info`） | 這是 OOM/LMK 前導信號，不是狀態轉換。要能被既有 warning/error 過濾與高亮機制撈起來，否則插進時間軸卻沉在資訊流裡 |
+| 沿用 `topPageLabel` 尾巴 | 「壓力發生在哪一頁」與 §P13 的「切換發生在哪一頁」同型，零額外成本 |
+| 保留 try-catch | `topPageLabel` 是 host 注入的 callback，會拋。雖然 binding 這條路徑會接住（見下方 1b），但不該讓 host 的錯誤汙染 `FlutterError`，且與既有 callback 寫法一致 |
+| 類別 doc comment 同步更新 | 現有註解寫「Records app lifecycle transitions」，需擴及記憶體壓力 |
+
+#### 1b. 測試（🔴 不可照抄既有 guard 測試）
+
+**規格 §5.4 的發現**：`binding.dart:1372` 的 `handleMemoryPressure()`
+**每個 observer 各自包 try-catch**（`:1376-1387`），
+而 `didChangeAppLifecycleState` 的廣播迴圈**沒有**。
+
+既有測試 `guard: onLog throws does not propagate` 靠「例外中斷廣播迴圈、
+後續 `_HostObserver` 收不到」來證明 guard 存在。
+**該手法在本路徑上驗不到東西**——即使拿掉 try-catch，binding 也會接住，
+`_HostObserver` 照樣被呼叫，測試恆綠但零驗證力。
+
+**正確寫法**：直接斷言「拋錯時不產生 log、且不向外拋出」。
+
+新增的 case（對應驗收條件 1–7）：
+
+| # | 測試名 | 斷言 |
+|:---:|:---|:---|
+| 1 | `memory pressure produces one warning log` | callCount==1、level==`warning`、訊息含 `Memory pressure` |
+| 2 | `memory pressure: topPageLabel appended after " · "` | 訊息 == `Memory pressure · HomePage (/home)` |
+| 3 | `memory pressure: null and empty label omit the suffix` | 訊息 == `Memory pressure`（兩種輸入） |
+| 4 | `memory pressure: not attached produces no log` | callCount==0 |
+| 5 | `memory pressure: no log after detach` | detach 後再觸發，callCount 不變 |
+| 6 | `memory pressure: throwing topPageLabel is caught` | `returnsNormally` 且 logged==false（**不使用 `_HostObserver`**） |
+
+觸發方式：`WidgetsBinding.instance.handleMemoryPressure()`（公開方法，無需 mock）。
+
+沿用既有測試檔的 `handler` + `tearDown` 慣例，避免 observer 洩漏到其他 case。
+
+#### 1c. 文件
+
+- `flutter_inspector.dart` 的 `captureLifecycleEvents` doc comment：
+  補一句它現在也記錄記憶體壓力事件。**不改任何程式碼**。
+- `README.md`：平台覆蓋度——Android 經 `onTrimMemory`、iOS 經 `didReceiveMemoryWarning`、
+  **Web 實質不會觸發**（避免使用者誤判為套件故障）。
+- `CHANGELOG.md`：Unreleased 條目。
+
+---
+
+## 3. 驗證
+
+```bash
+flutter test test/core/lifecycle_handler_test.dart   # 單檔快驗
+flutter test                                        # 全套（既有 554 + 新增）
+flutter analyze lib/ test/                          # 不得超出既有 7 個 info 基準
+```
+
+**版本號不動**——本計畫不含發版。發版走 `gen-update-publish-info`（4 處同步）。
+
+---
+
+## 4. 刻意不做
+
+| 項目 | 理由 |
+|:---|:---|
+| `AlertThrottler` 節流 | 未實測觸發頻率，預先加是解決想像中的問題。實測洗版才接（已支援建構式注入） |
+| 抽出 `_logWithPageSuffix()` 共用 helper | 兩處各 5 行、字面不同（`App lifecycle: ${state.name}` vs `Memory pressure`）。抽共用要嘛傳格式參數要嘛傳前綴字串，都比重複兩行更難讀。**第三次出現才抽** |
+| `captureMemoryPressure` 獨立旗標 | 已裁決併入（規格 §3） |
+| 新增 model／inspector／UI 檔 | 見 §1 |
+
+---
+
+## 5. 風險與回滾
+
+改動落在單一 callback，**不觸碰任何既有程式碼路徑**——
+既有 `didChangeAppLifecycleState`、`attach`/`detach`、UI、model 全數不動。
+
+最壞情況是新 callback 行為不如預期，刪掉該方法即完全回到現狀，無殘留。

--- a/docs/plans/2026-09-03-memory-pressure-marker.md
+++ b/docs/plans/2026-09-03-memory-pressure-marker.md
@@ -17,7 +17,7 @@
 
 資料流沿用既有路徑，一條線到底：
 
-```
+```text
 OS (onTrimMemory / didReceiveMemoryWarning)
   → WidgetsBinding.handleMemoryPressure()
   → LifecycleHandler.didHaveMemoryPressure()      ← 本次唯一新增的節點

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -196,6 +196,15 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
               const SizedBox(height: 20),
               ElevatedButton(
+                // Fires the same observer broadcast the OS triggers on real
+                // memory pressure (Android onTrimMemory, iOS
+                // didReceiveMemoryWarning). With captureLifecycleEvents
+                // enabled it lands on the timeline as a warning entry.
+                onPressed: () => WidgetsBinding.instance.handleMemoryPressure(),
+                child: const Text('Simulate Memory Pressure'),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
                 // Throws an uncaught async error. With captureUncaughtErrors
                 // enabled it is caught by PlatformDispatcher.instance.onError and
                 // surfaces as a red error log in the Console tab — tap it to

--- a/lib/src/core/flutter_inspector.dart
+++ b/lib/src/core/flutter_inspector.dart
@@ -110,6 +110,12 @@ class FlutterInspector {
   /// - Unlike the error hooks, this observer *is* torn down: [detach] removes
   ///   it from [WidgetsBinding.instance]. Removing one observer from the
   ///   binding's list cannot affect the host's own observers.
+  /// - This flag also covers **memory pressure**: the same observer records an
+  ///   OS memory-pressure warning as a [LogLevel.warning] entry, the only
+  ///   OOM/LMK precursor Dart can see. It shares this flag rather than getting
+  ///   its own because both are callbacks on one observer with one attach/
+  ///   detach lifecycle. Android delivers it via `onTrimMemory`, iOS via
+  ///   `didReceiveMemoryWarning`; Web effectively never fires it.
   final bool captureLifecycleEvents;
 
   /// Whether to mask sensitive headers (e.g. `Authorization`, `Cookie`,

--- a/lib/src/core/lifecycle_handler.dart
+++ b/lib/src/core/lifecycle_handler.dart
@@ -10,7 +10,8 @@ import 'uncaught_error_handler.dart' show LogCallback;
 /// observers in a list, so the host app's own observers keep receiving their
 /// callbacks unaffected.
 class LifecycleHandler with WidgetsBindingObserver {
-  /// The function called to log a lifecycle transition.
+  /// The function called to log a lifecycle transition or a memory-pressure
+  /// event.
   final LogCallback onLog;
 
   /// Optional supplier of a label for the current top-most page, appended to

--- a/lib/src/core/lifecycle_handler.dart
+++ b/lib/src/core/lifecycle_handler.dart
@@ -3,7 +3,8 @@ import 'package:flutter/widgets.dart';
 import '../models/log_level.dart';
 import 'uncaught_error_handler.dart' show LogCallback;
 
-/// Records app lifecycle transitions as [LogLevel.info] log entries.
+/// Records app lifecycle transitions as [LogLevel.info] log entries, and
+/// memory pressure warnings as [LogLevel.warning] entries.
 ///
 /// Registers itself on [WidgetsBinding.instance] as an observer. Flutter keeps
 /// observers in a list, so the host app's own observers keep receiving their
@@ -55,6 +56,35 @@ class LifecycleHandler with WidgetsBindingObserver {
       debugPrintStack(
         stackTrace: s,
         label: 'inspector lifecycle log failed: $e',
+      );
+    }
+  }
+
+  /// Records the OS-reported memory pressure as a [LogLevel.warning] entry.
+  ///
+  /// This is the only OOM/LMK precursor available to Dart — the actual RSS
+  /// figure needs a platform channel — and it arrives as a discrete, timestamped
+  /// event, so it lands on the merged timeline next to the network, route and
+  /// database entries that preceded it. Warning rather than info: it is a
+  /// precursor signal, not a state transition, so it has to surface through the
+  /// existing error/warning filters instead of sinking into the info stream.
+  ///
+  /// Platform coverage: Android reports it via `onTrimMemory`, iOS via
+  /// `didReceiveMemoryWarning`. Web effectively never fires it.
+  @override
+  void didHaveMemoryPressure() {
+    try {
+      final page = topPageLabel?.call();
+      final suffix = (page == null || page.isEmpty) ? '' : ' · $page';
+      onLog('Memory pressure$suffix', level: LogLevel.warning);
+    } catch (e, s) {
+      // The binding wraps each observer in its own try-catch here (unlike the
+      // lifecycle broadcast), so this guard is not what keeps the host's
+      // observers running — it keeps a throwing `topPageLabel` from surfacing
+      // as a FlutterError the host never caused.
+      debugPrintStack(
+        stackTrace: s,
+        label: 'inspector memory pressure log failed: $e',
       );
     }
   }

--- a/lib/src/core/lifecycle_handler.dart
+++ b/lib/src/core/lifecycle_handler.dart
@@ -79,10 +79,12 @@ class LifecycleHandler with WidgetsBindingObserver {
       final suffix = (page == null || page.isEmpty) ? '' : ' · $page';
       onLog('Memory pressure$suffix', level: LogLevel.warning);
     } catch (e, s) {
-      // The binding wraps each observer in its own try-catch here (unlike the
-      // lifecycle broadcast), so this guard is not what keeps the host's
-      // observers running — it keeps a throwing `topPageLabel` from surfacing
-      // as a FlutterError the host never caused.
+      // Same contract as the lifecycle callback above: on the SDK floor this
+      // package supports (Flutter >=3.10.0), `handleMemoryPressure` walks the
+      // observer list with no per-observer try-catch, so an escaping exception
+      // would halt the broadcast and rob every observer registered after this
+      // one. Flutter 3.44.0 added a per-observer guard there, but relying on it
+      // would break every supported version below that.
       debugPrintStack(
         stackTrace: s,
         label: 'inspector memory pressure log failed: $e',

--- a/test/core/lifecycle_handler_test.dart
+++ b/test/core/lifecycle_handler_test.dart
@@ -188,6 +188,131 @@ void main() {
     expect(messages, ['App lifecycle: paused', 'App lifecycle: resumed']);
   });
 
+  test('memory pressure: produces one warning log', () {
+    var callCount = 0;
+    LogLevel? lastLevel;
+    String? lastMessage;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+        lastLevel = level;
+        lastMessage = message;
+      },
+    );
+    handler = h;
+    h.attach();
+
+    WidgetsBinding.instance.handleMemoryPressure();
+
+    expect(callCount, 1);
+    // warning 而非 info：這是 OOM/LMK 前導信號，必須能被既有的
+    // warning/error 過濾與高亮機制撈起來，不能沉在資訊流裡。
+    expect(lastLevel, LogLevel.warning);
+    expect(lastMessage, contains('Memory pressure'));
+  });
+
+  test('memory pressure: non-empty label is appended after " · "', () {
+    String? lastMessage;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        lastMessage = message;
+      },
+      topPageLabel: () => 'HomePage (/home)',
+    );
+    handler = h;
+    h.attach();
+
+    WidgetsBinding.instance.handleMemoryPressure();
+
+    expect(lastMessage, 'Memory pressure · HomePage (/home)');
+  });
+
+  test('memory pressure: null and empty label both omit the suffix', () {
+    final messages = <String>[];
+    final labels = <String?>['', null];
+    var i = 0;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        messages.add(message);
+      },
+      topPageLabel: () => labels[i++],
+    );
+    handler = h;
+    h.attach();
+
+    WidgetsBinding.instance.handleMemoryPressure();
+    WidgetsBinding.instance.handleMemoryPressure();
+
+    expect(messages, ['Memory pressure', 'Memory pressure']);
+  });
+
+  test('memory pressure: not attached produces no log', () {
+    var callCount = 0;
+    handler = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+      },
+    );
+
+    // 刻意不呼叫 attach()。
+    WidgetsBinding.instance.handleMemoryPressure();
+
+    expect(callCount, 0);
+  });
+
+  test('memory pressure: no further logs after detach', () {
+    var callCount = 0;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        callCount++;
+      },
+    );
+    handler = h;
+    h.attach();
+
+    WidgetsBinding.instance.handleMemoryPressure();
+    h.detach();
+    WidgetsBinding.instance.handleMemoryPressure();
+
+    expect(callCount, 1);
+  });
+
+  test(
+    'memory pressure: a throwing topPageLabel never reaches FlutterError',
+    () {
+      var logged = false;
+      final h = LifecycleHandler(
+        onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+          logged = true;
+        },
+        topPageLabel: () => throw StateError('resolve failed'),
+      );
+      handler = h;
+      h.attach();
+
+      // 🔴 這個斷言的選擇是實測出來的，不是想當然耳：
+      //
+      // 1. 不能用上面 `guard: onLog throws` 的 _HostObserver 手法——binding 的
+      //    handleMemoryPressure() 為每個 observer 各自包了 try-catch
+      //    （didChangeAppLifecycleState 的廣播迴圈則沒有），例外不會中斷廣播。
+      // 2. 也不能只斷言 returnsNormally + 不產生 log——binding 那層 try-catch
+      //    會把例外接走，所以拿掉本類別的 guard 這兩個斷言照樣通過（已用
+      //    mutation test 證實：移除 try-catch 後 15 個測試全綠）。
+      //
+      // 唯一能分辨「guard 在不在」的可觀察差異是 FlutterError：沒有 guard 時，
+      // binding 會把例外轉成 FlutterErrorDetails 報上去；有 guard 時不會。
+      final captured = <FlutterErrorDetails>[];
+      final saved = FlutterError.onError;
+      FlutterError.onError = captured.add;
+      addTearDown(() => FlutterError.onError = saved);
+
+      WidgetsBinding.instance.handleMemoryPressure();
+
+      expect(captured, isEmpty);
+      expect(logged, isFalse);
+    },
+  );
+
   test('topPageLabel: a throwing supplier is caught, does not propagate', () {
     var logged = false;
     final h = LifecycleHandler(

--- a/test/core/lifecycle_handler_test.dart
+++ b/test/core/lifecycle_handler_test.dart
@@ -277,41 +277,50 @@ void main() {
     expect(callCount, 1);
   });
 
-  test(
-    'memory pressure: a throwing topPageLabel never reaches FlutterError',
-    () {
-      var logged = false;
-      final h = LifecycleHandler(
-        onLog: (message, {level = LogLevel.info, stackTrace, data}) {
-          logged = true;
-        },
-        topPageLabel: () => throw StateError('resolve failed'),
-      );
-      handler = h;
-      h.attach();
+  test('memory pressure: a throwing topPageLabel is caught by the guard', () {
+    var logged = false;
+    var hostCalled = false;
+    final h = LifecycleHandler(
+      onLog: (message, {level = LogLevel.info, stackTrace, data}) {
+        logged = true;
+      },
+      topPageLabel: () => throw StateError('resolve failed'),
+    );
+    handler = h;
+    h.attach();
 
-      // 🔴 這個斷言的選擇是實測出來的，不是想當然耳：
-      //
-      // 1. 不能用上面 `guard: onLog throws` 的 _HostObserver 手法——binding 的
-      //    handleMemoryPressure() 為每個 observer 各自包了 try-catch
-      //    （didChangeAppLifecycleState 的廣播迴圈則沒有），例外不會中斷廣播。
-      // 2. 也不能只斷言 returnsNormally + 不產生 log——binding 那層 try-catch
-      //    會把例外接走，所以拿掉本類別的 guard 這兩個斷言照樣通過（已用
-      //    mutation test 證實：移除 try-catch 後 15 個測試全綠）。
-      //
-      // 唯一能分辨「guard 在不在」的可觀察差異是 FlutterError：沒有 guard 時，
-      // binding 會把例外轉成 FlutterErrorDetails 報上去；有 guard 時不會。
-      final captured = <FlutterErrorDetails>[];
-      final saved = FlutterError.onError;
-      FlutterError.onError = captured.add;
-      addTearDown(() => FlutterError.onError = saved);
+    // 🔴 斷言兩件事，因為 binding 的行為隨 SDK 版本而異：
+    //
+    // - Flutter >=3.10.0（本套件的 SDK 下限）到 3.41.x：
+    //   handleMemoryPressure() 逐一呼叫 observer，**沒有** per-observer
+    //   try-catch。例外逃逸會中斷廣播，排在本 handler 之後註冊的 observer
+    //   全部收不到——與 didChangeAppLifecycleState 完全同型，所以沿用上面
+    //   `guard: onLog throws` 的 _HostObserver 手法（註冊順序同樣刻意讓
+    //   handler 排在 hostObserver 之前）。
+    // - Flutter 3.44.0 起：binding 補上 per-observer try-catch，此時
+    //   hostCalled 不論有無 guard 都為 true，該斷言失去鑑別力；改由
+    //   FlutterError 有沒有收到回報來分辨（沒 guard 時 binding 會把例外
+    //   轉成 FlutterErrorDetails 報上去）。
+    //
+    // 兩個斷言並存，整個支援範圍內才都真的驗得到 guard 存在。
+    final hostObserver = _HostObserver(() => hostCalled = true);
+    WidgetsBinding.instance.addObserver(hostObserver);
+    addTearDown(() => WidgetsBinding.instance.removeObserver(hostObserver));
 
-      WidgetsBinding.instance.handleMemoryPressure();
+    final captured = <FlutterErrorDetails>[];
+    final saved = FlutterError.onError;
+    FlutterError.onError = captured.add;
+    addTearDown(() => FlutterError.onError = saved);
 
-      expect(captured, isEmpty);
-      expect(logged, isFalse);
-    },
-  );
+    expect(
+      () => WidgetsBinding.instance.handleMemoryPressure(),
+      returnsNormally,
+    );
+
+    expect(hostCalled, isTrue);
+    expect(captured, isEmpty);
+    expect(logged, isFalse);
+  });
 
   test('topPageLabel: a throwing supplier is caught, does not propagate', () {
     var logged = false;
@@ -338,6 +347,10 @@ void main() {
 
 /// Minimal host observer, proving [LifecycleHandler] never crowds out the
 /// other observers registered on the binding.
+///
+/// Both callbacks report through the same hook: each test registers this after
+/// the handler and triggers only one of the two broadcasts, so whichever fires
+/// is the one under test.
 class _HostObserver with WidgetsBindingObserver {
   _HostObserver(this.onStateChange);
 
@@ -345,6 +358,11 @@ class _HostObserver with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    onStateChange();
+  }
+
+  @override
+  void didHaveMemoryPressure() {
     onStateChange();
   }
 }


### PR DESCRIPTION
## Summary

Closes #154

`LifecycleHandler` 已經是 `WidgetsBindingObserver`，卻只覆寫了 `didChangeAppLifecycleState`，
白白漏掉 `didHaveMemoryPressure`——那是 Dart 層唯一拿得到的 OOM/LMK 前導信號。
本 PR 補上該 callback，讓記憶體壓力事件落進混合時間軸。**12 行實作，零新增資料結構、
零新增旗標、零接線改動。**

## 修正問題

排查「App 用著用著就被系統殺掉」時，時間軸上完全沒有前導信號——開發者只知道 App 消失了，
無從得知壓力是在載入哪張大圖、或哪支回傳巨大 JSON 的 API 之後才開始密集出現。

Google Play 2026 Q3 已把 Memory usage 列為 **Feb 2027 強制**門檻，但 Play Console 只給
聚合百分比，答得出「多爛」、答不出「爛在哪個事件之後」。真正的 RSS 數值需要 platform channel
（粗糙且跨平台不一致，屬 app 內不可觀測），但 `didHaveMemoryPressure()` 是 Flutter SDK
內建回呼，且天然就是「帶時間戳的離散事件」，正是本套件鏈推斷要的因果原料。

## 修正方式

- **記為 `warning` 而非 `info`**：這是前導信號不是狀態轉換，必須能被既有的 errors-only
  過濾撈起來，不能沉在資訊流裡（`console_utils.dart:94` 明文 `warning || error`）
- **沿用既有 `topPageLabel` 尾巴**：`Memory pressure · CheckoutPage`，記錄壓力發生在哪一頁
- **併入既有 `captureLifecycleEvents`，不新增旗標**：兩者是同一個 observer 的兩個 callback，
  共用同一套 `attach`/`detach`。獨立旗標會讓旗標與 observer 不再一對一，為一個 bool 在
  `attach`、`detach` 與兩個 callback 內長出四處判斷
- **不新增 `MemoryEntry`／`MemoryInspector`／`RingBuffer`**：事件只有一個時間點，無結構化
  欄位可存，新增會讓過濾、報告、UI 全鏈路長出特殊情況卻換不到新資訊（Anti-Feature #6 的形狀）

### 測試的 guard 斷言是實測選出來的

這是本 PR 唯一值得細看的地方。最初照計畫寫的 guard 測試（`returnsNormally` + 不產生 log）
**驗不到任何東西**——mutation test 把 `try-catch` 整個移除後，15 個測試全數通過。

死因：`binding.dart:1372` 的 `handleMemoryPressure()` **為每個 observer 各自包了 try-catch**，
而 `didChangeAppLifecycleState` 的廣播迴圈**沒有**。所以既有測試 `guard: onLog throws`
依賴的「例外中斷廣播、後續 observer 收不到」在這條路徑上不成立；連「不拋出 + 不產生 log」
都不夠，因為 binding 那層會把例外接走，有沒有自己的 guard 結果完全一樣。

唯一能分辨 guard 在不在的可觀察差異是 **`FlutterError` 有沒有收到回報**——沒有 guard 時
binding 會轉成 `FlutterErrorDetails` 報上去。改用該斷言後：guard 在 → 15 綠；guard 移除 →
`+14 -1` 失敗。`level` 斷言也做了同樣的 mutation 驗證（改成 `info` → 失敗）。

## 已知範圍邊界（刻意不做）

| 項目 | 理由 |
|:---|:---|
| 節流（throttle） | 未實測觸發頻率，先加是解決想像中的問題。實測洗版才接既有 `AlertThrottler`（已支援建構式注入） |
| 抽 `_logWithPageSuffix()` 共用 helper | 兩處各 5 行、字面不同，抽共用比重複兩行更難讀。第三次出現才抽 |
| warning 列底色 | `console_tab.dart:429` 的 `tileColor` 只認 `error`，**是既有行為**（`git show origin/main` 該行一字未改），既有的 `webview_bridge_adapter.dart:93` warning 也一樣。改它等於重新定義所有 warning 的視覺呈現，屬計畫外擴大範圍，應另開項目 |
| 讀取實際 RSS 數值、記憶體洩漏偵測 | 前者需 platform channel，後者為 Anti-Feature #1 明確否決（交由官方 DevTools） |

## Verification

```
flutter test              → 563 tests, All tests passed
flutter analyze lib/ test/ → 7 issues（6 deprecated_member_use + 1 js interop）
                             = 既有基準，零新增
```

審查階段另實地查證兩項未在文件宣稱的行為：記憶體壓力事件會被 errors-only 過濾撈到
（`console_utils.dart:94`），也會進診斷報告（`diagnostic_report.dart:206` 同樣認 warning）。

**平台覆蓋度**：Android 經 `onTrimMemory`、iOS 經 `didReceiveMemoryWarning`、
Web 實質不觸發（README 已註明，避免使用者誤判為套件故障）。


## Sourcery 摘要

在合并时间线中记录 Flutter 内存压力事件，以便开发者将即将发生的内存相关终止与此前的应用活动关联起来。

新功能：
- 将操作系统内存压力回调作为警告级别条目记录到合并时间线中，并在可用时包含当前页面。

增强功能：
- 复用现有的生命周期捕获设置和观察者生命周期，不添加新的数据结构或集成路径。

文档：
- 记录内存压力事件、筛选行为，以及 Android、iOS 和 Web 平台支持范围。

测试：
- 增加对日志记录、严重性、页面标签、附件生命周期和错误隔离的覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在合并时间线中捕获 Flutter 内存压力事件，帮助开发者将潜在的内存相关应用终止与此前的活动关联起来。

新功能：
- 将操作系统内存压力事件记录为合并时间线中的警告级条目，并在可用时包含当前页面。

增强功能：
- 重用现有的生命周期捕获标志和观察者生命周期，不引入新的数据结构或集成路径。

文档：
- 记录内存压力日志、过滤行为，以及 Android、iOS 和 Web 平台的支持范围。

测试：
- 增加对内存压力日志记录、严重级别、页面标注、附件生命周期和错误隔离的覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在合并时间线中捕获 Flutter 内存压力事件，以便开发者将可能与内存相关的应用终止与此前的活动关联起来。

新功能：
- 将操作系统内存压力回调记录为合并时间线中的警告级别条目，并在可用时包含当前页面。

改进：
- 复用现有的生命周期捕获标志和观察者生命周期来处理内存压力事件，无需添加新的数据结构或集成路径。

文档：
- 记录内存压力日志、筛选行为，以及 Android、iOS 和 Web 平台支持情况。

测试：
- 增加对内存压力日志记录、严重性、页面标签、附加生命周期和错误隔离的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在合并时间线上捕获 Flutter 内存压力事件，以便开发者将潜在的内存相关应用终止与此前的活动关联起来。

新功能：
- 将操作系统内存压力事件记录为合并时间线上的警告级条目，并在可用时包含当前页面。

增强功能：
- 复用现有的生命周期捕获标志和观察者生命周期来处理内存压力事件，无需添加新的数据结构或集成路径。

文档：
- 记录内存压力日志、过滤行为，以及 Android、iOS 和 Web 平台支持范围。

测试：
- 增加对内存压力日志记录、严重级别、页面标记、附加生命周期和错误隔离的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在合并时间线中捕获 Flutter 内存压力事件，以便开发者将潜在的内存相关应用终止与之前的活动进行关联。

新功能：
- 将操作系统内存压力事件记录为合并时间线中的警告级别条目，并在可用时包含当前页面。
- 添加示例应用控件，用于模拟内存压力事件。

增强功能：
- 复用现有的生命周期事件捕获标志和观察者生命周期来报告内存压力事件，无需引入新的数据结构或集成路径。

文档：
- 记录内存压力日志、过滤行为，以及 Android、iOS 和 Web 平台的支持范围。

测试：
- 增加对内存压力日志记录、严重性、页面标签、附件生命周期和错误隔离的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Capture Flutter memory-pressure events in the merged timeline so developers can correlate potential memory-related app termination with preceding activity.

New Features:
- Record OS memory-pressure events as warning-level entries in the merged timeline, including the current page when available.
- Add an example-app control for simulating memory-pressure events.

Enhancements:
- Reuse the existing lifecycle event capture flag and observer lifecycle for memory-pressure reporting without introducing new data structures or integration paths.

Documentation:
- Document memory-pressure logging, filtering behavior, and Android, iOS, and Web platform coverage.

Tests:
- Add coverage for memory-pressure logging, severity, page labels, attachment lifecycle, and error isolation.

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 启用 `captureLifecycleEvents` 后，Android、iOS 和 macOS 的内存压力事件会记录为带时间戳的警告日志，并包含当前页面信息。
  * 内存压力事件会显示在 Console/Timeline 中；Web 通常不会触发此类事件。
  * 示例应用新增“模拟内存压力”按钮，便于查看事件记录效果。

* **文档**
  * 补充内存压力事件的配置说明、平台支持范围及行为规范。
  * 新增相关功能规格与实施计划文档。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->