### PR TITLE
docs(workflow): three cross-reference breakages left by the SKILL.md split

### DIFF
--- a/.claude/skills/gen-dev-workflow/SKILL.md
+++ b/.claude/skills/gen-dev-workflow/SKILL.md
@@ -82,7 +82,7 @@ description: |
     │     ｜設計判斷/跨層→最強                         │
     │  → 委派實作任務，verifier 兩階段驗收          │
     │     （spec compliance → code quality，          │
-    │      見 delegation-and-parallel.md）            │
+    │      見 references/delegation-and-parallel.md） │
     │  🪶 Ponytail：派發模板必附〈規則塊〉，驗收把  │
     │     計畫外抽象/依賴/防禦分支當品質不佳退回    │
     │     （規則塊全文見 .claude/agents/implementer.md）│

--- a/.claude/skills/gen-dev-workflow/references/delegation-and-parallel.md
+++ b/.claude/skills/gen-dev-workflow/references/delegation-and-parallel.md
@@ -1,7 +1,7 @@
 # Model 委派與並行契約（gen-dev-workflow 參考）
 
 > 本檔是 `gen-dev-workflow` 主 skill 的委派與並行參考。主檔（`../SKILL.md`）在派發子 agent、決定並行、或處理失敗 retry 時指向這裡。
-> 高頻查閱的「推論等級表」4 行已內嵌在主檔的「Model 與委派策略」小節；本檔收錄完整綁定原則、風險註記、Stage 分配、implementer 分級、不委派硬規則，以及並行契約全文。
+> 本檔收錄「推論等級表」（唯一定義處）、完整綁定原則、風險註記、Stage 分配、implementer 分級、不委派硬規則，以及並行契約全文。
 
 ## Model 與委派策略
 
@@ -24,9 +24,18 @@ Model 別名綁在各 agent 檔的 frontmatter（`.claude/agents/*.md`），主�
 - Workflow `agent()` 呼叫：`agentType: '<agent 名>'` 仍沿用 frontmatter 的 model 綁定；effort 另用 `opts.effort` 依本表帶入（frontmatter 已無 effort 可沿用，省略等於落回 session 預設）。
 - 要調整某角色的等級 → model 改該 agent 檔一行；effort 改本表一行，兩處呼叫端（Task 派發與 Workflow `agent()` 範例）跟著本表走，不散落各處硬編碼。
 
-> 🔴 **已知風險（實測案例，未完全排除）：`effort: 'xhigh'` 在 thinking 未開啟時，於 Opus 4.8 上曾實際遇到 `400 output_config.effort 'xhigh' is not supported when thinking is disabled on this model`。**
-> Claude Code 的 `Task`/`Agent`/Workflow `agent()` 呼叫是否會在帶 `effort: 'xhigh'`（或 `max`）時自動連帶開啟 thinking，**目前未經驗證**——若沒有，本表對 planner/reviewer/verifier（`xhigh`）與 implementer（`max`）的派發範例都可能在實際執行時 400。錯誤訊息本身指出安全退路：`effort: 'high'` 以下不受此限。
-> 在此風險被驗證排除之前：若某次派發真的撞到這個 400，先把該次呼叫的 effort 降到 `high` 復原可用性，並回來這裡更新本表——**不要**默默把全表降級成 `high`（那會抹掉 STAGE 2/3 原本要的差異化），也不要無視這條風險繼續往更多派發點複製 `xhigh`/`max`。
+> 🔴 **已知上游 bug（非本表設計問題）：`effort: 'xhigh'`／`'max'` 可能回 `400 output_config.effort 'xhigh' is not supported when thinking is disabled on this model`。**
+>
+> **API 層的規則（[官方 effort 文件](https://platform.claude.com/docs/en/build-with-claude/effort)）**：`xhigh` / `max` 這兩個等級下 thinking **不可被關閉**，`thinking: {type: "disabled"}` 與它們併用一律 400。所以 `xhigh` 本身是支援的——它要求 thinking 同時開著，是**組合約束**，不是單一參數的支援與否。
+>
+> **Claude Code 側的 bug**：`alwaysThinkingEnabled: true` **未被翻譯成對外請求的 `thinking: {type: "adaptive"}`**，導致 session 靜默地在沒有 thinking 的狀態下跑，於是踩到上述組合約束（[#79798](https://github.com/anthropics/claude-code/issues/79798)、[#76689](https://github.com/anthropics/claude-code/issues/76689)）。**關鍵後果：你無法從自己的 settings 推斷 thinking 實際有沒有送出**，所以這條風險無法靠「事先確認 effort 支援」排除。
+>
+> **撞到時的正確反應**（依序）：
+> 1. 先確認 thinking 是否實際送出（這才是根因）。
+> 2. 降 `effort` 到 `high` 以下是**繞過、不是修復**——它讓該次派發跑得完，但犧牲了該角色本來要的推論強度。若用了，就該當成暫時措施而非新基準。
+> 3. **不要**默默把全表降級成 `high`（那會抹掉 STAGE 2/3 原本要的差異化），也不要無視這條風險繼續往更多派發點複製 `xhigh`/`max`。
+>
+> **與 retry ladder 的關係**：這是基礎設施錯誤，**不是 model 能力不足**。它必然重現（參數沒變就再撞一次），所以若計入「同 tier 失敗 2 次」會直接觸發無效的 tier 升級——而 planner/reviewer/verifier 已在最高 tier，升級無處可升，只會走到「停止並等使用者決策」。詳見下方「退回路徑」的失敗分類。
 
 ### Stage 層級的基準分配
 
@@ -112,6 +121,9 @@ planner 在實作計畫中**應為每個任務標註複雜度等級**，implemen
 
 ```text
 失敗單元 → 分析原因
+  ├─ 基礎設施錯誤  → **不計入失敗次數**（見下方「為什麼要分類」）
+  │                   400 effort/thinking → 先查 thinking 是否送出，非原樣重派
+  │                   429 / 5xx / 連線中斷 → 同 tier 重派 1 次
   ├─ context 不足  → 補 context，重派同 model（最多 1 次）
   ├─ 任務過大      → 拆成更小單元，重新並行/序列
   ├─ 計畫本身有誤  → 退回 planner（STAGE 0b），不在 STAGE 2 硬修
@@ -124,5 +136,9 @@ planner 在實作計畫中**應為每個任務標註複雜度等級**，implemen
 ```
 
 > **Tier Upgrade 紀錄：** 當觸發 tier 升級時，必須在進度回報行中明確註記（例如：`[任務 N 升級至 標準 model]`），讓使用者知悉該任務正動用更高成本嘗試解決。
+
+> **為什麼基礎設施錯誤要與能力不足分開算：** 升級 tier 的前提是「這個執行者不夠強」。基礎設施錯誤（參數不被支援、限流、服務端錯誤、連線中斷）與 model 強弱無關，**換更強的 model 對它零幫助**。若混為一談，一次 `xhigh` 的 400 會吃掉兩次同 tier 重試（必然重現）再觸發升級，而最高 tier 無處可升，最終走到「停止並等使用者決策」——三次派發全部注定失敗，且給出錯誤診斷。
+>
+> 清單刻意維持極小，**只列實際觀測到或判斷無歧義的**：`400` effort/thinking（已記錄的事故，見上方 🔴 註記）、`429` 限流、`5xx`、連線中斷。**不要**擴寫成一份投機的暫時性錯誤分類學——字串比對錯誤訊息終究會誤判，而誤判的代價（多一次同 tier 重試）必須小於它要解決的問題。
 
 **與 STAGE 3 退回的關係：** STAGE 2 內部失敗在 STAGE 2 內 retry；STAGE 3 審查不通過才退回 STAGE 2 整體重做。兩者是不同層級的迴圈，不可混用。

--- a/.claude/skills/gen-dev-workflow/references/execution-modes.md
+++ b/.claude/skills/gen-dev-workflow/references/execution-modes.md
@@ -19,8 +19,12 @@ quick <描述或 #issue>
    - 不拆任務、不逐任務暫停；模糊需求仍問（≤2 個問題）
    - 改完跑相關測試（不重跑整套）
   ▼
-③ Task("reviewer", "快掃 <branch> diff，單 lens：correctness")
+③ Task("reviewer", "快掃 <branch> diff，單 lens：correctness", effort: "xhigh")
    - 保住「不讓同源 model 自審」原則；發現問題 → 主對話修正後重掃
+   - effort 依「推論等級表」帶入（reviewer = 最強推論）。**不可省略**——
+     quick 模式無 verifier 兩階段驗收，這是唯一的品質關卡，
+     且 lens 已收窄為單一 correctness，effort 再落回 session 預設
+     等於兩層折扣疊在同一個關卡上
   ▼
 ④ 呼叫 gen-commit skill 執行 commit → 用 gen-pr skill 產 PR 草稿
   ▼

--- a/docs/brainstorm/2026-08-25-workflow-brainstorm.md
+++ b/docs/brainstorm/2026-08-25-workflow-brainstorm.md
@@ -2006,3 +2006,125 @@ fs 層限制候選（上表三個 ❌ 項技術上同樣做得到，差別在採
 > ~~§W1 只在「quick 中途超標」時觸發，本 repo 至今未發生~~（已於 2026-08-26 解決）；
 > §W2 是安全強度不足而非功能故障，委派本身正常運作，hook 也確實掛著。
 > 兩者皆非阻擋項，可依實際需要排程。
+
+---
+
+## 🟠 第四部分之二：拆分殘留的交叉指涉與 effort 斷裂（2026-09-13 · orchestration 框架調研副產物）
+
+> **由來**：一輪「GitHub 知名 orchestration 框架 × gen-dev-workflow 機制比對」調研
+> （6 框架並行 + 收斂：LangGraph / CrewAI / AutoGen-AG2 / OpenHands+SWE-agent /
+> Claude-Flow 系 worktree orchestrator / Temporal+DBOS 耐久執行引擎）。
+>
+> **調研的主結論是「無機制可搬」**——10 個候選項中 3 個 recommend，而三者**全部是本專案既有
+> 設計的接線鬆脫，不是外部移植**；28 項明確排除（含容器隔離、checkpointer 資料庫、
+> LLM 決定路由、deterministic replay、StuckDetector 等）。本節只記錄那三項待辦，
+> 調研本體的框架比對矩陣與「基準優勢八項」不在此展開（非本檔主題）。
+>
+> **三項皆為 SKILL.md 拆分（PR #141）的殘留**，與 §W1／§W2 的「既有設計缺口」性質不同，
+> 故另立一節而非續編 §W 序列的語意——但編號仍沿用 §W 以維持單一序列。
+>
+> ⚠️ **狀態欄紀律**：本節三項於記錄時均為 `⬜ 待辦`。**PR 合併後才回寫 `✅ 已完成` 並補
+> commit SHA**——本檔已有四次「標為待辦／實際已完成」或「標為完成／實際只做一半」的漂移
+> 紀錄（§D6 / §P8 / §P19 / §D4，見 features-brainstorm），未合併就標完成會製造第五次。
+
+### §W3. `delegation-and-parallel.md:4` 的交叉指涉指向不存在的小節 — ⬜ 待辦
+
+**問題**：該檔引言宣稱「高頻查閱的『推論等級表』4 行**已內嵌在主檔的「Model 與委派策略」小節**」。
+實查 `SKILL.md` 六個標題（`:13` / `:19` / `:30` / `:156` / `:174` / `:204`）**無此小節**，
+且全檔無 `effort` 字樣。那個「Model 與委派策略」標題實際位於 **本檔自己的 `:6`**
+——它把自己的小節名當成主檔的小節名來引用。
+
+**研判為拆分殘留**：等級表原在 1017 行的單體 SKILL.md 內，拆分後整段搬進 reference（連同標題），
+這句交叉指涉未跟著修，於是變成「宣稱主檔有一個其實搬到自己身上的小節」。
+
+**危害有界但會自我延續**：
+- 正確的等級表就在同檔往下 8 行（`:12`），且 `SKILL.md:212` 的 References 索引獨立運作
+  並指向本檔，所以讀者走不進死路——**這不是可及性問題**。
+- 真正的成本是**誤導下一次修改**：讀到「已內嵌在主檔」的維護者可能認為那是既定設計，
+  於是在主檔真的補一個小節——而那會逆轉「1017 行 → 約 200 行主檔」的拆分決定，
+  去解一個不存在的問題。
+- 次要成本：引言首段就有指向不存在位置的交叉指涉，會讓讀者對該檔後續**真正吃重的**
+  斷言（effort 必須顯式帶入、retry ladder、不委派硬規則）一併打折。
+
+**修法**：砍掉前半句，把「推論等級表」併入「本檔收錄」清單並標注為唯一定義處。
+不動主檔、不動架構。
+
+**Effort**：trivial ｜ **價值**：⭐⭐（防止未來的逆向改動，非修復當下故障）
+
+### §W4. `execution-modes.md` quick 模式的 reviewer 派發漏帶 `effort` — ⬜ 待辦
+
+**問題**：`references/execution-modes.md` 的 quick 模式步驟 ③ 寫
+`Task("reviewer", "快掃 <branch> diff，單 lens：correctness")`，**未帶 `effort`**。
+
+**實查對照**（確認這是唯一一處真漏的）：
+
+| 檔案 | `Task(...)` 派發點 | 帶 effort |
+|:---|:---:|:---:|
+| `command-cheatsheet.md` | 12 處 | ✅ 全帶（含 `:31-32` 一處跨行呼叫，`effort` 在續行） |
+| `execution-modes.md:22` | 1 處 | ❌ **唯一漏的** |
+| `SKILL.md` 主檔 | 0 處（流程圖只寫等級名，無 `Task(...)` 範例） | — |
+
+**實際後果**（這是三項中唯一有行為影響的）：`model` 仍為 `opus`（綁 `reviewer.md` frontmatter，
+自動生效），但 `effort` 落回**主對話當下的 session effort**——因 `a6fcd29` 已移除逐 agent 的
+`effort:` frontmatter 綁定，改為子 agent 預設繼承 session effort，呼叫端不帶就沒有任何東西
+補上 `xhigh`。設計意圖是 `opus` + `xhigh`，實得 `opus` + 不確定值。
+
+**為何此處的降級比別處嚴重**：quick 模式**無 verifier 兩階段驗收**（那是 STAGE 2 的機制）、
+不拆任務、主對話直接實作，這次 reviewer 派發是該模式**唯一的品質關卡**，
+「不讓同源 model 自審」全靠它撐著。而 lens 已收窄為單一 correctness
+（完整流程的 STAGE 3 是多 angle），effort 再落回預設 = **兩層折扣疊在同一個關卡上**。
+
+**修法**：補 `effort: "xhigh"`，並加註「不可省略」與原因。
+
+**Effort**：trivial ｜ **價值**：⭐⭐⭐⭐（唯一有實際行為後果者）
+
+### §W5. `xhigh` 風險註記已過期，且其建議措施會誘導錯誤降級 — ⬜ 待辦
+
+**問題**：`delegation-and-parallel.md:27-29` 把 `effort: 'xhigh'` 的 400 錯誤記為
+「已知風險（實測案例，**未完全排除**）」，並稱「Claude Code 是否會在帶 `xhigh` 時自動連帶
+開啟 thinking，**目前未經驗證**」。**該風險現已查證，定性須改寫**：
+
+| | 原註記的說法 | 查證後的實況 |
+|:---|:---|:---|
+| 性質 | 未經驗證的風險 | **上游已知 bug**，有兩張 issue 追蹤 |
+| API 規則 | 未載明 | `xhigh`/`max` 下 thinking **不可關閉**，`thinking:{type:"disabled"}` 併用一律 400（[官方 effort 文件](https://platform.claude.com/docs/en/build-with-claude/effort)）。故 `xhigh` 本身支援，它要求 thinking 同時開著，是**組合約束** |
+| 根因 | 不明 | Claude Code **未把 `alwaysThinkingEnabled: true` 翻譯成對外請求的 `thinking:{type:"adaptive"}`**，session 靜默在無 thinking 狀態下跑（[#79798](https://github.com/anthropics/claude-code/issues/79798)、[#76689](https://github.com/anthropics/claude-code/issues/76689)；後者標題明載「despite alwaysThinkingEnabled: true」） |
+| 可否事先排除 | 暗示可驗證後排除 | **不能**——「靜默不送 thinking」正是該 bug 的症狀，**無法從自己的 settings 推斷實際有沒有送出** |
+
+**原註記的第二個問題（比過期更值得修）**：它建議「若某次派發真的撞到這個 400，
+**先把該次呼叫的 effort 降到 `high` 復原可用性**」。在知道根因後，降 effort 只是**繞過**
+而非修復——真正的修復是確認 thinking 有送出。而該註記同段又禁止「默默把全表降級成 `high`」，
+於是形成自我矛盾的指引：**它建議的動作正是它自己禁止的那個動作的第一步**。
+實際風險是養成「一遇 reviewer 失敗就先懷疑 effort、順手降級」的習慣，
+而降級的後果正是抹掉 STAGE 2/3 要的差異化。
+
+**連帶缺口（retry ladder 未分類失敗）**：此 400 是**基礎設施錯誤**而非 model 能力不足，
+且**必然重現**（參數沒變就再撞一次）。現行 retry ladder 對失敗不分類，於是：
+撞 400 → 算第 1 次 → 同 tier 重派 → 必然又 400 → 算第 2 次 → 觸發 tier 升級 →
+但 planner/reviewer/verifier 已在最高 tier → 走到「停止並等使用者決策」。
+**三次派發全部注定失敗，且給出錯誤診斷**（把參數問題診斷成 model 不夠強）。
+
+> **外部佐證（本項是三項中唯一有跨框架收斂支撐的）**：「把暫時性／機械性錯誤與實質任務
+> 失敗分開計算」在調研的 6 個框架中有 5 個獨立實作——Temporal `RetryPolicy.NonRetryableErrorTypes`、
+> Inngest `NonRetriableError`／`RetryAfterError`、LangGraph `RetryPolicy.retry_on`（預設只重試
+> 連線錯誤與 5xx）、SWE-agent `max_requeries`（格式／被擋動作／bash 語法錯誤與成本上限分開算）、
+> Restate terminal error。獨立設計的收斂是「該機制承重而非流行」的最強訊號。
+
+**修法**：① 改寫 `:27-29` 為「上游已知 bug + API 組合約束 + 撞到時的正確反應順序」，
+明確區分「繞過」與「修復」；② retry ladder 的失敗分析加一條「基礎設施錯誤不計入失敗次數」
+（400 effort/thinking 先查 thinking 是否送出、429/5xx/連線中斷同 tier 重派 1 次）；
+③ 清單刻意維持極小，**禁止擴寫成投機的暫時性錯誤分類學**——字串比對錯誤訊息終究會誤判，
+誤判代價（多一次同 tier 重試）必須小於它解決的問題。
+
+**Effort**：trivial ｜ **價值**：⭐⭐⭐（防止對著參數問題做無效 tier 升級 + 修掉自我矛盾的指引）
+
+> **⚠️ 三項皆為文件層面、不動程式碼**：`wf-state.sh`（421 行）查 `retry`／`tier`／`升級`
+> **零命中**——retry ladder 自始是給 orchestrator 讀的 markdown 指示，**無程式碼落點**，
+> 故 §W5 的修法是改規則文字而非加 bash 分支。
+> 這也順帶暴露一個結構事實（**本次不修，僅記錄**）：stage 轉移與暫停點棘輪都有
+> `wf-state.sh` 的 `exit 1` 硬強制，而 retry ladder 的「最多升級一次」**無任何程式強制**，
+> 靠 orchestrator 在 context 裡記帳——context 被摘要壓縮或跨 session 續接時計數可能丟失，
+> 且 state schema 無 `retry_count`／`failure_class` 欄位可承接。
+> **暫不加欄位**：無實際事故顯示 retry 失控過，而加欄位要同步處理「誰遞增／何時歸零／
+> 跨 session 怎麼接」，複雜度超過已知問題的嚴重度。待真的發生「莫名升級到最強仍失敗
+> 且事後查不出升級過幾次」才是動工時機。


### PR DESCRIPTION
## Summary

Closes #164

修正 `gen-dev-workflow` 三處 PR #141（SKILL.md 拆分）殘留的文件斷裂，並把三項記錄進 `docs/brainstorm/2026-08-25-workflow-brainstorm.md` 的「第四部分之二」作為 ⬜ 待辦 —— 依該檔既有實查紀律，**PR 合併後才回寫 ✅ 並補 commit SHA**（本檔已有四次狀態漂移紀錄，未合併就標完成會製造第五次）。

三項由一輪 GitHub orchestration 框架與本專案機制的比對調研發現（LangGraph / CrewAI / AutoGen-AG2 / OpenHands+SWE-agent / Claude-Flow 系 worktree orchestrator / Temporal+DBOS）。**該調研的主結論是「無機制可搬」** —— 10 個候選項中僅 3 個 recommend，而三者全部是本專案既有設計的接線鬆脫而非外部移植；28 項明確排除（容器隔離、checkpointer 資料庫、LLM 決定路由、deterministic replay、StuckDetector 等）。框架比對矩陣不寫入 brainstorm（非該檔主題）。

## 修正問題 / 修正方式

| 問題 | 修正方式 |
|:---|:---|
| **§W3** `delegation-and-parallel.md:4` 宣稱等級表「已內嵌在主檔的『Model 與委派策略』小節」，但 `SKILL.md` 六個標題無此小節 —— 該標題實際位於**本檔自己的 `:6`**，是把自己的小節名當主檔的引用 | 砍掉前半句，把「推論等級表」併入「本檔收錄」清單並標注唯一定義處 |
| **§W4** `execution-modes.md:22` quick 模式 reviewer 派發漏帶 `effort`（唯一真漏的一處） | 補 `effort: "xhigh"` + 「不可省略」的原因 |
| **§W5** `:27-29` 的 `xhigh` 風險註記記為「未驗證」已過期；且建議「降 `high` 復原」與同段「禁止默默降級成 `high`」自我矛盾 | 改寫為「上游已知 bug + API 組合約束 + 撞到時的正確反應順序」，明確區分「繞過」與「修復」 |
| **§W5 連帶** retry ladder 對失敗不分類 | 加「基礎設施錯誤不計入失敗次數」前置分支，清單壓到 4 種並明文禁止擴寫 |
| 附帶 `SKILL.md:85` 裸檔名（該相對路徑從 SKILL.md 所在目錄解不到） | 改 `references/` 前綴，與 `:168`/`:212` 一致 |

### §W4 是三項中唯一有實際行為後果者

`model` 仍為 `opus`（綁 `reviewer.md` frontmatter，自動生效），但 `effort` 自 `a6fcd29` 移除 frontmatter 綁定後**落回主對話 session 的預設值**。實查對照確認這是唯一漏的派發點：

| 檔案 | `Task(` 派發點 | 帶 `effort` |
|:---|:---:|:---:|
| `command-cheatsheet.md` | 12 處 | ✅ 全帶（含 `:31-32` 跨行呼叫，`effort` 在續行） |
| `execution-modes.md:22` | 1 處 | ❌ **唯一漏的** |
| `SKILL.md` 主檔 | 0 處（流程圖只寫等級名，無 `Task(` 範例） | — |

**為何此處降級比別處嚴重**：quick 模式**無 verifier 兩階段驗收**、不拆任務、主對話直接實作 —— 這次 reviewer 派發是該模式**唯一的品質關卡**，「不讓同源 model 自審」全靠它撐著。而 lens 已收窄為單一 correctness（完整流程 STAGE 3 是多 angle），effort 再落回預設等於**兩層折扣疊在同一個關卡上**。

### §W5 的定性已從「未驗證風險」改為「上游已知 bug」

- **API 層規則**（[官方 effort 文件](https://platform.claude.com/docs/en/build-with-claude/effort)）：`xhigh`/`max` 下 thinking **不可被關閉**。故 `xhigh` 本身支援 —— 它要求 thinking 同時開著，是**組合約束**而非參數不支援。
- **Claude Code 側 bug**：`alwaysThinkingEnabled: true` 未被翻譯成對外請求的 `thinking:{type:"adaptive"}`，session 靜默在無 thinking 下跑（anthropics/claude-code#79798、anthropics/claude-code#76689）。
- **關鍵後果**：無法從自己的 settings 推斷 thinking 實際有沒有送出，故**此風險無法靠「事先確認 effort 支援」排除**。

**retry ladder 為何要分類**：該 400 是基礎設施錯誤且**必然重現**。混算會讓一次 400 吃掉兩次同 tier 重試再觸發 tier 升級，而 planner/reviewer/verifier 已在最高 tier、無處可升 → 走到「停止並等決策」。**三次派發全部注定失敗，且把參數問題診斷成 model 不夠強。**

> **外部佐證**（三項中唯一有跨框架收斂支撐者）：「暫時性／機械性錯誤與實質任務失敗分開計算」在 6 個框架中有 **5 個獨立實作** —— Temporal `NonRetryableErrorTypes`、Inngest `NonRetriableError`、LangGraph `RetryPolicy.retry_on`、SWE-agent `max_requeries`、Restate terminal error。獨立設計的收斂是「該機制承重而非流行」的訊號。

## 刻意不做（已記錄判準）

- **不在主檔補「Model 與委派策略」小節** —— 那會逆轉「1017 行 → 約 200 行主檔」的拆分決定，去解一個不存在的問題（`:212` 索引已獨立運作）。§W3 的修法是砍掉錯誤指涉，不是照著錯誤陳述去實現它。
- **不加 `retry_count` / `failure_class` state 欄位** —— retry ladder 的「最多升級一次」確實無程式強制（`wf-state.sh` 查 `retry`/`tier` 零命中，計數靠 context 記帳），但無事故顯示失控過，而加欄位要處理「誰遞增／何時歸零／跨 session 怎麼接」，複雜度超過已知嚴重度。
- **不擴寫暫時性錯誤分類學**、**不修 `:1800` 的歷史行數敘述**、**不重排 ASCII 框寬度**。

## Verification

- 純文件變更（4 個 `.md`，+148/-6），未動 `lib/`、`test/`、腳本、hook、agent frontmatter → 不跑 `flutter test` / `flutter analyze`。
- 已經 reviewer agent 獨立審查（單 lens：correctness，`effort: xhigh`）：**15 項實查宣稱逐項驗證全數與 codebase 吻合**（行號、`grep -c` 結果、`a6fcd29` 的 7 檔 7 刪行、`7a0755b^` = 1017 行、四次漂移紀錄出處、`references/` 實有 8 檔）。範圍確認乾淨。
- ASCII 框以 East-Asian-Width 量測：改動行 `:85` 顯示寬度維持 **55**（與改前相同），全框區間 53–58 未惡化。
- 審查途中修正一處自身錯誤：原寫「13 處派發點」，逐行核對後實為 **12**（`:31-32` 為跨行呼叫，`grep -c 'Task('` 只計首行）。「全帶 effort」結論不受影響。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1mozFwQJ8uUw438xaZaME

## Sourcery 摘要

修复 gen-dev-workflow 文件拆分后的残留断裂，并补充 effort 与失败处理规则的文档指引。

Bug Fixes:
- 修正文档拆分后的交叉引用、quick 模式下 reviewer 分派遗漏 effort 的问题，以及与 xhigh/thinking 相关的过期和矛盾指引。

Enhancements:
- 完善 retry ladder 对基础设施错误的分类和处理规则，避免无效的 tier 升级。

Documentation:
- 在 workflow brainstorm 中记录 §W3–§W5 三项待办、调研结论和状态跟踪规范。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修复工作流文档拆分后的引用和执行指南，包括审阅者工作量要求以及基础设施错误处理。

错误修复：
- 修复拆分工作流技能文档后遗留的失效交叉引用。
- 恢复快速执行模式中缺失的审阅者工作量设置。
- 更正关于工作量/思考失败的过时指南，并在重试期间区分基础设施错误和任务失败。

增强功能：
- 明确推理级别参考表的归属和用法，并记录更安全的基础设施失败重试处理方式。

文档：
- 在工作流头脑风暴文档中记录三个文档后续事项及其状态跟踪规则。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修复工作流技能拆分后留下的不一致文档交叉引用和执行指南。

错误修复：
- 修复拆分工作流技能文档后留下的失效交叉引用。
- 恢复快速执行模式下评审者缺失的 `xhigh` 努力程度设置。
- 更正过时的努力程度/思考指南，并防止基础设施错误导致无效的重试级别升级。

增强功能：
- 明确推理级别参考表的归属，并在重试指南中区分基础设施故障和任务失败。

文档：
- 在工作流头脑风暴文档中记录三项文档后续工作、研究结论以及合并后的状态跟踪规则。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修复技能拆分后工作流文档中遗留的不一致问题，并明确审查者工作量和失败重试指导。

Bug 修复：
- 修复拆分工作流技能文档后遗留的失效交叉引用。
- 恢复快速模式审查者调度中缺失的 `xhigh` 工作量设置。
- 更正过时的工作量/思考指导，并避免基础设施错误导致无效的重试层级升级。

增强功能：
- 明确推理级别参考表的维护归属，并在重试指导中区分基础设施故障与任务失败。

文档：
- 在工作流头脑风暴文档中记录三项文档后续工作、编排研究结论，以及合并后的状态跟踪规则。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修复技能文档拆分后，工作流文档中的引用和执行指南不一致的问题。

错误修复：
- 修复拆分工作流技能文档后遗留的失效交叉引用。
- 恢复快速执行模式下审查者所需的 `xhigh` 工作量设置。
- 更正过时的工作量/思考指南，并防止基础设施错误触发无效的重试级别升级。

改进：
- 明确推理级别参考表的归属，并在重试指南中区分基础设施故障与任务失败。

文档：
- 在工作流头脑风暴文档中记录三项文档后续工作、编排研究结论以及合并后的状态跟踪规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Repair workflow documentation references and execution guidance left inconsistent after the skill documentation split.

Bug Fixes:
- Fix broken cross-references left by splitting the workflow skill documentation.
- Restore the required `xhigh` effort setting for reviewers in quick execution mode.
- Correct outdated effort/thinking guidance and prevent infrastructure errors from triggering ineffective retry-tier escalation.

Enhancements:
- Clarify the ownership of the inference-level reference table and distinguish infrastructure failures from task failures in retry guidance.

Documentation:
- Record the three documentation follow-ups, orchestration research conclusions, and post-merge status-tracking rules in the workflow brainstorm.

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 更新开发工作流指南中的参考链接，统一文档导航格式。
  - 补充并行执行失败处理说明，涵盖推理配置限制、基础设施错误分类、重试边界及降级规则。
  - 明确 Quick 模式审核步骤使用最高推理等级，并限定为正确性检查。
  - 新增工作流头脑风暴记录，整理文档拆分后的遗留问题、影响与修订方案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->